### PR TITLE
Optimize Claude agent/skill definitions for TDD workflow

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -20,33 +20,13 @@ You will receive:
 
 1. Run `dotnet test src/ --filter "FullyQualifiedName~<target>"` to see exactly which tests fail and why.
 2. Read the failing test file to understand the required behavior.
-3. Identify the production project from the test file path (see CLAUDE.md project map). Read existing production files or create new ones.
+3. Identify the production project from the test file path (see CLAUDE.md project map). Read existing production files or create new ones. Check `docs/decisions/` for relevant ADRs.
 4. Write the **minimum** code that makes the failing tests pass:
    - No speculative features, no extra overloads
-   - Follow existing patterns (file-scoped namespaces, `readonly struct` where appropriate)
-   - New or changed `public` API in non-test projects must be declared in `PublicAPI.Unshipped.txt` (enforced by RS0016 — the error includes the exact signature to copy)
-5. Run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` — fix **all** warnings. Common culprits: block-scoped namespace, `var`, missing braces, `new T()` instead of `new()`.
-6. Run `dotnet format --include <changed_cs_files> --exclude-diagnostics IDE0130` for all changed `.cs` and fix any incorrect formatting.
-7. Run `dotnet test src/ --filter "FullyQualifiedName~<target>"` — all targeted tests must pass.
-8. Run `dotnet test src/` — no regressions.
-
-## Code Style Quick Reference
-
-| Pattern | Correct | Wrong |
-|---|---|---|
-| Namespace | `namespace Foo.Bar;` | `namespace Foo.Bar { }` |
-| `var` | never — always explicit types | `var x = new Foo()` |
-| Object creation | `new()` when type is apparent | `new Foo()` on right side of assignment |
-| Braces | always, even for single-line `if`/`for` | `if (x) return;` |
-| `using` | `using var x = …;` | `using (var x = …) { }` |
-| `null` check | `x is null` / `x is not null` | `x == null` / `x != null` |
-| Ternary assign | `x = cond ? a : b;` | `if (cond) x = a; else x = b;` |
-| Ternary return | `return cond ? a : b;` | `if (cond) return a; return b;` |
-| Switch | `x switch { … }` | `switch (x) { … }` when all arms return |
-| Primary ctor | `class Foo(int x)` | `class Foo { Foo(int x) { _x = x; } }` |
-| Expression prop | `int X => _x;` | `int X { get { return _x; } }` |
-| Expression method | block body `{ return …; }` | `=> expr` |
-| Pattern matching | `x is Foo f` | `x is Foo; var f = (Foo)x` |
+   - Follow existing patterns and Code Style in CLAUDE.md
+   - New public API → `PublicAPI.Unshipped.txt` (see CLAUDE.md)
+5. Run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` — fix **all** warnings.
+6. Run `dotnet test src/ --filter "FullyQualifiedName~<target>" --no-build` — all targeted tests must pass.
 
 ## Output
 
@@ -59,5 +39,5 @@ Report:
 
 - Implement only what the tests demand — resist anticipating future tests
 - Do not add `public` API surface beyond what the tests reference
-- If a reviewer FIX_IMPLEMENTATION verdict was provided, address each finding while keeping all tests green
+- On FIX_IMPLEMENTATION: address each finding while keeping tests green
 - Prefer one type (class, record, interface etc) per file

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -21,8 +21,9 @@ You will receive one or more of:
 
 ## Steps
 
-1. Run `dotnet format --include <changed_cs_files> --exclude-diagnostics IDE0130 --verify-no-changes` for all changed `.cs` files — all formatting must be correct. If this fails, report it as a FIX_IMPLEMENTATION finding.
-2. Review the changed production files for reuse, quality, and efficiency issues (see "What to look for" section below).
+1. Run `dotnet format src/ --include <changed_cs_files> --exclude-diagnostics IDE0130 --verify-no-changes` — all formatting must be correct. If this fails, report as FIX_IMPLEMENTATION.
+2. Run `dotnet test src/` — full regression. All tests must pass. If any fail, report as FIX_IMPLEMENTATION.
+3. Review the changed production files for reuse, quality, and efficiency issues (see below).
 
 ## Output format
 
