### PR TITLE
[64.2] Strategy<T>: add | operator for OneOf composition

### DIFF
--- a/src/Conjecture.Core.Tests/StrategyExtensionsTests.cs
+++ b/src/Conjecture.Core.Tests/StrategyExtensionsTests.cs
@@ -77,3 +77,57 @@ public class ExtensionPropertyTests
         }
     }
 }
+
+public class PipeOperatorTests
+{
+    private static List<T> Collect<T>(Strategy<T> strategy, int count, ulong seed = 42UL)
+    {
+        List<T> results = new(count);
+        for (int i = 0; i < count; i++)
+        {
+            ConjectureData data = ConjectureData.ForGeneration(new SplittableRandom(seed + (ulong)i));
+            results.Add(strategy.Generate(data));
+        }
+
+        return results;
+    }
+
+    [Fact]
+    public void PipeOperator_ProducesValuesFromBothStrategies()
+    {
+        Strategy<int> a = Generate.Integers<int>().Positive;
+        Strategy<int> b = Generate.Integers<int>().Negative;
+        Strategy<int> combined = a | b;
+
+        List<int> values = Collect(combined, 200);
+
+        Assert.True(values.Exists(static x => x > 0), "| operator never produced a value from the left strategy");
+        Assert.True(values.Exists(static x => x < 0), "| operator never produced a value from the right strategy");
+    }
+
+    [Fact]
+    public void PipeOperator_IsLeftAssociative()
+    {
+        Strategy<int> a = Generate.Just(-1);
+        Strategy<int> b = Generate.Just(0);
+        Strategy<int> c = Generate.Just(1);
+        Strategy<int> combined = a | b | c;
+
+        List<int> values = Collect(combined, 300);
+
+        Assert.True(values.Exists(static x => x == -1), "| operator never produced a value from the first strategy");
+        Assert.True(values.Exists(static x => x == 0), "| operator never produced a value from the second strategy");
+        Assert.True(values.Exists(static x => x == 1), "| operator never produced a value from the third strategy");
+    }
+
+    [Fact]
+    public void PipeOperator_WorksWithExtensionProperties()
+    {
+        Strategy<int> combined = Generate.Integers<int>().Positive | Generate.Just(0);
+
+        List<int> values = Collect(combined, 200);
+
+        Assert.True(values.Exists(static x => x > 0), "| operator with .Positive never produced a positive integer");
+        Assert.True(values.Exists(static x => x == 0), "| operator with Generate.Just(0) never produced zero");
+    }
+}

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -19,3 +19,5 @@ Conjecture.Core.StrategyExtensionProperties.extension(Conjecture.Core.Strategy<s
 Conjecture.Core.StrategyExtensionProperties.extension(Conjecture.Core.Strategy<string!>!).NonEmpty.get -> Conjecture.Core.Strategy<string!>!
 Conjecture.Core.StrategyExtensionProperties.extension<T>(Conjecture.Core.Strategy<System.Collections.Generic.List<T>!>!)
 Conjecture.Core.StrategyExtensionProperties.extension<T>(Conjecture.Core.Strategy<System.Collections.Generic.List<T>!>!).NonEmpty.get -> Conjecture.Core.Strategy<System.Collections.Generic.List<T>!>!
+Conjecture.Core.StrategyExtensionProperties.extension<T>(Conjecture.Core.Strategy<T>!)
+static Conjecture.Core.StrategyExtensionProperties.extension<T>(Conjecture.Core.Strategy<T>!).operator |(Conjecture.Core.Strategy<T>! left, Conjecture.Core.Strategy<T>! right) -> Conjecture.Core.Strategy<T>!

--- a/src/Conjecture.Core/StrategyExtensionProperties.cs
+++ b/src/Conjecture.Core/StrategyExtensionProperties.cs
@@ -64,4 +64,11 @@ public static class StrategyExtensionProperties
         /// </remarks>
         public Strategy<List<T>> NonEmpty => s.Where(static x => x.Count > 0);
     }
+
+    extension<T>(Strategy<T> _)
+    {
+        /// <summary>Combines two strategies into a single strategy that draws from either, chosen uniformly at random.</summary>
+        public static Strategy<T> operator | (Strategy<T> left, Strategy<T> right)
+            => Generate.OneOf(left, right);
+    }
 }


### PR DESCRIPTION
## Description

Adds a `|` operator to `Strategy<T>` via a C# 14 extension block, enabling concise OneOf composition: `a | b | c` produces `OneOf(OneOf(a, b), c)` (left-associative). The operator delegates to the existing `Generate.OneOf` method. 

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #125
Part of #64