### PR TITLE
[140.1] PlanRunner: resolve IStrategyProvider<T> via reflection for arbitrary types

### DIFF
--- a/src/Conjecture.Tool.Tests/Plan/GenerationPlanTests.cs
+++ b/src/Conjecture.Tool.Tests/Plan/GenerationPlanTests.cs
@@ -553,9 +553,35 @@ public class PlanRunnerTests
         GenerationPlan plan = JsonSerializer.Deserialize<GenerationPlan>(json)!;
         PlanRunner runner = new();
 
-        NotImplementedException ex = Assert.Throws<NotImplementedException>(() => runner.Run(plan));
+        PlanException ex = Assert.Throws<PlanException>(() => runner.Run(plan));
 
+        Assert.Equal(1, ex.ExitCode);
         Assert.Contains("System.Guid", ex.Message);
+    }
+
+    [Fact]
+    public void Run_ProviderWithNoParameterlessCtor_ThrowsPlanExceptionWithExitCodeOne()
+    {
+        string assemblyPath = typeof(PlanRunnerTests).Assembly.Location.Replace("\\", "/");
+        string json = $$"""
+            {
+              "assembly": "{{assemblyPath}}",
+              "steps": [
+                { "name": "items", "type": "Conjecture.Tool.Tests.Plan.TestModels.NoCtorModel", "count": 3, "seed": 1 }
+              ],
+              "output": { "format": "json", "file": null }
+            }
+            """;
+
+        GenerationPlan plan = JsonSerializer.Deserialize<GenerationPlan>(json)!;
+        PlanRunner runner = new();
+
+        PlanException ex = Assert.Throws<PlanException>(() => runner.Run(plan));
+
+        Assert.Equal(1, ex.ExitCode);
+        Assert.True(
+            ex.Message.Contains("NoCtorModel") || ex.Message.Contains("constructor"),
+            $"Expected message to mention 'NoCtorModel' or 'constructor', but was: {ex.Message}");
     }
 
     [Fact]
@@ -1041,7 +1067,7 @@ public class PlanRunnerNestedRefTests
     // serialised output has nested objects is not yet possible end-to-end.
     // These tests will FAIL until PlanRunner supports record/object types.
 