@@ -42,7 +43,7 @@ Choose the verdict as follows:
 - **FIX_IMPLEMENTATION** — implementation has quality/efficiency/reuse issues that should be corrected without changing the test contract
 - **ADD_TEST** — a behavioral gap exists that is not covered by any test (missing edge case, missing boundary, untested contract)
 
-If there are both implementation issues and missing tests, pick the one that is more fundamental. A missing test is more fundamental than a style issue.
+If both issues exist, prioritize: ADD_TEST > FIX_IMPLEMENTATION.
 
 ## What to look for
 
@@ -56,7 +57,7 @@ If there are both implementation issues and missing tests, pick the one that is 
 - Leaky abstractions (exposing internals, breaking encapsulation)
 - Unnecessary comments (explaining WHAT, not WHY — flag for removal)
 - Stringly-typed code where constants or enums already exist
-- Unneccassary warning suppression
+- Unnecessary warning suppression
 - One file per type unless they are nested
 - One test class per SUT or feature
 

--- a/.claude/agents/test-developer.md
+++ b/.claude/agents/test-developer.md
@@ -27,11 +27,9 @@ You will receive:
    - Use `[Fact]` for deterministic cases, `[Theory]` + `[InlineData]` for parameterised
    - Assert on observable output only — no implementation details
    - Do NOT create stub implementations; reference types that don't exist yet (build will fail — that's correct)
-   - Follow code style: file-scoped namespaces, no `var`, braces on all control flow, `new()` when type is apparent
+   - Follow Code Style in CLAUDE.md
 4. If given a reviewer ADD_TEST verdict, add the missing tests the reviewer identified.
-5. Run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` — fix any style warnings in the test file itself.
-6. Run `dotnet format --include <changed_cs_files> --exclude-diagnostics IDE0130` for all changed `.cs` and fix any incorrect formatting.
-7. Run `dotnet build src/` — must fail (missing production types) or tests must fail. If green, the tests cover nothing new; revise them.
+5. Run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` — fix any style warnings in the test file. Build must fail (missing production types) or tests must fail. If green, tests cover nothing new; revise them.
 
 ## Output
 
@@ -42,10 +40,8 @@ Report:
 
 ## Guidelines
 
-- One test class per production class
+- One test class per production class, one test class per file
 - Keep each test focused on a single behavior
 - Prefer `Assert.Equal` / `Assert.True` over `Assert.NotNull` unless null-safety is the behavior under test
 - Avoid mocking framework internals; test at the public API surface
 - Match production namespace with `.Tests` appended
-- Prefer one test class per file
-- Prefer one test class per subject under test

