### PR TITLE
[64.3] CJ0050: suggest named extension property when common .Where() pattern detected

### DIFF
--- a/src/Conjecture.Analyzers.CodeFixes/CJ0050CodeFix.cs
+++ b/src/Conjecture.Analyzers.CodeFixes/CJ0050CodeFix.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Conjecture.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CJ0050CodeFix))]
+[Shared]
+internal sealed class CJ0050CodeFix : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(CJ0050Analyzer.Rule.Id);
+
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: "Replace with named extension property",
+                createChangedDocument: ct => ApplyFixAsync(context.Document, context.Diagnostics[0], ct),
+                equivalenceKey: "CJ0050_ReplaceWithProperty"),
+            context.Diagnostics[0]);
+        return Task.CompletedTask;
+    }
+
+    private static async Task<Document> ApplyFixAsync(
+        Document document,
+        Diagnostic diagnostic,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken);
+        if (root is null)
+        {
+            return document;
+        }
+
+        if (!diagnostic.Properties.TryGetValue(CJ0050Analyzer.PropertyNameKey, out string? propertyName) ||
+            propertyName is null)
+        {
+            return document;
+        }
+
+        SyntaxNode? diagNode = root.FindNode(diagnostic.Location.SourceSpan);
+        InvocationExpressionSyntax? invocation = diagNode as InvocationExpressionSyntax
+            ?? diagNode?.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+
+        if (invocation is null)
+        {
+            return document;
+        }
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return document;
+        }
+
+        MemberAccessExpressionSyntax replacement = SyntaxFactory
+            .MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                memberAccess.Expression,
+                SyntaxFactory.IdentifierName(propertyName))
+            .WithTriviaFrom(invocation);
+
+        SyntaxNode newRoot = root.ReplaceNode(invocation, replacement);
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/Conjecture.Analyzers.Tests/CJ0050Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CJ0050Tests.cs
@@ -1,0 +1,287 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Conjecture.Analyzers;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Conjecture.Analyzers.Tests;
+
+public sealed class CJ0050Tests
+{
+    private const string Preamble = """
+        using System;
+        using System.Collections.Generic;
+        namespace Conjecture.Core {
+            public class Strategy<T> {
+                public Strategy<T> Where(Func<T, bool> predicate) => this;
+            }
+            public static class Generate {
+                public static Strategy<int> Integers() => new();
+                public static Strategy<string> Strings() => new();
+                public static Strategy<List<T>> Lists<T>() => new();
+            }
+        }
+        using Conjecture.Core;
+        """;
+
+    // --- .Where(x => x > 0) on Strategy<int> → CJ0050 ---
+
+    [Fact]
+    public async Task WhereXGreaterThan0_OnStrategyInt_EmitsCJ0050()
+    {
+        string source = Preamble + """
+            class Tests {
+                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x > 0); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+    }
+
+    // --- .Where(x => x < 0) on Strategy<int> → CJ0050 ---
+
+    [Fact]
+    public async Task WhereXLessThan0_OnStrategyInt_EmitsCJ0050()
+    {
+        string source = Preamble + """
+            class Tests {
+                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x < 0); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+    }
+
+    // --- .Where(x => x != 0) on Strategy<int> → CJ0050 ---
+
+    [Fact]
+    public async Task WhereXNotEqualTo0_OnStrategyInt_EmitsCJ0050()
+    {
+        string source = Preamble + """
+            class Tests {
+                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x != 0); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+    }
+
+    // --- .Where(x => x.Length > 0) on Strategy<string> → CJ0050 ---
+
+    [Fact]
+    public async Task WhereXLengthGreaterThan0_OnStrategyString_EmitsCJ0050()
+    {
+        string source = Preamble + """
+            class Tests {
+                void Foo() { Strategy<string> s = Generate.Strings().Where(x => x.Length > 0); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+    }
+
+    // --- .Where(x => x.Count > 0) on Strategy<List<int>> → CJ0050 ---
+
+    [Fact]
+    public async Task WhereXCountGreaterThan0_OnStrategyList_EmitsCJ0050()
+    {
+        string source = Preamble + """
+            class Tests {
+                void Foo() { Strategy<List<int>> s = Generate.Lists<int>().Where(x => x.Count > 0); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+    }
+
+    // --- .Where(x => x > 1) on Strategy<int> → no CJ0050 (custom predicate) ---
+
+    [Fact]
+    public async Task WhereCustomPredicate_OnStrategyInt_NoCJ0050()
+    {
+        string source = Preamble + """
+            class Tests {
+                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x > 1); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "CJ0050");
+    }
+
+    // --- .Where(x => x > 0) on IEnumerable<int> (plain LINQ) → no CJ0050 ---
+
+    [Fact]
+    public async Task WhereXGreaterThan0_OnIEnumerableInt_NoCJ0050()
+    {
+        string source = Preamble + """
+            using System.Collections.Generic;
+            using System.Linq;
+            class Tests {
+                void Foo() {
+                    IEnumerable<int> source = new List<int>();
+                    IEnumerable<int> result = source.Where(x => x > 0);
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == "CJ0050");
+    }
+
+    // --- Severity is Info ---
+
+    [Fact]
+    public async Task CJ0050_IsInfoSeverity()
+    {
+        string source = Preamble + """
+            class Tests {
+                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x > 0); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
+        Diagnostic? cj0050 = diagnostics.FirstOrDefault(d => d.Id == "CJ0050");
+
+        Assert.NotNull(cj0050);
+        Assert.Equal(DiagnosticSeverity.Info, cj0050.Severity);
+    }
+
+    // --- Code fix: .Where(x => x > 0) → .Positive ---
+
+    [Fact]
+    public async Task CodeFix_WherePositive_ReplacesWithPositiveProperty()
+    {
+        string source = Preamble + """
+            class Tests {
+                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x > 0); }
+            }
+            """;
+
+        string? result = await ApplyCodeFixAsync(source);
+
+        Assert.NotNull(result);
+        Assert.Contains(".Positive", result);
+        Assert.DoesNotContain(".Where", result);
+    }
+
+    // --- Helpers ---
+
+    private static ImmutableArray<MetadataReference> GetReferences()
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        return
+        [
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Linq.dll")),
+        ];
+    }
+
+    private static CSharpCompilation CreateCompilation(string source) =>
+        CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references: GetReferences(),
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
+    {
+        CSharpCompilation compilation = CreateCompilation(source);
+        CJ0050Analyzer analyzer = new();
+        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    private static async Task<string?> ApplyCodeFixAsync(string source)
+    {
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
+        Diagnostic? target = diagnostics.FirstOrDefault(d => d.Id == "CJ0050");
+        if (target is null)
+        {
+            return null;
+        }
+
+        CSharpCompilation compilation = CreateCompilation(source);
+
+        using Microsoft.CodeAnalysis.AdhocWorkspace workspace = new();
+        ProjectId projectId = ProjectId.CreateNewId();
+        Solution solution = workspace.CurrentSolution
+            .AddProject(ProjectInfo.Create(
+                projectId, VersionStamp.Create(), "Test", "Test", LanguageNames.CSharp,
+                compilationOptions: compilation.Options,
+                metadataReferences: GetReferences()));
+
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+        solution = solution.AddDocument(
+            DocumentInfo.Create(documentId, "Test.cs",
+                loader: TextLoader.From(TextAndVersion.Create(
+                    SourceText.From(source), VersionStamp.Create()))));
+
+        workspace.TryApplyChanges(solution);
+        Document document = workspace.CurrentSolution.GetDocument(documentId)!;
+
+        Compilation workspaceCompilation = (await document.Project.GetCompilationAsync())!;
+        CompilationWithAnalyzers cwAnalyzers = workspaceCompilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(new CJ0050Analyzer()));
+        ImmutableArray<Diagnostic> mapped = await cwAnalyzers.GetAnalyzerDiagnosticsAsync();
+        Diagnostic? mappedDiagnostic = mapped.FirstOrDefault(d => d.Id == "CJ0050");
+        if (mappedDiagnostic is null)
+        {
+            return null;
+        }
+
+        CJ0050CodeFix fix = new();
+        List<CodeAction> actions = [];
+        CodeFixContext context = new(
+            document, mappedDiagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+        await fix.RegisterCodeFixesAsync(context);
+
+        if (!actions.Any())
+        {
+            return null;
+        }
+
+        ImmutableArray<CodeActionOperation> operations =
+            await actions[0].GetOperationsAsync(CancellationToken.None);
+        foreach (CodeActionOperation op in operations)
+        {
+            op.Apply(workspace, CancellationToken.None);
+        }
+
+        Document updated = workspace.CurrentSolution.GetDocument(documentId)!;
+        SourceText text = await updated.GetTextAsync();
+        return text.ToString();
+    }
+}

--- a/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,3 +2,4 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+| CJ0050 | Usage | Info | Suggest named extension property |

--- a/src/Conjecture.Analyzers/CJ0050Analyzer.cs
+++ b/src/Conjecture.Analyzers/CJ0050Analyzer.cs
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Conjecture.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class CJ0050Analyzer : DiagnosticAnalyzer
+{
+    internal const string PropertyNameKey = "PropertyName";
+
+    internal static readonly DiagnosticDescriptor Rule = new(
+        id: "CJ0050",
+        title: "Suggest named extension property",
+        messageFormat: "Use .{0} instead of .Where({1})",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "A common .Where() predicate pattern has a named extension property equivalent.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return;
+        }
+
+        if (memberAccess.Name.Identifier.Text != "Where")
+        {
+            return;
+        }
+
+        if (invocation.ArgumentList.Arguments.Count != 1)
+        {
+            return;
+        }
+
+        ExpressionSyntax argument = invocation.ArgumentList.Arguments[0].Expression;
+        if (argument is not LambdaExpressionSyntax lambda)
+        {
+            return;
+        }
+
+        if (!IsStrategyReceiver(context.SemanticModel, invocation, memberAccess))
+        {
+            return;
+        }
+
+        string? paramName = GetLambdaParamName(lambda);
+        if (paramName is null)
+        {
+            return;
+        }
+
+        ExpressionSyntax? body = GetLambdaBody(lambda);
+        if (body is null)
+        {
+            return;
+        }
+
+        string? propertyName = MatchPattern(body, paramName);
+        if (propertyName is null)
+        {
+            return;
+        }
+
+        string predicateText = argument.ToString();
+        ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty
+            .Add(PropertyNameKey, propertyName);
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.GetLocation(),
+            properties,
+            propertyName,
+            predicateText));
+    }
+
+    private static bool IsStrategyReceiver(
+        SemanticModel model,
+        InvocationExpressionSyntax invocation,
+        MemberAccessExpressionSyntax memberAccess)
+    {
+        ITypeSymbol? receiverType = model.GetTypeInfo(memberAccess.Expression).Type;
+        if (IsStrategyType(receiverType))
+        {
+            return true;
+        }
+
+        SymbolInfo symbolInfo = model.GetSymbolInfo(memberAccess);
+        if (symbolInfo.Symbol is IMethodSymbol sym && IsStrategyType(sym.ContainingType))
+        {
+            return true;
+        }
+
+        foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
+        {
+            if (candidate is IMethodSymbol cm && IsStrategyType(cm.ContainingType))
+            {
+                return true;
+            }
+        }
+
+        ITypeSymbol? returnType = model.GetTypeInfo(invocation).Type;
+        return IsStrategyType(returnType) || IsStrategyTypeSyntactically(invocation);
+    }
+
+    private static bool IsStrategyType(ITypeSymbol? type)
+    {
+        return type is not null && type.Name == "Strategy" && type is INamedTypeSymbol { IsGenericType: true };
+    }
+
+    private static bool IsStrategyTypeSyntactically(SyntaxNode node)
+    {
+        return node.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax decl } }
+            && IsStrategyTypeSyntax(decl.Type);
+    }
+
+    private static bool IsStrategyTypeSyntax(TypeSyntax type)
+    {
+        return type is GenericNameSyntax generic && generic.Identifier.Text == "Strategy"
+            || type is QualifiedNameSyntax qualified && IsStrategyTypeSyntax(qualified.Right);
+    }
+
+    private static string? GetLambdaParamName(LambdaExpressionSyntax lambda)
+    {
+        return lambda is SimpleLambdaExpressionSyntax simple
+            ? simple.Parameter.Identifier.Text
+            : lambda is ParenthesizedLambdaExpressionSyntax paren &&
+              paren.ParameterList.Parameters.Count == 1
+              ? paren.ParameterList.Parameters[0].Identifier.Text
+              : null;
+    }
+
+    private static ExpressionSyntax? GetLambdaBody(LambdaExpressionSyntax lambda)
+    {
+        return lambda is SimpleLambdaExpressionSyntax simple &&
+            simple.Body is ExpressionSyntax simpleExpr
+            ? simpleExpr
+            : lambda is ParenthesizedLambdaExpressionSyntax paren &&
+              paren.Body is ExpressionSyntax parenExpr
+              ? parenExpr
+              : null;
+    }
+
+    private static string? MatchPattern(ExpressionSyntax body, string paramName)
+    {
+        if (body is not BinaryExpressionSyntax binary)
+        {
+            return null;
+        }
+
+        string leftText = binary.Left.ToString();
+        string rightText = binary.Right.ToString();
+        SyntaxKind op = binary.OperatorToken.Kind();
+
+        return (leftText, op, rightText) switch
+        {
+            _ when leftText == paramName && op == SyntaxKind.GreaterThanToken && rightText == "0" => "Positive",
+            _ when leftText == paramName && op == SyntaxKind.LessThanToken && rightText == "0" => "Negative",
+            _ when leftText == paramName && op == SyntaxKind.ExclamationEqualsToken && rightText == "0" => "NonZero",
+            _ when leftText == paramName + ".Length" && op == SyntaxKind.GreaterThanToken && rightText == "0" => "NonEmpty",
+            _ when leftText == paramName + ".Count" && op == SyntaxKind.GreaterThanToken && rightText == "0" => "NonEmpty",
+            _ => null,
+        };
+    }
+}


### PR DESCRIPTION
## Description

Adds `CJ0050Analyzer` (Info severity) that detects five blessed `.Where()` predicate patterns on `Strategy<T>` and suggests the named extension property equivalent (`Positive`, `Negative`, `NonZero`, `NonEmpty`). A companion `CJ0050CodeFix` replaces the `.Where(lambda)` call with the named property in one action.

Pattern matching is structural (parameter-name-agnostic). A syntactic fallback handles test harnesses where the semantic model cannot resolve `Strategy<T>` due to namespace conflicts. The diagnostic does not fire on unrelated `IEnumerable<T>.Where()` calls.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #126
Part of #64