### PR TITLE
[64.1] StrategyExtensions: add C# 14 extension properties for int, string, and IList<T>

### DIFF
--- a/src/Conjecture.Core.Tests/StrategyExtensionsTests.cs
+++ b/src/Conjecture.Core.Tests/StrategyExtensionsTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests;
+
+public class ExtensionPropertyTests
+{
+    private static ConjectureData MakeData(ulong seed = 42UL) =>
+        ConjectureData.ForGeneration(new SplittableRandom(seed));
+
+    [Fact]
+    public void Positive_ReturnsOnlyPositiveIntegers()
+    {
+        Strategy<int> strategy = Generate.Integers<int>().Positive;
+        ConjectureData data = MakeData();
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.True(strategy.Generate(data) > 0, "Positive drew a non-positive integer");
+        }
+    }
+
+    [Fact]
+    public void Negative_ReturnsOnlyNegativeIntegers()
+    {
+        Strategy<int> strategy = Generate.Integers<int>().Negative;
+        ConjectureData data = MakeData();
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.True(strategy.Generate(data) < 0, "Negative drew a non-negative integer");
+        }
+    }
+
+    [Fact]
+    public void NonZero_NeverReturnsZero()
+    {
+        Strategy<int> strategy = Generate.Integers<int>().NonZero;
+        ConjectureData data = MakeData();
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.NotEqual(0, strategy.Generate(data));
+        }
+    }
+
+    [Fact]
+    public void String_NonEmpty_NeverReturnsEmptyString()
+    {
+        Strategy<string> strategy = Generate.Strings().NonEmpty;
+        ConjectureData data = MakeData();
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.NotEqual(string.Empty, strategy.Generate(data));
+        }
+    }
+
+    [Fact]
+    public void List_NonEmpty_NeverReturnsEmptyList()
+    {
+        Strategy<List<int>> strategy = Generate.Lists<int>(Generate.Integers<int>()).NonEmpty;
+        ConjectureData data = MakeData();
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.True(strategy.Generate(data).Count > 0, "NonEmpty drew an empty list");
+        }
+    }
+
+    [Fact]
+    public void ExtensionProperties_ComposeWithSelectAndZip()
+    {
+        Strategy<int> doubled = Generate.Integers<int>().Positive.Select(x => x % (int.MaxValue / 2) + 1);
+        ConjectureData data = MakeData();
+        for (int i = 0; i < 100; i++)
+        {
+            Assert.True(doubled.Generate(data) > 0, "Positive.Select(x => x % (int.MaxValue / 2) + 1) returned a non-positive value");
+        }
+    }
+}

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -10,3 +10,12 @@ Conjecture.Core.ConjectureSettings.ExportReproOnFailure.get -> bool
 Conjecture.Core.ConjectureSettings.ExportReproOnFailure.init -> void
 Conjecture.Core.ConjectureSettings.ReproOutputPath.get -> string!
 Conjecture.Core.ConjectureSettings.ReproOutputPath.init -> void
+Conjecture.Core.StrategyExtensionProperties
+Conjecture.Core.StrategyExtensionProperties.extension(Conjecture.Core.Strategy<int>!)
+Conjecture.Core.StrategyExtensionProperties.extension(Conjecture.Core.Strategy<int>!).Positive.get -> Conjecture.Core.Strategy<int>!
+Conjecture.Core.StrategyExtensionProperties.extension(Conjecture.Core.Strategy<int>!).Negative.get -> Conjecture.Core.Strategy<int>!
+Conjecture.Core.StrategyExtensionProperties.extension(Conjecture.Core.Strategy<int>!).NonZero.get -> Conjecture.Core.Strategy<int>!
+Conjecture.Core.StrategyExtensionProperties.extension(Conjecture.Core.Strategy<string!>!)
+Conjecture.Core.StrategyExtensionProperties.extension(Conjecture.Core.Strategy<string!>!).NonEmpty.get -> Conjecture.Core.Strategy<string!>!
+Conjecture.Core.StrategyExtensionProperties.extension<T>(Conjecture.Core.Strategy<System.Collections.Generic.List<T>!>!)
+Conjecture.Core.StrategyExtensionProperties.extension<T>(Conjecture.Core.Strategy<System.Collections.Generic.List<T>!>!).NonEmpty.get -> Conjecture.Core.Strategy<System.Collections.Generic.List<T>!>!

