### PR TITLE
Adds per-adapter DocFX tab groups to documentation pages

### DIFF
--- a/docs/site/articles/contributing.md
+++ b/docs/site/articles/contributing.md
@@ -77,4 +77,4 @@ Design decisions are documented in [`docs/decisions/`](https://github.com/<owner
 
 ## License
 
-Source code is licensed under [MPL-2.0](https://mozilla.org/MPL/2.0/). NuGet packages are distributed under [MIT](https://opensource.org/licenses/MIT). See [ADR-0031](../../decisions/0031-source-license-mpl2.md) for details.
+Source code is licensed under [MPL-2.0](https://mozilla.org/MPL/2.0/). NuGet packages are distributed under [MIT](https://opensource.org/licenses/MIT). See ADR-0031 in `docs/decisions/` for rationale.

--- a/docs/site/articles/guides/mcp-server.md
+++ b/docs/site/articles/guides/mcp-server.md
@@ -44,6 +44,8 @@ Generates a `[Property]` test skeleton from a C# method signature. Supports `xun
 
 Given `public static int Add(int a, int b)`:
 
+# [xUnit v2](#tab/xunit-v2)
+
 ```csharp
 using Conjecture.Core;
 using Conjecture.Xunit;
@@ -62,6 +64,72 @@ public class AddPropertyTests
     }
 }
 ```
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Xunit.V3;
+using Xunit;
+
+public class AddPropertyTests
+{
+    [Property]
+    public void Add_SatisfiesProperty(int a, int b)
+    {
+        // Act
+        // var result = Add(a, b);
+
+        // Assert
+        // Assert.True(result >= 0);
+    }
+}
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.NUnit;
+using NUnit.Framework;
+
+public class AddPropertyTests
+{
+    [Property]
+    public void Add_SatisfiesProperty(int a, int b)
+    {
+        // Act
+        // var result = Add(a, b);
+
+        // Assert
+        // Assert.That(result >= 0, Is.True);
+    }
+}
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class AddPropertyTests
+{
+    [Property]
+    public void Add_SatisfiesProperty(int a, int b)
+    {
+        // Act
+        // var result = Add(a, b);
+
+        // Assert
+        // Assert.IsTrue(result >= 0);
+    }
+}
+```
+
+***
 
 ### `explain-shrink-output`
 

--- a/docs/site/articles/guides/recursive-strategies.md
+++ b/docs/site/articles/guides/recursive-strategies.md
@@ -59,10 +59,8 @@ Strategy<Expr> exprStrategy = Generate.Recursive<Expr>(
     maxDepth: 5);
 
 [Property]
-public void Eval_nonNegativeLiterals_resultIsNonNegative([From<ExprProvider>] Expr expr)
-{
-    Assert.True(Eval(expr) >= 0);
-}
+public bool Eval_nonNegativeLiterals_resultIsNonNegative([From<ExprProvider>] Expr expr)
+    => Eval(expr) >= 0;
 ```
 
 When a failure is found (e.g., because `Mul` was implemented as subtraction), the shrinker reduces the tree depth and simplifies literal values. The result is typically a depth-1 or depth-0 tree — the minimal example that exposes the bug.

--- a/docs/site/articles/guides/targeted-testing.md
+++ b/docs/site/articles/guides/targeted-testing.md
@@ -18,14 +18,14 @@ Call `Target.Maximize` (or `Target.Minimize`) anywhere in a `[Property]` test bo
 
 ```csharp
 [Property]
-public void Sorting_preserves_length(List<int> xs)
+public bool Sorting_preserves_length(List<int> xs)
 {
     List<int> sorted = xs.OrderBy(x => x).ToList();
 
     // Tell the engine to seek longer lists
     Target.Maximize(xs.Count, "list_length");
 
-    Assert.Equal(xs.Count, sorted.Count);
+    return xs.Count == sorted.Count;
 }
 ```
 
@@ -33,12 +33,12 @@ public void Sorting_preserves_length(List<int> xs)
 
 ```csharp
 [Property]
-public void Compression_never_expands_empty_input(byte[] data)
+public bool Compression_never_expands_empty_input(byte[] data)
 {
     Target.Minimize(data.Length, "input_size");
 
     byte[] compressed = Compress(data);
-    Assert.True(compressed.Length <= data.Length || data.Length == 0);
+    return compressed.Length <= data.Length || data.Length == 0;
 }
 ```
 
@@ -50,13 +50,13 @@ A single property can track multiple metrics:
 
 ```csharp
 [Property]
-public void Graph_traversal_visits_all_nodes(int[,] adjacency)
+public bool Graph_traversal_visits_all_nodes(int[,] adjacency)
 {
     Target.Maximize(NodeCount(adjacency), "nodes");
     Target.Maximize(EdgeCount(adjacency), "edges");
 
     IEnumerable<int> visited = BreadthFirst(adjacency, start: 0);
-    Assert.Equal(NodeCount(adjacency), visited.Count());
+    return NodeCount(adjacency) == visited.Count();
 }
 ```
 

--- a/docs/site/articles/installation.md
+++ b/docs/site/articles/installation.md
@@ -29,9 +29,34 @@ dotnet add package Conjecture.Analyzers
 
 ## Namespace
 
-All core types live in the `Conjecture.Core` namespace. Framework adapters use their own namespace (e.g., `Conjecture.Xunit`).
+All core types live in the `Conjecture.Core` namespace. Framework adapters use their own namespace:
+
+# [xUnit v2](#tab/xunit-v2)
 
 ```csharp
 using Conjecture.Core;   // Generate, Strategy<T>, Assume, ConjectureSettings, ...
 using Conjecture.Xunit;  // [Property], [Example], [From<T>], [FromFactory], ...
 ```
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+using Conjecture.Core;       // Generate, Strategy<T>, Assume, ConjectureSettings, ...
+using Conjecture.Xunit.V3;  // [Property], [Example], [From<T>], [FromFactory], ...
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+using Conjecture.Core;   // Generate, Strategy<T>, Assume, ConjectureSettings, ...
+using Conjecture.NUnit;  // [Property], [Example], [From<T>], [FromFactory], ...
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+using Conjecture.Core;    // Generate, Strategy<T>, Assume, ConjectureSettings, ...
+using Conjecture.MSTest;  // [Property], [Example], [From<T>], [FromFactory], ...
+```
+
+***

--- a/docs/site/articles/quick-start.md
+++ b/docs/site/articles/quick-start.md
@@ -4,15 +4,45 @@ Get a property test running in under 5 minutes.
 
 ## 1. Create a Test Project
 
+# [xUnit v2](#tab/xunit-v2)
+
 ```bash
 dotnet new xunit -n MyProject.Tests
 cd MyProject.Tests
 dotnet add package Conjecture.Xunit
 ```
 
+# [xUnit v3](#tab/xunit-v3)
+
+```bash
+dotnet new xunit -n MyProject.Tests
+cd MyProject.Tests
+dotnet add package Conjecture.Xunit.V3
+```
+
+# [NUnit](#tab/nunit)
+
+```bash
+dotnet new nunit -n MyProject.Tests
+cd MyProject.Tests
+dotnet add package Conjecture.NUnit
+```
+
+# [MSTest](#tab/mstest)
+
+```bash
+dotnet new mstest -n MyProject.Tests
+cd MyProject.Tests
+dotnet add package Conjecture.MSTest
+```
+
+***
+
 ## 2. Write a Property Test
 
 Replace the default test class with:
+
+# [xUnit v2](#tab/xunit-v2)
 
 ```csharp
 using Conjecture.Core;
@@ -37,6 +67,88 @@ public class MathTests
     }
 }
 ```
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Xunit.V3;
+
+namespace MyProject.Tests;
+
+public class MathTests
+{
+    [Property]
+    public bool Addition_is_commutative(int a, int b)
+    {
+        return a + b == b + a;
+    }
+
+    [Property]
+    public bool Abs_is_non_negative(int value)
+    {
+        // Skip int.MinValue — Math.Abs throws for it
+        Assume.That(value != int.MinValue);
+        return Math.Abs(value) >= 0;
+    }
+}
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.NUnit;
+
+namespace MyProject.Tests;
+
+public class MathTests
+{
+    [Property]
+    public bool Addition_is_commutative(int a, int b)
+    {
+        return a + b == b + a;
+    }
+
+    [Property]
+    public bool Abs_is_non_negative(int value)
+    {
+        // Skip int.MinValue — Math.Abs throws for it
+        Assume.That(value != int.MinValue);
+        return Math.Abs(value) >= 0;
+    }
+}
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MyProject.Tests;
+
+[TestClass]
+public class MathTests
+{
+    [Property]
+    public bool Addition_is_commutative(int a, int b)
+    {
+        return a + b == b + a;
+    }
+
+    [Property]
+    public bool Abs_is_non_negative(int value)
+    {
+        // Skip int.MinValue — Math.Abs throws for it
+        Assume.That(value != int.MinValue);
+        return Math.Abs(value) >= 0;
+    }
+}
+```
+
+***
 
 ## 3. Run
 
@@ -64,6 +176,8 @@ Run it, and Conjecture will find a counterexample and shrink it down to `1000` �
 
 Property methods can return `bool` (Conjecture asserts it's `true`) or `void` (use your framework's assertions):
 
+# [xUnit v2](#tab/xunit-v2)
+
 ```csharp
 [Property]
 public void Sorting_preserves_length(List<int> items)
@@ -72,6 +186,41 @@ public void Sorting_preserves_length(List<int> items)
     Assert.Equal(items.Count, sorted.Count);
 }
 ```
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+[Property]
+public void Sorting_preserves_length(List<int> items)
+{
+    var sorted = items.OrderBy(x => x).ToList();
+    Assert.Equal(items.Count, sorted.Count);
+}
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+[Property]
+public void Sorting_preserves_length(List<int> items)
+{
+    var sorted = items.OrderBy(x => x).ToList();
+    Assert.That(sorted.Count, Is.EqualTo(items.Count));
+}
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+[Property]
+public void Sorting_preserves_length(List<int> items)
+{
+    var sorted = items.OrderBy(x => x).ToList();
+    Assert.AreEqual(items.Count, sorted.Count);
+}
+```
+
+***
 
 ## Explicit Examples
 

--- a/docs/site/articles/tutorials/01-your-first-property-test.md
+++ b/docs/site/articles/tutorials/01-your-first-property-test.md
@@ -5,7 +5,7 @@ This tutorial walks you through writing and running your first property-based te
 ## Prerequisites
 
 - .NET 10 SDK
-- A test project with `Conjecture.Xunit` installed (see [Installation](../installation.md))
+- A test project with a Conjecture adapter installed (see [Installation](../installation.md))
 
 ## What We're Testing
 
@@ -27,6 +27,8 @@ A traditional unit test might check a few specific cases. A property test descri
 
 ## Writing the Property
 
+# [xUnit v2](#tab/xunit-v2)
+
 ```csharp
 using Conjecture.Xunit;
 
@@ -39,6 +41,55 @@ public class StringUtilsTests
     }
 }
 ```
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+using Conjecture.Xunit.V3;
+
+public class StringUtilsTests
+{
+    [Property]
+    public bool Reverse_twice_returns_original(string input)
+    {
+        return StringUtils.Reverse(StringUtils.Reverse(input)) == input;
+    }
+}
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+using Conjecture.NUnit;
+
+public class StringUtilsTests
+{
+    [Property]
+    public bool Reverse_twice_returns_original(string input)
+    {
+        return StringUtils.Reverse(StringUtils.Reverse(input)) == input;
+    }
+}
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+using Conjecture.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class StringUtilsTests
+{
+    [Property]
+    public bool Reverse_twice_returns_original(string input)
+    {
+        return StringUtils.Reverse(StringUtils.Reverse(input)) == input;
+    }
+}
+```
+
+***
 
 That's it. The `[Property]` attribute tells Conjecture to:
 
