### PR TITLE
Improves docs site for 1.0 readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+# Changelog
+
+All notable changes to Conjecture.NET are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning follows [SemVer](https://semver.org/) — API stability guarantees begin at v1.0.0.
+
+---
+
+## [Unreleased]
+
+---
+
+## [0.6.0-alpha.1] — 2026-04-05
+
+First public alpha release. All seven implementation phases are complete.
+
+### Added
+
+**Core engine**
+- `ConjectureData` byte-stream-backed test case generation
+- `Strategy<T>` abstract base with `Draw(ConjectureData)` semantics
+- `SplittableRandom` (SplitMix64) reproducible PRNG
+- `Assume.That(condition)` for filtering
+- `[Property]` attribute with auto-resolved parameter strategies
+
+**Strategy library**
+- Primitives: `Generate.Booleans()`, `Generate.Bytes(size)`, `Generate.Integers<T>()`, `Generate.Doubles()`, `Generate.Floats()`
+- Strings: `Generate.Strings(...)`, `Generate.Text(...)`
+- Collections: `Generate.Lists<T>()`, `Generate.Sets<T>()`, `Generate.Dictionaries<K,V>()`
+- Combinators: `Select`, `Where`, `SelectMany`, `Zip`, `OrNull`, `WithLabel`
+- Choice: `Generate.Just()`, `Generate.OneOf()`, `Generate.SampledFrom()`, `Generate.Enums<T>()`
+- Composition: `Generate.Compose(ctx => ...)` imperative builder
+- Recursive: `Generate.Recursive<T>(baseCase, recursive, maxDepth)`
+- Stateful: `Generate.StateMachine<TMachine, TState, TCommand>(maxSteps)`
+
+**Shrinking**
+- 10-pass byte-stream shrinking (ZeroBlocks, DeleteBlocks, LexMinimize, IntegerReduction, FloatSimplification, StringAware, BlockSwapping, CommandSequence, and more)
+- No custom shrinker code required — works universally for all types
+
+**Targeted testing**
+- `Target.Maximize(score, label)` / `Target.Minimize(score, label)`
+- `IGeneratorContext.Target(score, label)` inside `Generate.Compose`
+- Hill-climbing phase after random generation
+
+**Stateful testing**
+- `IStateMachine<TState, TCommand>` interface
+- Command sequence generation and shrinking
+- `StateMachineRun<TState>` result with step-by-step failure reporting
+
+**Test framework adapters**
+- `Conjecture.Xunit` — xUnit v2
+- `Conjecture.Xunit.V3` — xUnit v3
+- `Conjecture.NUnit` — NUnit 4
+- `Conjecture.MSTest` — MSTest
+
+**Parameter resolution attributes**
+- `[From<TProvider>]` — custom `IStrategyProvider<T>`
+- `[FromFactory(methodName)]` — static factory method
+- `[Example(args)]` — explicit test cases run before generated ones
+- `[Arbitrary]` — source generator marker
+
+**Roslyn tooling** (bundled in `Conjecture.Core`)
+- Source generator: auto-derives `IStrategyProvider<T>` for `[Arbitrary]` types
+- 6 analyzers: CON100–CON105
+- Code fixes for common diagnostics
+
+**Example database**
+- SQLite-backed persistence of failing byte buffers
+- Automatic replay on subsequent runs for regression prevention
+
+**Structured logging**
+- `ILogger` integration via `ConjectureSettings.Logger`
+- Auto-wired to framework output in all four adapters
+- 12 structured log events covering generation, shrinking, and targeting
+
+**Release infrastructure**
+- MinVer tag-based versioning
+- SourceLink + deterministic builds
+- GitHub Actions release workflow (`v*` tag → NuGet publish)
+- Public API tracking (`PublicAPI.Shipped.txt`)
+
+[0.6.0-alpha.1]: https://github.com/kommundsen/Conjecture/releases/tag/v0.6.0-alpha.1

--- a/docs/site/articles/changelog.md
+++ b/docs/site/articles/changelog.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes are documented here. See also [`CHANGELOG.md`](https://github.com/kommundsen/Conjecture/blob/main/CHANGELOG.md) in the repository root.
+
+## [0.6.0-alpha.1] — 2026-04-05
+
+First public alpha. All seven implementation phases complete.
+
+### Added
+
+- **Core engine** — byte-stream-backed generation, `SplittableRandom` PRNG, `[Property]` attribute
+- **Strategy library** — integers, floats, strings, booleans, bytes, enums, collections, tuples, nullable, `SampledFrom`, `Just`, `OneOf`, `Recursive`, `StateMachine`
+- **LINQ combinators** — `Select`, `Where`, `SelectMany`, `Zip`, `OrNull`, `WithLabel`, `Generate.Compose`
+- **10-pass shrinking** — universal byte-stream minimization; no custom shrinkers required
+- **Targeted testing** — `Target.Maximize` / `Target.Minimize` with hill-climbing phase
+- **Stateful testing** — `IStateMachine<TState, TCommand>`, command sequence shrinking
+- **Framework adapters** — xUnit v2, xUnit v3, NUnit 4, MSTest
+- **Parameter resolution** — `[From<T>]`, `[FromFactory]`, `[Example]`, `[Arbitrary]`
+- **Roslyn tooling** — source generator + 6 analyzers bundled in `Conjecture.Core`
+- **Example database** — SQLite persistence of failing inputs for regression prevention
+- **Structured logging** — `ILogger` integration, auto-wired in all adapters
+- **Release infrastructure** — MinVer, SourceLink, GitHub Actions publish workflow

--- a/docs/site/articles/configuration.md
+++ b/docs/site/articles/configuration.md
@@ -47,6 +47,9 @@ var ciSettings = settings with { MaxExamples = 1000 };
 | `Deadline` | `TimeSpan?` | `null` | Per-example timeout. `null` = no deadline. On `[Property]`, use `DeadlineMs` (int, milliseconds, `0` = no deadline). |
 | `MaxStrategyRejections` | `int` | `5` | Max consecutive rejections by a single `Where()` filter before giving up. Must be >= 0. |
 | `MaxUnsatisfiedRatio` | `int` | `200` | Max ratio of skipped-to-valid examples before the test is marked as too flaky. Must be >= 0. |
+| `Targeting` | `bool` | `true` | Enable or disable the targeted testing phase (hill climbing after generation). See [Targeted Testing](guides/targeted-testing.md). |
+| `TargetingProportion` | `double` | `0.5` | Fraction of `MaxExamples` reserved for targeting. Must be in `[0.0, 1.0)`. |
+| `Logger` | `ILogger` | `NullLogger.Instance` | Structured logging sink. Adapters auto-wire framework output. See [Observability](guides/observability.md). |
 
 ## Reproducibility
 

--- a/docs/site/articles/contributing.md
+++ b/docs/site/articles/contributing.md
@@ -22,8 +22,8 @@ src/
 ├── Conjecture.Xunit.V3       # xUnit v3 adapter
 ├── Conjecture.NUnit          # NUnit adapter
 ├── Conjecture.MSTest          # MSTest adapter
-├── Conjecture.Generators      # Source generator ([Arbitrary])
-├── Conjecture.Analyzers       # Roslyn analyzer (CON100-105)
+├── Conjecture.Generators      # Source generator ([Arbitrary]) — bundled into Conjecture.Core.nupkg
+├── Conjecture.Analyzers       # Roslyn analyzer (CON100-105) — bundled into Conjecture.Core.nupkg
 ├── Conjecture.Tests           # Core unit tests
 ├── Conjecture.Xunit.Tests     # xUnit v2 adapter tests
 ├── Conjecture.Xunit.V3.Tests  # xUnit v3 adapter tests

--- a/docs/site/articles/guides/analyzers.md
+++ b/docs/site/articles/guides/analyzers.md
@@ -1,12 +1,6 @@
 # Roslyn Analyzers
 
-The `Conjecture.Analyzers` package provides compile-time diagnostics that catch common property-test mistakes.
-
-## Setup
-
-```bash
-dotnet add package Conjecture.Analyzers
-```
+Conjecture includes Roslyn analyzers (bundled in `Conjecture.Core`) that provide compile-time diagnostics catching common property-test mistakes. They activate automatically — no additional packages are needed.
 
 ## Diagnostic Rules
 

--- a/docs/site/articles/guides/settings-profiles.md
+++ b/docs/site/articles/guides/settings-profiles.md
@@ -30,6 +30,8 @@ Available properties on `ConjectureSettingsAttribute`:
 | `MaxStrategyRejections` | `int` | 5 |
 | `MaxUnsatisfiedRatio` | `int` | 200 |
 | `DatabasePath` | `string` | `".conjecture/examples/"` |
+| `Targeting` | `bool` | `true` |
+| `TargetingProportion` | `double` | `0.5` |
 
 ## Per-Test Settings
 

--- a/docs/site/articles/guides/source-generators.md
+++ b/docs/site/articles/guides/source-generators.md
@@ -1,12 +1,6 @@
 # Source Generators
 
-The `Conjecture.Generators` package provides a Roslyn incremental source generator that derives `IStrategyProvider<T>` implementations from your types at compile time.
-
-## Setup
-
-```bash
-dotnet add package Conjecture.Generators
-```
+Conjecture includes a Roslyn incremental source generator (bundled in `Conjecture.Core`) that derives `IStrategyProvider<T>` implementations from your types at compile time. No additional packages are needed.
 
 ## Usage
 

--- a/docs/site/articles/installation.md
+++ b/docs/site/articles/installation.md
@@ -13,19 +13,9 @@ Install the adapter package for your test framework. Each adapter transitively r
 | NUnit 4 | `Conjecture.NUnit` | `dotnet add package Conjecture.NUnit` |
 | MSTest | `Conjecture.MSTest` | `dotnet add package Conjecture.MSTest` |
 
-## Optional Packages
+## Analyzers and Source Generator
 
-| Package | Purpose |
-|---|---|
-| `Conjecture.Generators` | Source generator — derive strategies for your types with `[Arbitrary]` |
-| `Conjecture.Analyzers` | Roslyn analyzers — catch common property-test mistakes at compile time |
-
-Install them alongside your adapter:
-
-```bash
-dotnet add package Conjecture.Generators
-dotnet add package Conjecture.Analyzers
-```
+Roslyn analyzers and the `[Arbitrary]` source generator are bundled into `Conjecture.Core` and activate automatically — no additional packages needed.
 
 ## Namespace
 

--- a/docs/site/articles/toc.yml
+++ b/docs/site/articles/toc.yml
@@ -13,5 +13,9 @@ items:
     href: tutorials/toc.yml
   - name: Guides
     href: guides/toc.yml
+  - name: Changelog
+    href: changelog.md
+  - name: Troubleshooting
+    href: troubleshooting.md
   - name: Contributing
     href: contributing.md

--- a/docs/site/articles/troubleshooting.md
+++ b/docs/site/articles/troubleshooting.md
@@ -1,0 +1,98 @@
+# Troubleshooting
+
+## `UnsatisfiedAssumptionException`: filter too restrictive
+
+`Where()` or `Assume.That()` rejected too many values before finding a valid one. The default budget is 5 consecutive rejections per strategy (`MaxStrategyRejections`).
+
+**Fix:** Constrain the input range instead of filtering:
+
+```csharp
+// Problematic — most ints aren't prime:
+Generate.Integers<int>(2, 1_000_000).Where(IsPrime)
+
+// Better — generate only from a small known set:
+Generate.SampledFrom(new[] { 2, 3, 5, 7, 11, 13 })
+```
+
+If filtering is unavoidable, raise the budget:
+
+```csharp
+[Property(MaxStrategyRejections = 50)]
+public bool My_filtered_property(int value) => ...;
+```
+
+## `ConjectureException`: health check failure
+
+Thrown when too many examples overall are skipped relative to valid ones. The default ratio is 200:1 (`MaxUnsatisfiedRatio`).
+
+**Fix:** Restructure the strategy to generate only valid inputs, or relax the ratio:
+
+```csharp
+[assembly: ConjectureSettings(MaxUnsatisfiedRatio = 500)]
+```
+
+## Test is slow
+
+**Causes and fixes:**
+
+- **Too many rejections** — see above; use narrower strategies instead of `Where()`
+- **Large search space** — reduce `MaxExamples` during development, increase in CI
+- **Expensive property body** — add a per-example deadline to catch regressions:
+
+```csharp
+[Property(DeadlineMs = 500)]
+public bool Should_be_fast(List<int> items) => ...;
+```
+
+- **Enable logging** to see rejection counts:
+
+```csharp
+[assembly: ConjectureSettings(/* Logger wired automatically by adapters */)]
+```
+
+Adapters auto-wire the test framework's output as the logger. Check the test output for `Skipped` event counts.
+
+## How do I reproduce a failure?
+
+Every failure message includes the seed:
+
+```
+Falsifying example after 42 examples (seed: 0xDEADBEEF12345678):
+  value = 42
+```
+
+Pin it to make the test deterministic:
+
+```csharp
+[Property(Seed = 0xDEADBEEF12345678)]
+public bool My_property(int value) => ...;
+```
+
+Remove the seed once the bug is fixed.
+
+## `[Arbitrary]` type doesn't generate
+
+Check the following:
+
+- The type must be `partial`
+- Must have at least one accessible constructor
+- All constructor parameter types must be auto-resolvable (primitives, strings, collections, enums, or other `[Arbitrary]` types)
+
+The source generator emits diagnostics when requirements aren't met:
+
+| ID | Description |
+|---|---|
+| CON200 | No accessible constructor |
+| CON201 | Type is not `partial` |
+| CON202 | Parameter type has no resolvable strategy |
+
+## Test not discovered by the runner
+
+Check the following:
+
+- Correct adapter package installed for your framework (`Conjecture.Xunit.V3`, `Conjecture.NUnit`, etc.)
+- Correct `using` namespace (e.g. `using Conjecture.Xunit.V3;`)
+- `[Property]` attribute applied to the method
+- Test class is `public`
+- MSTest: test class must also have `[TestClass]`
+- Method returns `bool`, `void`, `Task`, or `Task<bool>`

--- a/docs/site/articles/tutorials/06-advanced-patterns.md
+++ b/docs/site/articles/tutorials/06-advanced-patterns.md
@@ -4,7 +4,7 @@ This tutorial covers advanced Conjecture features: source generators, the exampl
 
 ## Source Generators
 
-The `Conjecture.Generators` package auto-derives strategies for your types at compile time.
+The source generator (bundled in `Conjecture.Core`) auto-derives strategies for your types at compile time.
 
 Mark a type with `[Arbitrary]`:
 
@@ -34,13 +34,7 @@ See the [Source Generators Guide](../guides/source-generators.md) for details.
 
 ## Roslyn Analyzers
 
-Install `Conjecture.Analyzers` for compile-time feedback:
-
-```bash
-dotnet add package Conjecture.Analyzers
-```
-
-Diagnostics:
+Roslyn analyzers are bundled in `Conjecture.Core` and active automatically. Diagnostics:
 
 | ID | Description |
 |---|---|

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -35,6 +35,11 @@ No hand-written test cases. Conjecture generates random lists, runs the property
 - **All major frameworks** — xUnit v2, xUnit v3, NUnit, MSTest
 - **Source generators** — derive strategies for your types with `[Arbitrary]`
 - **Roslyn analyzers** — catch common mistakes at compile time
+- **Stateful testing** — model systems as state machines and explore command sequences
+- **Targeted testing** — steer generation toward extremes with `Target.Maximize` / `Target.Minimize`
+- **Recursive strategies** — generate bounded-depth trees and self-referential types
+- **Example database** — persist failing inputs for automatic regression prevention
+- **Structured logging** — structured events for generation, shrinking, and targeting phases
 
 ## Install
 

--- a/docs/site/toc.yml
+++ b/docs/site/toc.yml
@@ -11,5 +11,9 @@ items:
     href: articles/porting-guide.md
   - name: API Reference
     href: api/
+  - name: Changelog
+    href: articles/changelog.md
+  - name: Troubleshooting
+    href: articles/troubleshooting.md
   - name: Contributing
     href: articles/contributing.md


### PR DESCRIPTION
## Description

Fixes factual errors in the docs site and fills gaps ahead of broader alpha feedback.

Key changes:
- Removes incorrect separate install instructions for `Conjecture.Generators` and `Conjecture.Analyzers` — both are bundled into `Conjecture.Core` per ADR-0038 and were never published as standalone packages
- Adds missing `Targeting`, `TargetingProportion`, and `Logger` settings to the configuration reference
- Expands the landing page feature list to include stateful testing, targeted testing, recursive strategies, example database, and structured logging
- Adds a troubleshooting guide (common exceptions, slow tests, seed reproduction, `[Arbitrary]` pitfalls, test discovery)
- Adds `CHANGELOG.md` at repo root and a Changelog page in the docs site with v0.6.0-alpha.1 release notes

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style