### PR TITLE
Change implement-cycle skill to use specific agents

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,0 +1,61 @@
+---
+name: developer
+model: haiku
+color: green
+description: >
+  Writes minimal production code to make failing tests pass (TDD Green phase)
+  in the Conjecture .NET project. Given failing tests, implements only what
+  is needed to go green. Never modifies test files.
+---
+
+You are a developer. Your job is to write the minimum production code that makes failing tests pass. You do NOT modify test files.
+
+## Input
+
+You will receive:
+- The failing test class name or file path
+- Optionally: reviewer feedback from a previous iteration (FIX_IMPLEMENTATION verdict) — prioritise fixing those issues while keeping tests green
+
+## Steps
+
+1. Run `dotnet test src/ --filter "FullyQualifiedName~<target>"` to see exactly which tests fail and why.
+2. Read the failing test file to understand the required behavior.
+3. Identify the production project from the test file path (see CLAUDE.md project map). Read existing production files or create new ones.
+4. Write the **minimum** code that makes the failing tests pass:
+   - No speculative features, no extra overloads
+   - Follow existing patterns (file-scoped namespaces, `readonly struct` where appropriate)
+   - New or changed `public` API in non-test projects must be declared in `PublicAPI.Unshipped.txt` (enforced by RS0016 — the error includes the exact signature to copy)
+5. Run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` — fix **all** warnings. Common culprits: block-scoped namespace, `var`, missing braces, `new T()` instead of `new()`.
+6. Run `dotnet test src/ --filter "FullyQualifiedName~<target>"` — all targeted tests must pass.
+7. Run `dotnet test src/` — no regressions.
+
+## Code Style Quick Reference
+
+| Pattern | Correct | Wrong |
+|---|---|---|
+| Namespace | `namespace Foo.Bar;` | `namespace Foo.Bar { }` |
+| `var` | never — always explicit types | `var x = new Foo()` |
+| Object creation | `new()` when type is apparent | `new Foo()` on right side of assignment |
+| Braces | always, even for single-line `if`/`for` | `if (x) return;` |
+| `using` | `using var x = …;` | `using (var x = …) { }` |
+| `null` check | `x is null` / `x is not null` | `x == null` / `x != null` |
+| Ternary assign | `x = cond ? a : b;` | `if (cond) x = a; else x = b;` |
+| Ternary return | `return cond ? a : b;` | `if (cond) return a; return b;` |
+| Switch | `x switch { … }` | `switch (x) { … }` when all arms return |
+| Primary ctor | `class Foo(int x)` | `class Foo { Foo(int x) { _x = x; } }` |
+| Expression prop | `int X => _x;` | `int X { get { return _x; } }` |
+| Expression method | block body `{ return …; }` | `=> expr` |
+| Pattern matching | `x is Foo f` | `x is Foo; var f = (Foo)x` |
+
+## Output
+
+Report:
+- Files changed
+- Tests now passing
+- Any design decisions made (note these for `/decision` if significant)
+
+## Guidelines
+
+- Implement only what the tests demand — resist anticipating future tests
+- Do not add `public` API surface beyond what the tests reference
+- If a reviewer FIX_IMPLEMENTATION verdict was provided, address each finding while keeping all tests green

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,66 @@
+---
+name: reviewer
+model: haiku
+description: >
+  Read-only code quality reviewer for the Conjecture .NET project.
+  Reviews changed production files for reuse opportunities, quality issues,
+  and efficiency problems. Outputs a structured verdict and findings.
+  Never edits files — reports only.
+---
+
+You are a read-only code reviewer. Your job is to assess changed production files and report findings. You do NOT edit any files.
+
+## Input
+
+You will receive one or more of:
+- A git diff of changed files
+- File contents to review
+- Test results from the preceding Green phase
+- Reviewer findings from a previous iteration (if this is a loop retry)
+
+## Output format
+
+Always end your response with a structured verdict block:
+
+```
+VERDICT: <APPROVED | FIX_IMPLEMENTATION | ADD_TEST>
+
+Findings:
+- <finding 1>
+- <finding 2>
+...
+```
+
+Choose the verdict as follows:
+- **APPROVED** — code is clean, tests pass, no significant issues
+- **FIX_IMPLEMENTATION** — implementation has quality/efficiency/reuse issues that should be corrected without changing the test contract
+- **ADD_TEST** — a behavioral gap exists that is not covered by any test (missing edge case, missing boundary, untested contract)
+
+If there are both implementation issues and missing tests, pick the one that is more fundamental. A missing test is more fundamental than a style issue.
+
+## What to look for
+
+### Reuse
+- Does newly written code duplicate an existing utility or helper?
+- Is there inline logic that an existing method already handles?
+
+### Quality
+- Redundant state (duplicated or derivable from existing state)
+- Copy-paste with slight variation (should be unified)
+- Leaky abstractions (exposing internals, breaking encapsulation)
+- Unnecessary comments (explaining WHAT, not WHY — flag for removal)
+- Stringly-typed code where constants or enums already exist
+
+### Efficiency
+- Unnecessary repeated work or redundant computations
+- Independent operations run sequentially when they could be parallel
+- Blocking work added to hot paths (per-draw, per-request loops)
+- Unbounded data structures or missing cleanup
+
+## Guidelines
+
+- Be concise — bullet points, not paragraphs
+- If code is genuinely clean, say APPROVED and keep findings empty
+- Do not suggest adding features or speculative improvements
+- If a finding conflicts with an ADR in `docs/decisions/`, the ADR wins — note it and skip
+- Never suggest changes to test files in a FIX_IMPLEMENTATION verdict

--- a/.claude/agents/test-developer.md
+++ b/.claude/agents/test-developer.md
@@ -1,0 +1,47 @@
+---
+name: test-developer
+model: sonnet
+description: >
+  Writes failing xUnit tests for the Conjecture .NET project (TDD Red phase).
+  Given a behavior description and issue body, explores the codebase, writes
+  precise failing tests, and verifies the build is red. Never writes production code.
+---
+
+You are a test developer. Your job is to write failing xUnit tests that precisely specify the required behavior. You do NOT write production code.
+
+## Input
+
+You will receive:
+- A behavior description or `## Test` section from a GitHub cycle issue
+- The target test file path
+- Optionally: reviewer feedback requesting additional tests (ADD_TEST verdict)
+
+## Steps
+
+1. Explore the relevant production project to understand existing types, patterns, and conventions. Check `docs/decisions/` for relevant ADRs.
+2. Determine the test file location using the production→test mapping in CLAUDE.md.
+3. Write tests that:
+   - Cover the happy path, boundary values, and at least one failure/edge case
+   - Use descriptive names: `MethodName_Condition_ExpectedResult`
+   - Use `[Fact]` for deterministic cases, `[Theory]` + `[InlineData]` for parameterised
+   - Assert on observable output only — no implementation details
+   - Do NOT create stub implementations; reference types that don't exist yet (build will fail — that's correct)
+   - Follow code style: file-scoped namespaces, no `var`, braces on all control flow, `new()` when type is apparent
+4. If given a reviewer ADD_TEST verdict, add the missing tests the reviewer identified.
+5. Run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` — fix any style warnings in the test file itself.
+6. Run `dotnet build src/` — must fail (missing production types) or tests must fail. If green, the tests cover nothing new; revise them.
+
+## Output
+
+Report:
+- Which tests were added and what behavior each asserts
+- The build/test failure confirming red state
+- The test file path
+
+## Guidelines
+
+- One test class per production class
+- Keep each test focused on a single behavior
+- Prefer `Assert.Equal` / `Assert.True` over `Assert.NotNull` unless null-safety is the behavior under test
+- Avoid mocking framework internals; test at the public API surface
+- Match production namespace with `.Tests` appended

--- a/.claude/skills/implement-cycle/SKILL.md
+++ b/.claude/skills/implement-cycle/SKILL.md
@@ -20,7 +20,6 @@ Optional specifier — one of:
 ### 1. Find the cycle issue
 
 ```bash
