### PR TITLE
[76.3] Conjecture.Tool CLI project

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: reviewer
 model: haiku
+color: blue
 description: >
   Read-only code quality reviewer for the Conjecture .NET project.
   Reviews changed production files for reuse opportunities, quality issues,

--- a/.claude/agents/test-developer.md
+++ b/.claude/agents/test-developer.md
@@ -1,6 +1,7 @@
 ---
 name: test-developer
 model: sonnet
+color: red
 description: >
   Writes failing xUnit tests for the Conjecture .NET project (TDD Red phase).
   Given a behavior description and issue body, explores the codebase, writes

--- a/src/Conjecture.Tool.Tests/AssemblyLoaderTests.cs
+++ b/src/Conjecture.Tool.Tests/AssemblyLoaderTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+using Conjecture.Core;
+using Conjecture.Tool;
+
+namespace Conjecture.Tool.Tests;
+
+// Providers defined in the test assembly so AssemblyLoader can discover them.
+public sealed class IntStrategyProvider : IStrategyProvider<int>
+{
+    public Strategy<int> Create() => Generate.Integers<int>(0, 100);
+}
+
+public sealed class StringStrategyProvider : IStrategyProvider<string>
+{
+    public Strategy<string> Create() => Generate.Strings();
+}
+
+public class AssemblyLoaderTests
+{
+    private static string TestAssemblyPath => typeof(AssemblyLoaderTests).Assembly.Location;
+
+    // ── Discovery ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void FindProviders_LoadsAssembly_ReturnsImplementations()
+    {
+        IReadOnlyList<Type> providers = AssemblyLoader.FindProviders(TestAssemblyPath);
+
+        Assert.NotEmpty(providers);
+    }
+
+    [Fact]
+    public void FindProviders_ReturnsType_ImplementingIStrategyProviderOfT()
+    {
+        IReadOnlyList<Type> providers = AssemblyLoader.FindProviders(TestAssemblyPath);
+
+        Assert.Contains(typeof(IntStrategyProvider), providers);
+    }
+
+    [Fact]
+    public void FindProviders_ReturnsAllProviders_FromAssembly()
+    {
+        IReadOnlyList<Type> providers = AssemblyLoader.FindProviders(TestAssemblyPath);
+
+        Assert.Contains(typeof(IntStrategyProvider), providers);
+        Assert.Contains(typeof(StringStrategyProvider), providers);
+    }
+
+    [Fact]
+    public void FindProviders_NonExistentAssembly_ThrowsFileNotFoundException()
+    {
+        Assert.Throws<FileNotFoundException>(() =>
+            AssemblyLoader.FindProviders("/nonexistent/path/to/assembly.dll"));
+    }
+
+    // ── Type resolution by full name ─────────────────────────────────────────
+
+    [Fact]
+    public void ResolveByTargetType_FullName_ReturnsMatchingProvider()
+    {
+        Assembly assembly = Assembly.LoadFrom(TestAssemblyPath);
+
+        Type? provider = AssemblyLoader.ResolveByTargetType(assembly, "System.Int32");
+
+        Assert.Equal(typeof(IntStrategyProvider), provider);
+    }
+
+    [Fact]
+    public void ResolveByTargetType_SimpleName_ReturnsMatchingProvider()
+    {
+        Assembly assembly = Assembly.LoadFrom(TestAssemblyPath);
+
+        Type? provider = AssemblyLoader.ResolveByTargetType(assembly, "Int32");
+
+        Assert.Equal(typeof(IntStrategyProvider), provider);
+    }
+
+    [Fact]
+    public void ResolveByTargetType_String_FullName_ReturnsStringProvider()
+    {
+        Assembly assembly = Assembly.LoadFrom(TestAssemblyPath);
+
+        Type? provider = AssemblyLoader.ResolveByTargetType(assembly, "System.String");
+
+        Assert.Equal(typeof(StringStrategyProvider), provider);
+    }
+
+    [Fact]
+    public void ResolveByTargetType_UnknownType_ReturnsNull()
+    {
+        Assembly assembly = Assembly.LoadFrom(TestAssemblyPath);
+
+        Type? provider = AssemblyLoader.ResolveByTargetType(assembly, "SomeUnknownType");
+
+        Assert.Null(provider);
+    }
+}