--- a/.claude/hooks/format-cs.sh
+++ b/.claude/hooks/format-cs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Auto-format .cs files after Edit/Write tool calls.
+# Runs dotnet format on the changed file only; always exits 0 (non-blocking).
+
+FILE_PATH=$(cat | jq -r '.tool_input.file_path')
+
+case "$FILE_PATH" in
+  *.cs)
+    REL_PATH="${FILE_PATH#$CLAUDE_PROJECT_DIR/}"
+    dotnet format src/ --include "$REL_PATH" --exclude-diagnostics IDE0130 2>/dev/null
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,19 @@
 {
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/format-cs.sh\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/implement-cycle/SKILL.md
+++ b/.claude/skills/implement-cycle/SKILL.md
@@ -71,7 +71,7 @@ Spawn a `developer` agent with the test class name extracted from the test file 
 
 Run `dotnet test src/ --filter "FullyQualifiedName~<TestClassName>"`.
 
-If tests still fail, spawn the `developer` agent again with the failing output as additional context. After 2 failed haiku attempts, respawn with `model: "sonnet"` as override. If still failing after 3 total attempts, stop and report.
+If tests still fail, spawn the `developer` agent again with the failing output as additional context. If still failing after 2 total attempts, stop and report.
 
 #### 3c. Review phase — assess quality (reviewer agent)
 
@@ -95,28 +95,22 @@ What would you like to do?
 Options:
 - **Fix implementation** — re-run 3b with reviewer findings threaded as context (skip 3a)
 - **Add / refine tests** — re-run from 3a with reviewer findings as context
-- **Approve** — exit loop and proceed to step 6
+- **Approve** — exit loop and proceed to PublicAPI check
 - **Abort** — stop here, leave branch as-is
 
 If the verdict is APPROVED, still show the checkpoint but default-highlight "Approve".
 
-### 6. Verify no regressions
-
-Run `dotnet test src/` — full suite must be green.
-
-If any previously-passing test now fails: stop, report the regression, and do NOT proceed.
-
-### 7. PublicAPI check
+### 6. PublicAPI check
 
 If the **## Implement** section mentions new public API surface, verify `PublicAPI.Unshipped.txt` was updated with the new symbols. If not, update it now.
 
-### 8. Commit
+### 7. Commit
 
 Invoke the `commit-message` skill to generate a suggested commit message.
 
 Stage all new and modified files from this cycle and commit with the suggested message (no `Co-Authored-By` trailer).
 
-### 9. Push branch and create PR
+### 8. Push branch and create PR
 
 ```bash
 git push -u origin feat/<parent>-<sub>-<slug>

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,59 +1,11 @@
 ---
 name: implement
 description: >
-  Write the minimal production code to make failing tests pass (TDD Green phase) in the Conjecture .NET project.
-  Use this skill whenever the user asks to implement a feature, make tests pass, write production code, or is in the green phase of a TDD cycle — even if they don't say "TDD" or "green phase" explicitly.
-  Triggers on phrases like "implement X", "make the tests pass", "write the code for", "make it compile", or after failing tests have been written and production code is needed.
+  Write the minimal production code to make failing tests pass (TDD Green phase).
+  Triggers: "implement X", "make the tests pass", "write the code for", "make it compile",
+  or after failing tests need production code.
 ---
 
-Write the minimal production code to make failing tests pass (TDD Green phase).
-
-## Input
-
-Test class or file to target (e.g., `IntegerStrategyTests` or `src/Conjecture.Tests/IntegerStrategyTests.cs`). If omitted, run all failing tests and address them all.
-
-## Steps
-
-1. Run `dotnet test src/ --filter "FullyQualifiedName~<target>"` (or `dotnet test src/` if no target) to see which tests fail and why.
-2. Read the failing test(s) to understand the exact behavior required.
-3. Identify the production project from the test file path using the mapping in CLAUDE.md. Read the relevant production file(s) there (or create them if they don't exist). Check `docs/decisions/` for ADRs that constrain the design.
-4. Write the **minimum** code that makes the failing tests pass:
-   - No speculative features, no extra overloads
-   - Hardcode constants only if a single test demands it; generalise only when a second test forces you to
-   - Follow existing patterns in the codebase (file-scoped namespaces, `readonly struct` where appropriate, etc.)
-   - Any new or changed `public` API surface in non-test projects must be declared in that project's `PublicAPI.Unshipped.txt` (see CLAUDE.md). The project enforces this via RS0016 at build time — the compiler error includes the exact signature string to copy in.
-   - Follow the **Code Style Quick Reference** below — these rules are enforced as build warnings.
-5. Run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` — fix **all** warnings before continuing. Common culprits: block-scoped namespace, `var`, missing braces, `new T()` instead of `new()`, explicit `if`/`return` instead of ternary.
-6. Run `dotnet test src/ --filter "FullyQualifiedName~<target>"` again — all targeted tests must be green.
-7. Run `dotnet test src/` — no previously passing tests may be broken.
-8. Report: files changed, tests now passing, and any design choices made.
-
-## Guidelines
-
-- Implement only what the tests demand — resist the urge to anticipate future tests
-- If making a test pass requires a design decision (e.g., choosing an algorithm), record it with `/decision` before implementing
-- Keep methods short; if a method exceeds ~20 lines, note it for the Refactor phase (`/simplify`)
-- Do not add `public` API surface beyond what the tests reference
-
-## Code Style Quick Reference
-
-Rules enforced as build warnings — write them correctly the first time:
-
-| Pattern | Correct | Wrong |
-|---|---|---|
-| Namespace | `namespace Foo.Bar;` | `namespace Foo.Bar { }` |
-| `var` | never — always explicit types | `var x = new Foo()` |
-| Object creation | `new()` when type is apparent | `new Foo()` on right side of assignment |
-| Braces | always, even for single-line `if`/`for` | `if (x) return;` |
-| `using` | `using var x = …;` (simple) | `using (var x = …) { }` |
-| `null` check | `x is null` / `x is not null` | `x == null` / `x != null` |
-| Null propagation | `x?.Foo` | `x == null ? null : x.Foo` |
-| Ternary assign | `x = cond ? a : b;` | `if (cond) x = a; else x = b;` |
-| Ternary return | `return cond ? a : b;` | `if (cond) return a; return b;` |
-| Switch | `x switch { … }` | `switch (x) { … }` when all arms return |
-| Index | `arr[^1]` | `arr[arr.Length - 1]` |
-| Primary ctor | `class Foo(int x)` | `class Foo { Foo(int x) { _x = x; } }` |
-| Expression prop | `int X => _x;` | `int X { get { return _x; } }` |
-| Expression method | block body `{ return …; }` | `=>` (methods must use block bodies) |
-| Pattern matching | `x is Foo f` | `x is Foo; var f = (Foo)x` |
-| `not` pattern | `x is not null` | `!(x is null)` |
+Spawn a `developer` agent with the user's input as the target test class or file.
+If no target specified, tell the agent to run all failing tests.
+Report the agent's output to the user.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -2,34 +2,28 @@
 name: simplify
 description: >
   Review changed code for reuse, quality, and efficiency, then fix any issues found — the TDD Refactor phase for the Conjecture .NET project.
-  Use this skill whenever the user wants to clean up code after making tests pass, refactor a file, review for code smells, or is in the refactor phase of a TDD cycle — even if they don't say "refactor" or "simplify" explicitly.
-  Triggers on phrases like "clean this up", "refactor", "simplify", "review for issues", "any code smells?", or automatically after the implement skill completes a green phase.
+  Triggers: "clean this up", "refactor", "simplify", "review for issues", "any code smells?",
+  or automatically after the implement skill completes a green phase.
 ---
 
 Review changed code for reuse, quality, and efficiency, then fix any issues found.
 
 ## Input
 
-One or more production file paths to review (e.g., `src/Conjecture.Core/Strategies/FooStrategy.cs`). If omitted, runs `git diff` to find changed files automatically.
+One or more production file paths to review. If omitted, runs `git diff` to find changed files.
 
 ## Steps
 
-1. **Identify changes**
-   - If arguments provided: read those files directly.
-   - Otherwise: run `git diff HEAD` to find changed production files.
-
-2. **Spawn the `reviewer` agent** — pass the full diff or file contents and any available test results. Use `subagent_type: "reviewer"`.
-
-3. **Fix issues** — based on the reviewer's findings. Before applying, check whether the user's ask was narrow or broad:
-   - **Broad ask** ("simplify", "refactor", "any issues?", "clean this up"): apply all legitimate findings.
-   - **Narrow ask** ("clean up the comments", "just fix X"): apply only findings that match the stated scope. Note other findings as observations but don't apply them.
-
-4. **Verify** — run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` to catch style violations, then run `dotnet test src/` to confirm tests still pass.
-
+1. **Identify changes** — if arguments provided, read those files. Otherwise run `git diff HEAD` to find changed production files.
+2. **Spawn the `reviewer` agent** — pass the full diff or file contents and any available test results.
+3. **Fix issues** — based on the reviewer's findings:
+   - **Broad ask** ("simplify", "refactor", "any issues?"): apply all legitimate findings
+   - **Narrow ask** ("just fix X"): apply only matching findings, note others as observations
+4. **Verify** — run `dotnet test src/` to confirm tests still pass.
 5. **Report** — summarise what was fixed, or confirm the code was already clean.
 
 ## Guidelines
 
-- Only fix issues in the files under review — do not refactor surrounding code.
-- Do not add features or anticipate future requirements.
-- If a finding conflicts with an ADR in `docs/decisions/`, the ADR wins — note it and skip the fix.
+- Only fix issues in the files under review — do not refactor surrounding code
+- Do not add features or anticipate future requirements
+- If a finding conflicts with an ADR in `docs/decisions/`, the ADR wins — note it and skip

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,40 +1,13 @@
 ---
 name: test
 description: >
-  Write failing xUnit tests for a behavior before implementation exists (TDD Red phase) in the Conjecture .NET project.
-  Use this skill whenever the user wants NEW tests written — they describe a behavior to verify, say "write tests for X", "add coverage for X", "test that X does Y", "I need a failing test", or name a strategy/feature that needs tests.
-  Triggers even without "TDD" or "red phase" language, as long as the goal is creating tests rather than acting on existing ones.
-  Do NOT trigger when the user wants to make existing failing tests pass (use implement), fix build errors in test files (use implement), refactor or reorganize existing tests (use simplify), or simply run/explain tests.
+  Write failing xUnit tests for a behavior (TDD Red phase).
+  Triggers: "write tests for X", "add coverage for X", "test that X does Y",
+  "I need a failing test", or naming a feature that needs tests.
+  Do NOT trigger when the user wants to make existing failing tests pass (use implement),
+  refactor existing tests (use simplify), or simply run/explain tests.
 ---
 
-Write failing xUnit tests for a behavior before implementation exists (TDD Red phase).
-
-## Input
-
-The behavior to test, e.g. `IntegerStrategy generates values within [min, max]`.
-
-## Steps
-
-1. Identify the target class/component from the description. Check the relevant production project (see CLAUDE.md for the project map) for existing types; check `docs/decisions/` for relevant ADRs.
-2. Determine the test file location using the production→test project mapping in CLAUDE.md:
-   - New class `Foo` in `src/Conjecture.Core/` → `src/Conjecture.Core.Tests/FooTests.cs`
-   - Mirror the production file's relative path inside the paired test project.
-   - Add to existing file if tests for that class already exist.
-3. Write tests that:
-   - Cover the happy path, boundary values, and at least one failure/edge case
-   - Use descriptive method names: `MethodName_Condition_ExpectedResult`
-   - Use `[Fact]` for deterministic cases, `[Theory]` + `[InlineData]` for parameterised
-   - Assert on observable output only — no implementation details
-   - Do NOT create stub/fake implementations to make them compile; use `#pragma warning disable` or `// TODO: implement` comments if the type doesn't exist yet
-   - Follow the same code style rules as production code (file-scoped namespace, no `var`, braces on all control flow, `new()` when type is apparent, etc.) — see the **Code Style Quick Reference** in the `implement` skill.
-4. Run `dotnet build src/ 2>&1 | grep -E 'warning (IDE|CS)'` — fix any style warnings **in the test file itself** (the goal is red from missing production code, not from style violations in the tests).
-5. Run `dotnet build src/` — the build **must fail** or tests **must fail** (red). If they pass, the tests are not testing anything new; revise them.
-6. Report: which tests were added, which assertion checks what behavior, and what the build/test failure is.
-
-## Guidelines
-
-- One test class per production class
-- Keep each test focused on a single behavior
-- Prefer `Assert.Equal` / `Assert.True` over `Assert.NotNull` unless null-safety is the behavior under test
-- Avoid mocking framework internals; test at the public API surface
-- File-scoped namespaces, match the production namespace with `.Tests` appended
+Spawn a `test-developer` agent with the user's behavior description.
+Include the target test file path if the user specified one.
+Report the agent's output to the user.

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -5,16 +5,44 @@
 
 ## Build & Test
 
-```bash
-dotnet build src/
-dotnet test src/
-dotnet test src/ --filter "FullyQualifiedName~SomeTest"
-```
-## Format
+`dotnet format` runs automatically via hook after every .cs file edit — no need to run manually.
 
 ```bash
-dotnet format src/ --include .somedir/somefile.cs .somedir/somefile2.cs
+dotnet build src/                                                     # check for warnings
+dotnet test src/ --filter "FullyQualifiedName~Target" --no-build      # safe after build
+dotnet test src/                                                      # full suite (review only)
 ```
+
+## Code Style
+
+Rules enforced as build errors — write them correctly the first time:
+
+| Pattern | Correct | Wrong | IDE |
+|---|---|---|---|
+| File header | `// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.` + newline + `// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/` | Missing header | IDE0073 |
+| Namespace | `namespace Foo.Bar;` | `namespace Foo.Bar { }` | IDE0160 |
+| `var` | never — always explicit types | `var x = new Foo()` | — |
+| Object creation | `new()` when type is apparent | `new Foo()` on right side | IDE0090 |
+| Braces | always, even single-line `if`/`for` | `if (x) return;` | IDE0011 |
+| `using` | `using var x = …;` | `using (var x = …) { }` | IDE0063 |
+| `null` check | `x is null` / `x is not null` | `x == null` / `x != null` | IDE0041 |
+| `not` pattern | `x is not null` | `!(x is null)` | IDE0083 |
+| Null propagation | `x?.Foo` | `x == null ? null : x.Foo` | IDE0031 |
+| Null coalescing | `x ?? y` | `x is null ? y : x` | IDE0029 |
+| Ternary assign | `x = cond ? a : b;` | `if (cond) x = a; else x = b;` | IDE0045 |
+| Ternary return | `return cond ? a : b;` | `if (cond) return a; return b;` | IDE0046 |
+| Switch | `x switch { … }` | `switch (x) { … }` when all arms return | IDE0066 |
+| Default | `default` | `default(T)` | IDE0034 |
+| Index | `arr[^1]` | `arr[arr.Length - 1]` | IDE0056 |
+| Range | `arr[1..^1]` | `arr.Skip(1).Take(…)` | IDE0057 |
+| Local function | `static void F() { }` | `Action f = () => …` | IDE0039 |
+| Static lambda | `static () => …` | `() => …` (when no captures) | IDE0258 |
+| Primary ctor | `class Foo(int x)` | ctor + field assignment | IDE0290 |
+| Throw expression | `x ?? throw new …` | `if (x is null) throw …` | IDE0016 |
+| Expression prop | `int X => _x;` | `int X { get { return _x; } }` | — |
+| Expression method | block body `{ return …; }` | `=> expr` (methods must use block bodies) | — |
+| Pattern matching | `x is Foo f` | `x is Foo; var f = (Foo)x` | IDE0019/20 |
+| Readonly struct | `readonly struct` / `readonly` members | Mutable struct when immutable | IDE0250/251 |
 
 ## Project Structure
 


### PR DESCRIPTION
## Description

Reduces duplication and improves efficiency across Claude agent and skill definitions:

- **Single source of truth**: code style table moved to `CLAUDE.md` (24 rows, verified against `.editorconfig`)
- **Skills as thin wrappers**: `test` and `implement` skills now delegate to `test-developer` and `developer` agents instead of duplicating instructions
- **Auto-format hook**: PostToolUse hook runs `dotnet format` on `.cs` files after every Edit/Write, removing the explicit format step from agents
- **Review-only test suite**: full `dotnet test src/` moved exclusively to the reviewer agent; developer agent uses targeted `--no-build` run only
- **Cleaned up implement-cycle**: removed haiku escalation (sonnet throughout), removed redundant regression step (reviewer now covers it)
- **Expanded permission allowlist**: added `dotnet format`, `gh issue`, and `git` commands to avoid permission prompts during TDD cycles

Net: 10 files changed, -54 lines.

## Type of change

- [x] Refactor (no behavior change)

## Checklist

- [x] `dotnet test src/` passes
- [ ] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style