### PR TITLE
Adds Hypothesis attribution headers to 56 derived source files

### DIFF
--- a/docs/decisions/0032-ported-code-attribution-policy.md
+++ b/docs/decisions/0032-ported-code-attribution-policy.md
@@ -14,10 +14,12 @@ Files derived from Python Hypothesis source get an additional attribution commen
 ```csharp
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
-//
-// This file is derived from the Python Hypothesis library.
+
+// Derived from the Python Hypothesis library.
 // Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
 ```
+
+A blank line (not `//`) separates the license header from the attribution. This ensures IDE0073 (`file_header_template`) only inspects the two-line license block and does not flag the attribution as a header mismatch.
 
 All other files use only the standard two-line header.
 
@@ -26,3 +28,4 @@ All other files use only the standard two-line header.
 - Clear provenance tracking for ported code without a separate licensing model.
 - Contributors who port code know exactly what header to use.
 - Upstream Hypothesis authors receive proper attribution.
+- Attribution is IDE0073-compatible — no `.editorconfig` changes or per-file suppressions needed.

--- a/src/Conjecture.Core/Assume.cs
+++ b/src/Conjecture.Core/Assume.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core;
 
 /// <summary>Provides assumption helpers for filtering property test inputs.</summary>

--- a/src/Conjecture.Core/BooleanStrategy.cs
+++ b/src/Conjecture.Core/BooleanStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/BytesStrategy.cs
+++ b/src/Conjecture.Core/BytesStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/ComposeStrategy.cs
+++ b/src/Conjecture.Core/ComposeStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/ConjectureException.cs
+++ b/src/Conjecture.Core/ConjectureException.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core;
 
 /// <summary>Thrown when a Conjecture health check fails (e.g., too many unsatisfied assumptions).</summary>

--- a/src/Conjecture.Core/ConjectureSettings.cs
+++ b/src/Conjecture.Core/ConjectureSettings.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/src/Conjecture.Core/ConjectureSettingsAttribute.cs
+++ b/src/Conjecture.Core/ConjectureSettingsAttribute.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core;
 
 /// <summary>Assembly-level attribute to configure default settings for all property tests in the assembly.</summary>

--- a/src/Conjecture.Core/DictionaryStrategy.cs
+++ b/src/Conjecture.Core/DictionaryStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/FloatingPointStrategy.cs
+++ b/src/Conjecture.Core/FloatingPointStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using Conjecture.Core.Internal;

--- a/src/Conjecture.Core/Gen.cs
+++ b/src/Conjecture.Core/Gen.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Numerics;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/IGeneratorContext.cs
+++ b/src/Conjecture.Core/IGeneratorContext.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 
 namespace Conjecture.Core;
 

--- a/src/Conjecture.Core/IStateMachine.cs
+++ b/src/Conjecture.Core/IStateMachine.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Collections.Generic;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/IntegerStrategy.cs
+++ b/src/Conjecture.Core/IntegerStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Numerics;
 using Conjecture.Core.Internal;
 

--- a/src/Conjecture.Core/Internal/AdaptivePass.cs
+++ b/src/Conjecture.Core/Internal/AdaptivePass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal sealed class AdaptivePass(IShrinkPass inner) : IShrinkPass

--- a/src/Conjecture.Core/Internal/BlockSwappingPass.cs
+++ b/src/Conjecture.Core/Internal/BlockSwappingPass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal sealed class BlockSwappingPass : IShrinkPass

--- a/src/Conjecture.Core/Internal/CommandSequenceShrinkPass.cs
+++ b/src/Conjecture.Core/Internal/CommandSequenceShrinkPass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Collections.Generic;
 
 namespace Conjecture.Core.Internal;

--- a/src/Conjecture.Core/Internal/ConjectureData.cs
+++ b/src/Conjecture.Core/Internal/ConjectureData.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Buffers;
 
 namespace Conjecture.Core.Internal;

--- a/src/Conjecture.Core/Internal/DeleteBlocksPass.cs
+++ b/src/Conjecture.Core/Internal/DeleteBlocksPass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal sealed class DeleteBlocksPass : IShrinkPass

--- a/src/Conjecture.Core/Internal/ExampleDatabase.cs
+++ b/src/Conjecture.Core/Internal/ExampleDatabase.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/Conjecture.Core/Internal/FloatSimplificationPass.cs
+++ b/src/Conjecture.Core/Internal/FloatSimplificationPass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Runtime.CompilerServices;
 
 namespace Conjecture.Core.Internal;

--- a/src/Conjecture.Core/Internal/HillClimber.cs
+++ b/src/Conjecture.Core/Internal/HillClimber.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/src/Conjecture.Core/Internal/IRNode.cs
+++ b/src/Conjecture.Core/Internal/IRNode.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal readonly struct IRNode

--- a/src/Conjecture.Core/Internal/IRNodeKind.cs
+++ b/src/Conjecture.Core/Internal/IRNodeKind.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal enum IRNodeKind { Integer, Boolean, Bytes, Float64 = 3, Float32 = 4, StringLength = 5, StringChar = 6, CommandStart = 7 }

--- a/src/Conjecture.Core/Internal/IntegerReductionPass.cs
+++ b/src/Conjecture.Core/Internal/IntegerReductionPass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal sealed class IntegerReductionPass : IShrinkPass

