### PR TITLE
Fix NU5118: remove missing README.md reference from Conjecture.Formatters

### DIFF
--- a/src/Conjecture.Formatters/Conjecture.Formatters.csproj
+++ b/src/Conjecture.Formatters/Conjecture.Formatters.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -35,7 +35,7 @@
 
   <ItemGroup Condition="'$(IsPackable)' != 'false'">
     <None Include="$(MSBuildThisFileDirectory)..\LICENSE-MIT.txt" Pack="true" PackagePath="\" Visible="false" />
-    <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" Visible="false" Condition="!Exists('$(MSBuildProjectDirectory)\README.md')" />
+    <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" Visible="false" Condition="'$(PackageHasOwnReadme)' != 'true'" />
     <PackageReference Include="MinVer" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
## Description

The v0.7.0 release action failed during `dotnet pack` with:

```
error NU5118: File 'Conjecture.Formatters/README.md' is not added because the package already contains file '/README.md'
```

Root cause: `Conjecture.Formatters.csproj` had a `<None Include="README.md" Pack="true" PackagePath="\" />` item referencing a file that **does not exist**. At the same time, `Directory.Build.props` always included the root `README.md` at the same pack path (its `Exists()`-based condition was unreliable). NuGet tried to add both, then rejected the second.

Two changes:

1. **`Conjecture.Formatters.csproj`** — remove the `<None>` item for the non-existent local README; the root README from `Directory.Build.props` covers this package.
2. **`Directory.Build.props`** — replace the fragile `Exists()` condition with an explicit opt-in property `PackageHasOwnReadme`. Any project that does have its own README can set `<PackageHasOwnReadme>true</PackageHasOwnReadme>` to suppress the root fallback.

## Type of change

- [x] Bug fix

## Checklist

- [x] `dotnet test src/` passes
- [x] Follows `.editorconfig` code style