### PR TITLE
[140.2] Docs: document generic type providers and nested ref paths in use-cli-tool.md

### DIFF
--- a/docs/site/articles/how-to/use-cli-tool.md
+++ b/docs/site/articles/how-to/use-cli-tool.md
@@ -79,6 +79,47 @@ conjecture generate --plan generation-plan.yaml
 
 The plan runner executes each step in order and writes all results to the configured output.
 
+## Use custom types in a plan
+
+Plan steps are not limited to built-in types like `System.Int32` or `System.String`. Any type that has an `IStrategyProvider<T>` in the plan assembly is supported.
+
+Define the type and its provider in your test project:
+
+```csharp
+public record Location(int CityCode);
+
+public sealed class LocationProvider : IStrategyProvider<Location>
+{
+    public Strategy<Location> Create() =>
+        Generate.Integers<int>(1, 999).Select(static code => new Location(code));
+}
+```
+
+Then reference the type by its fully qualified name in a plan step. A later step can bind to a property of the generated objects using a `$ref` with dot-path navigation:
+
+```yaml
+assembly: path/to/MyAssembly.dll
+steps:
+  - name: locations
+    type: MyNamespace.Location
+    count: 5
+    seed: 1
+  - name: orders
+    type: System.Int32
+    count: 5
+    seed: 2
+    bindings:
+      Value:
+        $ref: "locations[*].CityCode"
+output:
+  format: json
+  file: null
+```
+
+The `[*]` in a `$ref` expands all elements from that step; the dot-path after it navigates nested JSON properties on each serialised object. So `locations[*].CityCode` collects the `CityCode` value from every generated `Location`, and the `orders` step samples from those collected values.
+
+The provider must have a public parameterless constructor so the plan runner can instantiate it via reflection.
+
 ## Reproducible output
 
 Fix the seed for deterministic generation:


### PR DESCRIPTION
## Description

Adds a "Use custom types in a plan" section to `docs/site/articles/how-to/use-cli-tool.md` explaining:

- How to define a custom record type and its `IStrategyProvider<T>`
- A complete YAML plan example using the custom type with a nested `$ref` binding
- How the `step[*].Property` ref syntax works (`[*]` expands all elements; dot-path navigates nested JSON properties)
- The parameterless constructor requirement for reflection-based instantiation

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #143
Part of #140