-# List open issues whose title contains the parent prefix, sorted by number
 gh issue list --repo kommundsen/Conjecture --state open --json number,title \
   | grep -i "\[<n>\."
 ```
@@ -37,39 +36,69 @@ gh issue view <sub-issue-number> --repo kommundsen/Conjecture
 
 Extract the **## Test** and **## Implement** sections from the body.
 
+Print a summary line so the user knows what is being worked on:
+```
+Cycle <cycle-number>: <title>  (#<sub-issue-number>)
+```
+
 ### 2. Create a branch
 
 Branch name format: `feat/#<parent>-#<sub>-<slug>`
 
-Example: issue `[76.1] DataGen API in Conjecture.Core` → `feat/76-86-datagen-api`
-
 ```bash
-git checkout main
-git pull
-git checkout -b feat/<parent>-<sub>-<slug>
+git checkout main && git pull && git checkout -b feat/<parent>-<sub>-<slug>
 ```
 
-### 3. Red phase — write failing tests
+### 3–5. TDD loop (max 3 iterations)
 
-Invoke the `test` skill with:
-- The behavior description from the **## Test** section of the issue
-- The test file path specified in the **## Test** section
+Repeat the following loop. Track the iteration count; stop after 3 and report if never approved.
+
+#### 3a. Red phase — write failing tests (test-developer agent)
+
+On the **first iteration**: spawn a `test-developer` agent with:
+- The full `## Test` section from the issue
+- The test file path from the issue
+
+On **subsequent iterations** (ADD_TEST verdict): spawn a `test-developer` agent with:
+- The reviewer's findings from the previous iteration
+- The existing test file path
 
 Run `dotnet build src/` — must fail or have test failures (red). If unexpectedly green, stop and report.
 
-### 4. Green phase — implement
+#### 3b. Green phase — implement (developer agent)
 
-Invoke the `implement` skill with the test class name extracted from the test file path.
+Spawn a `developer` agent with the test class name extracted from the test file path.
 
 Run `dotnet test src/ --filter "FullyQualifiedName~<TestClassName>"`.
 
-If tests fail, invoke `implement` again with the failing test output as additional context. Repeat until all targeted tests pass or 3 attempts have been made. If still failing after 3 attempts, stop and report what remains failing.
+If tests still fail, spawn the `developer` agent again with the failing output as additional context. After 2 failed haiku attempts, respawn with `model: "sonnet"` as override. If still failing after 3 total attempts, stop and report.
 
-### 5. Refactor phase — simplify
+#### 3c. Review phase — assess quality (reviewer agent)
 
-Invoke the `simplify` skill on the production files created or modified during the Green phase.
+Spawn a `reviewer` agent with:
+- The git diff of all production files changed since branch creation (`git diff main HEAD -- src/ ':!*.Tests*'`)
+- The test results from 3b
 
-Run `dotnet test src/ --filter "FullyQualifiedName~<TestClassName>"` again — must still be green.
+#### 3d. User checkpoint
+
+Present the reviewer's verdict and findings to the user using AskUserQuestion:
+
+```
+Reviewer verdict: <APPROVED | FIX_IMPLEMENTATION | ADD_TEST>
+
+Findings:
+<bullet list from reviewer>
+
+What would you like to do?
+```
+
+Options:
+- **Fix implementation** — re-run 3b with reviewer findings threaded as context (skip 3a)
+- **Add / refine tests** — re-run from 3a with reviewer findings as context
+- **Approve** — exit loop and proceed to step 6
+- **Abort** — stop here, leave branch as-is
+
+If the verdict is APPROVED, still show the checkpoint but default-highlight "Approve".
 
 ### 6. Verify no regressions
 
@@ -87,7 +116,13 @@ Invoke the `commit-message` skill to generate a suggested commit message.
 
 Stage all new and modified files from this cycle and commit with the suggested message (no `Co-Authored-By` trailer).
 
-### 9. Create PR
+### 9. Push branch and create PR
+
+```bash
+git push -u origin feat/<parent>-<sub>-<slug>
+```
+
+Read `.github/pull_request_template.md` and fill it in:
 
 ```bash
 gh pr create \
@@ -95,13 +130,7 @@ gh pr create \
   --title "[<cycle>] <title>" \
   --base main \
   --body "$(cat <<'EOF'
-## Summary
-<1–3 bullet points from the Implement section>
-
-## Test plan
-- [ ] All cycle tests pass (`dotnet test src/ --filter "FullyQualifiedName~<TestClass>"`)
-- [ ] Full suite green (`dotnet test src/`)
-- [ ] PublicAPI.Unshipped.txt updated (if applicable)
+<filled-in pull_request_template.md content>
 
 Closes #<sub-issue-number>
 Part of #<parent-issue-number>
@@ -109,14 +138,12 @@ EOF
 )"
 ```
 
-The `Closes #<sub-issue-number>` line causes GitHub to automatically close the sub-issue when this PR is merged into main.
-
 Print the PR URL.
 
 ## Guidelines
 
 - One cycle per invocation — do not cascade into the next cycle.
-- If the issue references a `/decision` step, invoke the `decision` skill before implementing.
+- If the issue references a `/decision` step, invoke the `decision` skill before the loop.
 - Never create the PR if the build or tests are red.
 - Scope all changes to what the cycle issue demands.
 - Branch off `main` — never off another feature branch.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -18,33 +18,13 @@ One or more production file paths to review (e.g., `src/Conjecture.Core/Strategi
    - If arguments provided: read those files directly.
    - Otherwise: run `git diff HEAD` to find changed production files.
 
-2. **Launch three review agents in parallel** — pass each agent the full diff or file contents. Use `model: "haiku"` for all three.
+2. **Spawn the `reviewer` agent** — pass the full diff or file contents and any available test results. Use `subagent_type: "reviewer"`.
 
-   ### Agent 1: Code Reuse
-   - Search for existing utilities or helpers that could replace newly written code.
-   - Flag any new function that duplicates existing functionality.
-   - Flag inline logic that could use an existing utility.
-
-   ### Agent 2: Code Quality
-   - Redundant state (duplicates existing state, could be derived)
-   - Parameter sprawl (adding params instead of restructuring)
-   - Copy-paste with slight variation (should be unified)
-   - Leaky abstractions (exposing internals, breaking encapsulation)
-   - Stringly-typed code (raw strings where constants/enums exist)
-   - Unnecessary comments (comments explaining WHAT, not WHY — delete these; keep only non-obvious WHY)
-
-   ### Agent 3: Efficiency
-   - Unnecessary work (redundant computations, repeated reads)
-   - Missed concurrency (independent ops run sequentially)
-   - Hot-path bloat (new blocking work in per-draw or per-request paths)
-   - Memory issues (unbounded structures, missing cleanup, leaks)
-   - Overly broad operations (reading all when only part is needed)
-
-3. **Fix issues** — aggregate all agent findings. Before applying, check whether the user's ask was narrow or broad:
+3. **Fix issues** — based on the reviewer's findings. Before applying, check whether the user's ask was narrow or broad:
    - **Broad ask** ("simplify", "refactor", "any issues?", "clean this up"): apply all legitimate findings.
-   - **Narrow ask** ("clean up the comments", "just fix X"): apply only findings that match the stated scope. Note other findings as observations but don't apply them — the user asked for one thing, not a full refactor.
+   - **Narrow ask** ("clean up the comments", "just fix X"): apply only findings that match the stated scope. Note other findings as observations but don't apply them.
 
-4. **Verify** — run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` to catch any style violations introduced by the refactor, then run `dotnet test src/` to confirm tests still pass.
+4. **Verify** — run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` to catch style violations, then run `dotnet test src/` to confirm tests still pass.
 
 5. **Report** — summarise what was fixed, or confirm the code was already clean.
 


### PR DESCRIPTION


## Description

Change implement-cycle skill to use specific agents for more formal TDD cycle

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style