--- a/src/Conjecture.Core/StrategyExtensionProperties.cs
+++ b/src/Conjecture.Core/StrategyExtensionProperties.cs
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core;
+
+/// <summary>Convenience extension properties for common strategy filters.</summary>
+public static class StrategyExtensionProperties
+{
+    extension(Strategy<int> s)
+    {
+        /// <summary>
+        /// Filters to positive integers only (x &gt; 0).
+        /// </summary>
+        /// <remarks>
+        /// For tight value ranges, prefer a targeted strategy such as
+        /// <c>Generate.Integers(1, 100)</c> over chaining <c>.Where()</c>,
+        /// which may exhaust the filter budget on sparse distributions.
+        /// </remarks>
+        public Strategy<int> Positive => s.Where(static x => x > 0);
+
+        /// <summary>
+        /// Filters to negative integers only (x &lt; 0).
+        /// </summary>
+        /// <remarks>
+        /// For tight value ranges, prefer a targeted strategy such as
+        /// <c>Generate.Integers(-100, -1)</c> over chaining <c>.Where()</c>,
+        /// which may exhaust the filter budget on sparse distributions.
+        /// </remarks>
+        public Strategy<int> Negative => s.Where(static x => x < 0);
+
+        /// <summary>
+        /// Filters out zero (x != 0).
+        /// </summary>
+        /// <remarks>
+        /// For tight value ranges, prefer a targeted strategy such as
+        /// <c>Generate.Integers(1, 100)</c> over chaining <c>.Where()</c>,
+        /// which may exhaust the filter budget on sparse distributions.
+        /// </remarks>
+        public Strategy<int> NonZero => s.Where(static x => x is not 0);
+    }
+
+    extension(Strategy<string> s)
+    {
+        /// <summary>
+        /// Filters to non-empty strings only (Length &gt; 0).
+        /// </summary>
+        /// <remarks>
+        /// For tight value ranges, prefer a targeted strategy such as
+        /// <c>Generate.Strings(minLength: 1)</c> over chaining <c>.Where()</c>,
+        /// which may exhaust the filter budget on sparse distributions.
+        /// </remarks>
+        public Strategy<string> NonEmpty => s.Where(static x => x.Length > 0);
+    }
+
+    extension<T>(Strategy<List<T>> s)
+    {
+        /// <summary>
+        /// Filters to non-empty lists only (Count &gt; 0).
+        /// </summary>
+        /// <remarks>
+        /// For tight value ranges, prefer a targeted strategy such as
+        /// <c>Generate.Lists(inner, minSize: 1)</c> over chaining <c>.Where()</c>,
+        /// which may exhaust the filter budget on sparse distributions.
+        /// </remarks>
+        public Strategy<List<T>> NonEmpty => s.Where(static x => x.Count > 0);
+    }
+}

--- a/src/Conjecture.Core/StrategyExtensions.cs
+++ b/src/Conjecture.Core/StrategyExtensions.cs
@@ -82,3 +82,4 @@ public static class StrategyExtensions
         return new LabeledStrategy<T>(source, label);
     }
 }
+


### PR DESCRIPTION
## Description

Adds C# 14 `extension` blocks to `StrategyExtensionProperties.cs` with blessed filter properties:

- `Strategy<int>` → `.Positive`, `.Negative`, `.NonZero`
- `Strategy<string>` → `.NonEmpty`
- `Strategy<List<T>>` → `.NonEmpty`

All properties are backed by `.Where()` with XML doc noting the filter-budget caveat for tight ranges. `PublicAPI.Unshipped.txt` updated with correct nullability-annotated extension block symbols (no pragma suppression required).

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #124
Part of #64