### PR TITLE
Add pack step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Build
-        run: dotnet build src/Conjecture.slnx
+        run: dotnet build src/Conjecture.slnx -c Release
 
       - name: Test
-        run: dotnet test src/Conjecture.slnx --no-build
+        run: dotnet test src/Conjecture.slnx -c Release --no-build
 
       - name: Pack
-        run: dotnet pack src/Conjecture.slnx --no-build -o /tmp/packages
+        run: dotnet pack src/Conjecture.slnx -c Release --no-build -o /tmp/packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Test
         run: dotnet test src/Conjecture.slnx --no-build
+
+      - name: Pack
+        run: dotnet pack src/Conjecture.slnx --no-build -o /tmp/packages


### PR DESCRIPTION
## Description

Adds a `dotnet pack` step to the CI workflow so packaging errors are caught on PRs rather than at release time. Reuses existing build artifacts via `--no-build`.

Would have caught the NU5118 issue from today before it reached the release action.

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] Follows `.editorconfig` code style