@@ -63,6 +114,8 @@ Passed StringUtilsTests.Reverse_twice_returns_original [100 examples]
 
 Return `void` and use your framework's assertions instead of returning `bool`:
 
+# [xUnit v2](#tab/xunit-v2)
+
 ```csharp
 [Property]
 public void Reverse_preserves_length(string input)
@@ -70,6 +123,38 @@ public void Reverse_preserves_length(string input)
     Assert.Equal(input.Length, StringUtils.Reverse(input).Length);
 }
 ```
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+[Property]
+public void Reverse_preserves_length(string input)
+{
+    Assert.Equal(input.Length, StringUtils.Reverse(input).Length);
+}
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+[Property]
+public void Reverse_preserves_length(string input)
+{
+    Assert.That(StringUtils.Reverse(input).Length, Is.EqualTo(input.Length));
+}
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+[Property]
+public void Reverse_preserves_length(string input)
+{
+    Assert.AreEqual(input.Length, StringUtils.Reverse(input).Length);
+}
+```
+
+***
 
 ## A Failing Property
 

--- a/docs/site/articles/tutorials/05-framework-adapters.md
+++ b/docs/site/articles/tutorials/05-framework-adapters.md
@@ -4,7 +4,7 @@ Conjecture works with all major .NET test frameworks. The `[Property]` attribute
 
 ## Side-by-Side Comparison
 
-### xUnit v2
+# [xUnit v2](#tab/xunit-v2)
 
 ```csharp
 using Conjecture.Xunit;