--- a/src/Conjecture.Tool.Tests/Conjecture.Tool.Tests.csproj
+++ b/src/Conjecture.Tool.Tests/Conjecture.Tool.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Tool\Conjecture.Tool.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.Tool.Tests/GenerateCommandTests.cs
+++ b/src/Conjecture.Tool.Tests/GenerateCommandTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Text.Json;
+using Conjecture.Tool;
+
+namespace Conjecture.Tool.Tests;
+
+public class GenerateCommandTests
+{
+    private static string TestAssemblyPath => typeof(AssemblyLoaderTests).Assembly.Location;
+
+    // ── JSON output ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_GenerateInts_ProducesValidJsonArray()
+    {
+        string output = await GenerateCommand.ExecuteAsync(
+            assemblyPath: TestAssemblyPath,
+            typeName: "Int32",
+            count: 10,
+            seed: 42UL,
+            format: "json");
+
+        using JsonDocument doc = JsonDocument.Parse(output);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+    }
+
+    [Fact]
+    public async Task Execute_GenerateInts_ProducesExactCount()
+    {
+        string output = await GenerateCommand.ExecuteAsync(
+            assemblyPath: TestAssemblyPath,
+            typeName: "Int32",
+            count: 10,
+            seed: 42UL,
+            format: "json");
+
+        using JsonDocument doc = JsonDocument.Parse(output);
+        Assert.Equal(10, doc.RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Execute_GenerateInts_ArrayElementsAreIntegers()
+    {
+        string output = await GenerateCommand.ExecuteAsync(
+            assemblyPath: TestAssemblyPath,
+            typeName: "Int32",
+            count: 5,
+            seed: 1UL,
+            format: "json");
+
+        using JsonDocument doc = JsonDocument.Parse(output);
+        foreach (JsonElement element in doc.RootElement.EnumerateArray())
+        {
+            Assert.Equal(JsonValueKind.Number, element.ValueKind);
+            Assert.True(element.TryGetInt32(out _));
+        }
+    }
+
+    // ── Full name resolution ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_TypeByFullName_ProducesSameResultAsSimpleName()
+    {
+        string bySimple = await GenerateCommand.ExecuteAsync(
+            assemblyPath: TestAssemblyPath,
+            typeName: "Int32",
+            count: 5,
+            seed: 7UL,
+            format: "json");
+
+        string byFull = await GenerateCommand.ExecuteAsync(
+            assemblyPath: TestAssemblyPath,
+            typeName: "System.Int32",
+            count: 5,
+            seed: 7UL,
+            format: "json");
+
+        Assert.Equal(bySimple, byFull);
+    }
+
+    // ── Seed determinism ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_SameSeed_ProducesIdenticalOutput()
+    {
+        string first = await GenerateCommand.ExecuteAsync(
+            assemblyPath: TestAssemblyPath,
+            typeName: "Int32",
+            count: 10,
+            seed: 99UL,
+            format: "json");
+
+        string second = await GenerateCommand.ExecuteAsync(
+            assemblyPath: TestAssemblyPath,
+            typeName: "Int32",
+            count: 10,
+            seed: 99UL,
+            format: "json");
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public async Task Execute_DifferentSeeds_ProduceDifferentOutput()
+    {
+        string first = await GenerateCommand.ExecuteAsync(
+            assemblyPath: TestAssemblyPath,
+            typeName: "Int32",
+            count: 10,
+            seed: 1UL,
+            format: "json");
+
+        string second = await GenerateCommand.ExecuteAsync(
+            assemblyPath: TestAssemblyPath,
+            typeName: "Int32",
+            count: 10,
+            seed: 2UL,
+            format: "json");
+
+        Assert.NotEqual(first, second);
+    }
+
+    // ── Unknown type ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Execute_UnknownType_ThrowsInvalidOperationException()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            GenerateCommand.ExecuteAsync(
+                assemblyPath: TestAssemblyPath,
+                typeName: "NoSuchType",
+                count: 5,
+                seed: 1UL,
+                format: "json"));
+    }
+}