--- a/src/Conjecture.Core/Internal/IntervalDeletionPass.cs
+++ b/src/Conjecture.Core/Internal/IntervalDeletionPass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal sealed class IntervalDeletionPass : IShrinkPass

--- a/src/Conjecture.Core/Internal/LexMinimizePass.cs
+++ b/src/Conjecture.Core/Internal/LexMinimizePass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal sealed class LexMinimizePass : IShrinkPass

--- a/src/Conjecture.Core/Internal/RedistributionPass.cs
+++ b/src/Conjecture.Core/Internal/RedistributionPass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal sealed class RedistributionPass : IShrinkPass

--- a/src/Conjecture.Core/Internal/SettingsLoader.cs
+++ b/src/Conjecture.Core/Internal/SettingsLoader.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 

--- a/src/Conjecture.Core/Internal/SettingsResolver.cs
+++ b/src/Conjecture.Core/Internal/SettingsResolver.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Diagnostics.CodeAnalysis;
 
 namespace Conjecture.Core.Internal;

--- a/src/Conjecture.Core/Internal/Shrinker.cs
+++ b/src/Conjecture.Core/Internal/Shrinker.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/Conjecture.Core/Internal/SplittableRandom.cs
+++ b/src/Conjecture.Core/Internal/SplittableRandom.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Runtime.InteropServices;
 
 namespace Conjecture.Core.Internal;

--- a/src/Conjecture.Core/Internal/StateMachineRunner.cs
+++ b/src/Conjecture.Core/Internal/StateMachineRunner.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Collections.Generic;
 using System.Text;
 

--- a/src/Conjecture.Core/Internal/Status.cs
+++ b/src/Conjecture.Core/Internal/Status.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal enum Status { Valid, Invalid, Interesting, Overrun }

--- a/src/Conjecture.Core/Internal/StringAwarePass.cs
+++ b/src/Conjecture.Core/Internal/StringAwarePass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal sealed class StringAwarePass : IShrinkPass

--- a/src/Conjecture.Core/Internal/TestRunner.cs
+++ b/src/Conjecture.Core/Internal/TestRunner.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 

--- a/src/Conjecture.Core/Internal/ZeroBlocksPass.cs
+++ b/src/Conjecture.Core/Internal/ZeroBlocksPass.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core.Internal;
 
 internal sealed class ZeroBlocksPass : IShrinkPass

--- a/src/Conjecture.Core/JustStrategy.cs
+++ b/src/Conjecture.Core/JustStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/LabeledStrategy.cs
+++ b/src/Conjecture.Core/LabeledStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/ListStrategy.cs
+++ b/src/Conjecture.Core/ListStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/NullableStrategy.cs
+++ b/src/Conjecture.Core/NullableStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/OneOfStrategy.cs
+++ b/src/Conjecture.Core/OneOfStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/RecursiveStrategy.cs
+++ b/src/Conjecture.Core/RecursiveStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/SampledFromStrategy.cs
+++ b/src/Conjecture.Core/SampledFromStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/SelectManyStrategy.cs
+++ b/src/Conjecture.Core/SelectManyStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/SelectStrategy.cs
+++ b/src/Conjecture.Core/SelectStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/SetStrategy.cs
+++ b/src/Conjecture.Core/SetStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/StateMachineFormatter.cs
+++ b/src/Conjecture.Core/StateMachineFormatter.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Text;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/StateMachineRun.cs
+++ b/src/Conjecture.Core/StateMachineRun.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Collections.Generic;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/StateMachineStrategy.cs
+++ b/src/Conjecture.Core/StateMachineStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using System.Collections.Generic;
 using Conjecture.Core.Internal;
 

--- a/src/Conjecture.Core/Strategy.cs
+++ b/src/Conjecture.Core/Strategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/StrategyExtensions.cs
+++ b/src/Conjecture.Core/StrategyExtensions.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core;
 
 /// <summary>LINQ-style extension methods for composing strategies.</summary>

--- a/src/Conjecture.Core/StringStrategy.cs
+++ b/src/Conjecture.Core/StringStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/Target.cs
+++ b/src/Conjecture.Core/Target.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/UnsatisfiedAssumptionException.cs
+++ b/src/Conjecture.Core/UnsatisfiedAssumptionException.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 namespace Conjecture.Core;
 
 /// <summary>Thrown when a <c>Where</c> filter exhausts its retry budget, marking the test case as invalid.</summary>

--- a/src/Conjecture.Core/WhereStrategy.cs
+++ b/src/Conjecture.Core/WhereStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;

--- a/src/Conjecture.Core/ZipStrategy.cs
+++ b/src/Conjecture.Core/ZipStrategy.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+// Derived from the Python Hypothesis library.
+// Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
+
 using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;


### PR DESCRIPTION
- Inserts provenance comment below the MPL-2.0 license header in all Conjecture.Core files ported from Python Hypothesis (engine, shrink passes, strategies, stateful testing, settings)
- Amends ADR-0032 to use a blank-line separator instead of // so the attribution doesn't conflict with IDE0073 file_header_template enforcement

## Description

<!-- What does this PR do and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [ ] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style