@@ -25,7 +25,7 @@ public class MathTests
 
 Package: `Conjecture.Xunit`
 
-### xUnit v3
+# [xUnit v3](#tab/xunit-v3)
 
 ```csharp
 using Conjecture.Xunit.V3;
@@ -46,7 +46,7 @@ public class MathTests
 
 Package: `Conjecture.Xunit.V3`
 
-### NUnit
+# [NUnit](#tab/nunit)
 
 ```csharp
 using Conjecture.NUnit;
@@ -67,7 +67,7 @@ public class MathTests
 
 Package: `Conjecture.NUnit`
 
-### MSTest
+# [MSTest](#tab/mstest)
 
 ```csharp
 using Conjecture.MSTest;
@@ -91,6 +91,8 @@ public class MathTests
 Package: `Conjecture.MSTest`
 
 > **Note:** MSTest requires `[TestClass]` on the class. The other frameworks don't.
+
+***
 
 ## Shared Features
 


### PR DESCRIPTION
- quick-start, installation, tutorial 01, tutorial 05, and the MCP server guide now use DocFX tab syntax so readers can select their adapter (xUnit v2, xUnit v3, NUnit, MSTest) and see matching code throughout the page
- Guides that used framework assertions incidentally (recursive-strategies, targeted-testing) are converted to bool-returning properties instead of adding unnecessary tabs
- Fixes an invalid file link in contributing.md that pointed outside the docset into docs/decisions/

## Description

<!-- What does this PR do and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [ ] `dotnet test src/` passes
- [ ] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [ ] Follows `.editorconfig` code style