-    [Fact(Skip = "Pending: generic type support via reflection; currently only System.Int32 and System.String are supported")]
+    [Fact]
     public void RunAsync_BindingToNestedPropertyPath_ResolvesTwoLevels()
     {
         // Goal: a "locations" step produces objects like {"City": "Oslo"},

--- a/src/Conjecture.Tool.Tests/Plan/TestModels.cs
+++ b/src/Conjecture.Tool.Tests/Plan/TestModels.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using Conjecture.Core;
+
 namespace Conjecture.Tool.Tests.Plan.TestModels;
 
 public class Location
@@ -11,4 +13,23 @@ public class Location
 public class StringSource
 {
     public required string Id { get; init; }
+}
+
+public sealed class LocationProvider : IStrategyProvider<Location>
+{
+    public Strategy<Location> Create() => Generate.Integers<int>(1, 999)
+        .Select(static code => new Location { CityCode = code });
+}
+
+public class NoCtorModel
+{
+    public required int Value { get; init; }
+}
+
+public sealed class NoCtorModelProvider(int seed) : IStrategyProvider<NoCtorModel>
+{
+    private readonly int seed = seed;
+
+    public Strategy<NoCtorModel> Create() => Generate.Integers<int>(1, 100)
+        .Select(static v => new NoCtorModel { Value = v });
 }

--- a/src/Conjecture.Tool/Plan/PlanRunner.cs
+++ b/src/Conjecture.Tool/Plan/PlanRunner.cs
@@ -14,16 +14,19 @@ public class PlanRunner
     private const string StringTypeFull = "System.String";
     private const string StringTypeSimple = "String";
 
+    private static readonly System.Reflection.MethodInfo RunProviderStrategyMethod =
+        typeof(PlanRunner).GetMethod(nameof(RunProviderStrategy), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
     public PlanResult Run(GenerationPlan plan)
     {
         var stepResults = new Dictionary<string, IReadOnlyList<JsonElement>>();
 
         plan.Output.Validate();
 
+        System.Reflection.Assembly assembly;
         try
         {
-            // Validate assembly exists; will be used for custom type resolution in future
-            System.Reflection.Assembly.LoadFrom(plan.Assembly);
+            assembly = System.Reflection.Assembly.LoadFrom(plan.Assembly);
         }
         catch (System.IO.FileNotFoundException)
         {
@@ -52,7 +55,7 @@ public class PlanRunner
                 }
             }
 
-            object? data = GenerateStepData(step, resolvedBindings);
+            object? data = GenerateStepData(step, resolvedBindings, assembly);
 
             IReadOnlyList<JsonElement> jsonElements = ConvertToJsonElements(data);
             stepResults[step.Name] = jsonElements;
@@ -63,22 +66,54 @@ public class PlanRunner
 
     private object? GenerateStepData(
         PlanStep step,
-        IDictionary<string, IReadOnlyList<JsonElement>> resolvedBindings)
+        IDictionary<string, IReadOnlyList<JsonElement>> resolvedBindings,
+        System.Reflection.Assembly assembly)
     {
         ValidateBindingKeys(step, resolvedBindings);
-        return IsInt32(step.Type)
-            ? GenerateBoundOrDefault(
+        if (IsInt32(step.Type))
+        {
+            return GenerateBoundOrDefault(
                 step,
                 resolvedBindings,
                 elem => elem.GetInt32(),
-                () => Generate.Integers<int>())
-            : IsString(step.Type)
-            ? GenerateBoundOrDefault(
+                () => Generate.Integers<int>());
+        }
+
+        if (IsString(step.Type))
+        {
+            return GenerateBoundOrDefault(
                 step,
                 resolvedBindings,
                 elem => elem.GetString()!,
-                () => Generate.Strings())
-            : throw new NotImplementedException($"Type {step.Type} is not yet supported");
+                () => Generate.Strings());
+        }
+
+        Type? providerType = AssemblyLoader.ResolveByTargetType(assembly, step.Type);
+        if (providerType is null)
+        {
+            throw new PlanException($"No IStrategyProvider<T> found for type {step.Type}", exitCode: 1);
+        }
+
+        IStrategyProvider provider;
+        try
+        {
+            provider = (IStrategyProvider)Activator.CreateInstance(providerType)!;
+        }
+        catch (MissingMethodException)
+        {
+            throw new PlanException(
+                $"Provider for type {step.Type} has no public parameterless constructor",
+                exitCode: 1);
+        }
+        Type targetType = AssemblyLoader.GetProviderTargetType(providerType)!;
+        System.Reflection.MethodInfo method = RunProviderStrategyMethod.MakeGenericMethod(targetType);
+        return method.Invoke(this, [provider, step]);
+    }
+
+    private object? RunProviderStrategy<T>(IStrategyProvider<T> provider, PlanStep step)
+    {
+        Strategy<T> strategy = provider.Create();
+        return DataGen.Sample(strategy, step.Count, step.Seed);
     }
 
     private void ValidateBindingKeys(


### PR DESCRIPTION
## Description

Wires up `AssemblyLoader.ResolveByTargetType` into `PlanRunner.GenerateStepData()` so that arbitrary record/class types are supported via `IStrategyProvider<T>` reflection dispatch, replacing the previous `NotImplementedException` fallback.

Key changes in `PlanRunner`:
- Stores the loaded assembly so `GenerateStepData` can use it for type resolution
- For non-scalar types, resolves the provider via `AssemblyLoader.ResolveByTargetType`; throws `PlanException` (exitCode 1) when no provider is found
- Wraps `MissingMethodException` from `Activator.CreateInstance` as `PlanException` (exitCode 1) for providers without a parameterless constructor
- Dispatches to `RunProviderStrategy<T>` via a cached `static readonly MethodInfo` + `MakeGenericMethod`

Adds `LocationProvider` and `NoCtorModelProvider` test models; enables the previously-skipped `RunAsync_BindingToNestedPropertyPath_ResolvesTwoLevels` test.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #142
Part of #140