--- a/src/Conjecture.Tool/AssemblyLoader.cs
+++ b/src/Conjecture.Tool/AssemblyLoader.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+using Conjecture.Core;
+
+namespace Conjecture.Tool;
+
+/// <summary>Loads assemblies and discovers IStrategyProvider implementations.</summary>
+public static class AssemblyLoader
+{
+    /// <summary>Loads an assembly and finds all types implementing IStrategyProvider&lt;T&gt;.</summary>
+    /// <param name="assemblyPath">Path to the assembly file.</param>
+    /// <returns>A read-only list of types implementing IStrategyProvider&lt;T&gt;.</returns>
+    /// <exception cref="FileNotFoundException">Thrown if the assembly file does not exist.</exception>
+    public static IReadOnlyList<Type> FindProviders(string assemblyPath)
+    {
+        if (!File.Exists(assemblyPath))
+        {
+            throw new FileNotFoundException($"Assembly not found: {assemblyPath}", assemblyPath);
+        }
+
+        Assembly assembly = Assembly.LoadFrom(assemblyPath);
+        return FindProvidersInAssembly(assembly);
+    }
+
+    /// <summary>Finds IStrategyProvider&lt;T&gt; implementations in an assembly where T matches the given type name.</summary>
+    /// <param name="assembly">The assembly to search.</param>
+    /// <param name="typeName">The target type name (full name like "System.Int32" or simple name like "Int32").</param>
+    /// <returns>The provider type if found; null otherwise.</returns>
+    public static Type? ResolveByTargetType(Assembly assembly, string typeName)
+    {
+        IReadOnlyList<Type> providers = FindProvidersInAssembly(assembly);
+
+        foreach (Type providerType in providers)
+        {
+            if (IsProviderForType(providerType, typeName))
+            {
+                return providerType;
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<Type> FindProvidersInAssembly(Assembly assembly)
+    {
+        var providers = new List<Type>();
+
+        foreach (Type type in assembly.GetTypes())
+        {
+            if (ImplementsIStrategyProvider(type))
+            {
+                providers.Add(type);
+            }
+        }
+
+        return providers;
+    }
+
+    internal static Type? GetProviderTargetType(Type type)
+    {
+        foreach (Type iface in type.GetInterfaces())
+        {
+            if (iface.IsGenericType &&
+                iface.GetGenericTypeDefinition() == typeof(IStrategyProvider<>))
+            {
+                return iface.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+
+    private static bool ImplementsIStrategyProvider(Type type)
+    {
+        return GetProviderTargetType(type) is not null;
+    }
+
+    private static bool IsProviderForType(Type providerType, string typeName)
+    {
+        Type? targetType = GetProviderTargetType(providerType);
+        if (targetType is not null)
+        {
+            return targetType.FullName == typeName || targetType.Name == typeName;
+        }
+
+        return false;
+    }
+}

--- a/src/Conjecture.Tool/Commands/GenerateCommand.cs
+++ b/src/Conjecture.Tool/Commands/GenerateCommand.cs
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+using Conjecture.Core;
+using Conjecture.Formatters;
+
+namespace Conjecture.Tool;
+
+/// <summary>Generates values using a discovered strategy provider.</summary>
+public static class GenerateCommand
+{
+    /// <summary>Executes data generation by loading an assembly, finding a provider, and formatting output.</summary>
+    /// <param name="assemblyPath">Path to the assembly containing the strategy provider.</param>
+    /// <param name="typeName">Target type name (full or simple name) for the strategy provider.</param>
+    /// <param name="count">Number of values to generate.</param>
+    /// <param name="seed">Optional seed for deterministic generation.</param>
+    /// <param name="format">Output format name (e.g., "json", "jsonl").</param>
+    /// <returns>The formatted output as a string.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the type is not found or format is not supported.</exception>
+    public static async Task<string> ExecuteAsync(
+        string assemblyPath,
+        string typeName,
+        int count,
+        ulong? seed,
+        string format)
+    {
+        Assembly assembly = Assembly.LoadFrom(assemblyPath);
+        Type? providerType = AssemblyLoader.ResolveByTargetType(assembly, typeName);
+
+        if (providerType is null)
+        {
+            throw new InvalidOperationException($"Type provider not found for: {typeName}");
+        }
+
+        IOutputFormatter? formatter = GetFormatter(format);
+        if (formatter is null)
+        {
+            throw new InvalidOperationException($"Unknown format: {format}");
+        }
+
+        // Dynamically invoke ExecuteTypedAsync<T> with the correct T
+        Type? targetType = AssemblyLoader.GetProviderTargetType(providerType);
+        if (targetType is null)
+        {
+            throw new InvalidOperationException($"Could not determine target type for provider: {providerType.Name}");
+        }
+
+        MethodInfo? executeMethod = typeof(GenerateCommand).GetMethod(
+            nameof(ExecuteTypedAsync),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        if (executeMethod is null)
+        {
+            throw new InvalidOperationException("Failed to find ExecuteTypedAsync method");
+        }
+
+        MethodInfo genericExecuteMethod = executeMethod.MakeGenericMethod(targetType);
+        object?[] args = new object?[] { providerType, count, seed, formatter };
+        object? invocationResult = genericExecuteMethod.Invoke(null, args);
+        Task<string> task = (Task<string>)(invocationResult ?? throw new InvalidOperationException("Failed to invoke ExecuteTypedAsync"));
+
+        return await task;
+    }
+
+    private static IOutputFormatter? GetFormatter(string format)
+    {
+        return format switch
+        {
+            "json" => new JsonOutputFormatter(),
+            "jsonl" => new JsonLinesOutputFormatter(),
+            _ => null,
+        };
+    }
+
+    private static async Task<string> ExecuteTypedAsync<T>(
+        Type providerType,
+        int count,
+        ulong? seed,
+        IOutputFormatter formatter)
+    {
+        object? providerInstance = Activator.CreateInstance(providerType);
+        if (providerInstance is null)
+        {
+            throw new InvalidOperationException($"Failed to create instance of provider: {providerType.Name}");
+        }
+
+        var provider = (IStrategyProvider<T>)providerInstance;
+        Strategy<T> strategy = provider.Create();
+        IEnumerable<T> data = DataGen.Stream(strategy, count, seed);
+
+        using MemoryStream ms = new();
+        await formatter.WriteAsync(data, ms);
+        ms.Position = 0;
+        using StreamReader reader = new(ms);
+        return await reader.ReadToEndAsync();
+    }
+}

--- a/src/Conjecture.Tool/Conjecture.Tool.csproj
+++ b/src/Conjecture.Tool/Conjecture.Tool.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>conjecture</ToolCommandName>
+    <Description>CLI for Conjecture.NET standalone data generation</Description>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="System.CommandLine" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+    <ProjectReference Include="..\Conjecture.Formatters\Conjecture.Formatters.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Conjecture.Tool.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.Tool/Program.cs
+++ b/src/Conjecture.Tool/Program.cs
@@ -1,0 +1,5 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+// Entry point — CLI implementation pending.
+await Task.CompletedTask;

--- a/src/Conjecture.Tool/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Tool/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.Tool/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Tool/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+#nullable enable
+Conjecture.Tool.AssemblyLoader
+static Conjecture.Tool.AssemblyLoader.FindProviders(string! assemblyPath) -> System.Collections.Generic.IReadOnlyList<System.Type!>!
+static Conjecture.Tool.AssemblyLoader.ResolveByTargetType(System.Reflection.Assembly! assembly, string! typeName) -> System.Type?
+Conjecture.Tool.GenerateCommand
+static Conjecture.Tool.GenerateCommand.ExecuteAsync(string! assemblyPath, string! typeName, int count, ulong? seed, string! format) -> System.Threading.Tasks.Task<string!>!

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -20,4 +20,6 @@
   <Project Path="Conjecture.Mcp.Tests/Conjecture.Mcp.Tests.csproj" />
   <Project Path="Conjecture.Formatters/Conjecture.Formatters.csproj" />
   <Project Path="Conjecture.Formatters.Tests/Conjecture.Formatters.Tests.csproj" />
+  <Project Path="Conjecture.Tool/Conjecture.Tool.csproj" />
+  <Project Path="Conjecture.Tool.Tests/Conjecture.Tool.Tests.csproj" />
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -51,5 +51,8 @@
     <!-- MCP server -->
     <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+
+    <!-- CLI tool -->
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25277.114" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Adds the `Conjecture.Tool` CLI project — a packable .NET tool (`conjecture`) that generates sample data from user-supplied strategy providers found in a compiled assembly.

- `AssemblyLoader` scans an assembly for `IStrategyProvider<T>` implementations and resolves providers by full or simple type name
- `GenerateCommand` loads a provider via reflection, generates values with `DataGen.Stream`, and writes output using `IOutputFormatter` (json/jsonl)
- Adds `System.CommandLine` to central package management

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #88
Part of #76