### PR TITLE
[78.1] Core time value generators: DateTimeOffset, TimeSpan, DateOnly, TimeOnly

### DIFF
--- a/src/Conjecture.Core.Tests/Strategies/DateOnlyStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/DateOnlyStrategyTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class DateOnlyStrategyTests
+{
+    private static ConjectureData MakeData(ulong seed = 42UL) =>
+        ConjectureData.ForGeneration(new SplittableRandom(seed));
+
+    [Fact]
+    public void DateOnlyValues_BoundedRange_ReturnsInRange()
+    {
+        DateOnly min = new(2000, 1, 1);
+        DateOnly max = new(2030, 12, 31);
+        Strategy<DateOnly> strategy = Generate.DateOnlyValues(min, max);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 1000; i++)
+        {
+            DateOnly value = strategy.Generate(data);
+            Assert.InRange(value, min, max);
+        }
+    }
+
+    [Fact]
+    public void DateOnlyValues_DefaultRange_DoesNotThrow()
+    {
+        Strategy<DateOnly> strategy = Generate.DateOnlyValues();
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 100; i++)
+        {
+            _ = strategy.Generate(data);
+        }
+    }
+
+    [Fact]
+    public void DateOnlyValues_MinEqualsMax_ReturnsConstant()
+    {
+        DateOnly t = new(2025, 3, 14);
+        Strategy<DateOnly> strategy = Generate.DateOnlyValues(t, t);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 20; i++)
+        {
+            Assert.Equal(t, strategy.Generate(data));
+        }
+    }
+
+    [Fact]
+    public void DateOnlyValues_MinGreaterThanMax_Throws()
+    {
+        DateOnly later = new(2030, 1, 1);
+        DateOnly earlier = new(2020, 1, 1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Generate.DateOnlyValues(later, earlier));
+    }
+}

--- a/src/Conjecture.Core.Tests/Strategies/DateTimeOffsetStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/DateTimeOffsetStrategyTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class DateTimeOffsetStrategyTests
+{
+    private static ConjectureData MakeData(ulong seed = 42UL) =>
+        ConjectureData.ForGeneration(new SplittableRandom(seed));
+
+    [Fact]
+    public void DateTimeOffsets_BoundedRange_ReturnsInRange()
+    {
+        DateTimeOffset min = new(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        DateTimeOffset max = new(2030, 12, 31, 23, 59, 59, TimeSpan.Zero);
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets(min, max);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 1000; i++)
+        {
+            DateTimeOffset value = strategy.Generate(data);
+            Assert.InRange(value, min, max);
+        }
+    }
+
+    [Fact]
+    public void DateTimeOffsets_DefaultRange_DoesNotThrow()
+    {
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets();
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 100; i++)
+        {
+            _ = strategy.Generate(data);
+        }
+    }
+
+    [Fact]
+    public void DateTimeOffsets_MinEqualsMax_ReturnsConstant()
+    {
+        DateTimeOffset t = new(2025, 6, 15, 12, 0, 0, TimeSpan.Zero);
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets(t, t);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 20; i++)
+        {
+            Assert.Equal(t, strategy.Generate(data));
+        }
+    }
+
+    [Fact]
+    public void DateTimeOffsets_MinGreaterThanMax_Throws()
+    {
+        DateTimeOffset max = new(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        DateTimeOffset min = new(2020, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Generate.DateTimeOffsets(max, min));
+    }
+
+    [Fact]
+    public void DateTimeOffsets_AlwaysReturnsUtcOffset()
+    {
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets();
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 100; i++)
+        {
+            DateTimeOffset value = strategy.Generate(data);
+            Assert.Equal(TimeSpan.Zero, value.Offset);
+        }
+    }
+
+    [Fact]
+    public void DateTimeOffsets_BoundedWithNonUtcOffsets_ReturnsUtcOffset()
+    {
+        TimeSpan offset = TimeSpan.FromHours(5);
+        DateTimeOffset min = new(2000, 1, 1, 0, 0, 0, offset);
+        DateTimeOffset max = new(2030, 12, 31, 23, 59, 59, offset);
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets(min, max);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 100; i++)
+        {
+            DateTimeOffset value = strategy.Generate(data);
+            Assert.Equal(TimeSpan.Zero, value.Offset);
+        }
+    }
+}

--- a/src/Conjecture.Core.Tests/Strategies/TimeOnlyStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/TimeOnlyStrategyTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class TimeOnlyStrategyTests
+{
+    private static ConjectureData MakeData(ulong seed = 42UL) =>
+        ConjectureData.ForGeneration(new SplittableRandom(seed));
+
+    [Fact]
+    public void TimeOnlyValues_BoundedRange_ReturnsInRange()
+    {
+        TimeOnly min = new(6, 0, 0);
+        TimeOnly max = new(18, 0, 0);
+        Strategy<TimeOnly> strategy = Generate.TimeOnlyValues(min, max);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 1000; i++)
+        {
+            TimeOnly value = strategy.Generate(data);
+            Assert.InRange(value, min, max);
+        }
+    }
+
+    [Fact]
+    public void TimeOnlyValues_DefaultRange_DoesNotThrow()
+    {
+        Strategy<TimeOnly> strategy = Generate.TimeOnlyValues();
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 100; i++)
+        {
+            _ = strategy.Generate(data);
+        }
+    }
+
+    [Fact]
+    public void TimeOnlyValues_MinEqualsMax_ReturnsConstant()
+    {
+        TimeOnly t = new(14, 30, 0);
+        Strategy<TimeOnly> strategy = Generate.TimeOnlyValues(t, t);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 20; i++)
+        {
+            Assert.Equal(t, strategy.Generate(data));
+        }
+    }
+
+    [Fact]
+    public void TimeOnlyValues_MinGreaterThanMax_Throws()
+    {
+        TimeOnly later = new(20, 0, 0);
+        TimeOnly earlier = new(8, 0, 0);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Generate.TimeOnlyValues(later, earlier));
+    }
+}

--- a/src/Conjecture.Core.Tests/Strategies/TimeSpanStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/TimeSpanStrategyTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class TimeSpanStrategyTests
+{
+    private static ConjectureData MakeData(ulong seed = 42UL) =>
+        ConjectureData.ForGeneration(new SplittableRandom(seed));
+
+    [Fact]
+    public void TimeSpans_BoundedRange_ReturnsInRange()
+    {
+        TimeSpan min = TimeSpan.FromSeconds(-3600);
+        TimeSpan max = TimeSpan.FromSeconds(3600);
+        Strategy<TimeSpan> strategy = Generate.TimeSpans(min, max);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 1000; i++)
+        {
+            TimeSpan value = strategy.Generate(data);
+            Assert.InRange(value, min, max);
+        }
+    }
+
+    [Fact]
+    public void TimeSpans_DefaultRange_DoesNotThrow()
+    {
+        Strategy<TimeSpan> strategy = Generate.TimeSpans();
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 100; i++)
+        {
+            _ = strategy.Generate(data);
+        }
+    }
+
+    [Fact]
+    public void TimeSpans_MinEqualsMax_ReturnsConstant()
+    {
+        TimeSpan t = TimeSpan.FromMinutes(90);
+        Strategy<TimeSpan> strategy = Generate.TimeSpans(t, t);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 20; i++)
+        {
+            Assert.Equal(t, strategy.Generate(data));
+        }
+    }
+
+    [Fact]
+    public void TimeSpans_MinGreaterThanMax_Throws()
+    {
+        TimeSpan big = TimeSpan.FromHours(10);
+        TimeSpan small = TimeSpan.FromHours(1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Generate.TimeSpans(big, small));
+    }
+}

--- a/src/Conjecture.Core/DateOnlyStrategy.cs
+++ b/src/Conjecture.Core/DateOnlyStrategy.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class DateOnlyStrategy : Strategy<DateOnly>
+{
+    private readonly DateOnly min;
+    private readonly DateOnly max;
+
+    internal DateOnlyStrategy(DateOnly min, DateOnly max)
+    {
+        if (min > max)
+        {
+            throw new ArgumentOutOfRangeException(nameof(min), "min must be less than or equal to max.");
+        }
+
+        this.min = min;
+        this.max = max;
+    }
+
+    internal override DateOnly Generate(ConjectureData data)
+    {
+        ulong rangeMinus1 = (ulong)(max.DayNumber - min.DayNumber);
+        ulong raw = data.NextInteger(0UL, rangeMinus1);
+        return DateOnly.FromDayNumber(min.DayNumber + (int)raw);
+    }
+}

--- a/src/Conjecture.Core/DateTimeOffsetStrategy.cs
+++ b/src/Conjecture.Core/DateTimeOffsetStrategy.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class DateTimeOffsetStrategy : TickRangeStrategy<DateTimeOffset>
+{
+    internal DateTimeOffsetStrategy(DateTimeOffset min, DateTimeOffset max) : base(min.Ticks, max.Ticks)
+    {
+        if (min > max)
+        {
+            throw new ArgumentOutOfRangeException(nameof(min), "min must be less than or equal to max.");
+        }
+    }
+
+    protected override DateTimeOffset FromTicks(long ticks) => new(ticks, TimeSpan.Zero);
+}

--- a/src/Conjecture.Core/Gen.cs
+++ b/src/Conjecture.Core/Gen.cs
@@ -183,6 +183,38 @@ public static class Generate
         return new StateMachineStrategy<TMachine, TState, TCommand>(maxSteps);
     }
 
+    /// <summary>Returns a strategy that generates random <see cref="DateTimeOffset"/> values across the full range.</summary>
+    public static Strategy<DateTimeOffset> DateTimeOffsets()
+        => new DateTimeOffsetStrategy(DateTimeOffset.MinValue, DateTimeOffset.MaxValue);
+
+    /// <summary>Returns a strategy that generates random <see cref="DateTimeOffset"/> values in [<paramref name="min"/>, <paramref name="max"/>].</summary>
+    public static Strategy<DateTimeOffset> DateTimeOffsets(DateTimeOffset min, DateTimeOffset max)
+        => new DateTimeOffsetStrategy(min, max);
+
+    /// <summary>Returns a strategy that generates random <see cref="TimeSpan"/> values across the full range.</summary>
+    public static Strategy<TimeSpan> TimeSpans()
+        => new TimeSpanStrategy(TimeSpan.MinValue, TimeSpan.MaxValue);
+
+    /// <summary>Returns a strategy that generates random <see cref="TimeSpan"/> values in [<paramref name="min"/>, <paramref name="max"/>].</summary>
+    public static Strategy<TimeSpan> TimeSpans(TimeSpan min, TimeSpan max)
+        => new TimeSpanStrategy(min, max);
+
+    /// <summary>Returns a strategy that generates random <see cref="DateOnly"/> values across the full range.</summary>
+    public static Strategy<DateOnly> DateOnlyValues()
+        => new DateOnlyStrategy(DateOnly.MinValue, DateOnly.MaxValue);
+
+    /// <summary>Returns a strategy that generates random <see cref="DateOnly"/> values in [<paramref name="min"/>, <paramref name="max"/>].</summary>
+    public static Strategy<DateOnly> DateOnlyValues(DateOnly min, DateOnly max)
+        => new DateOnlyStrategy(min, max);
+
+    /// <summary>Returns a strategy that generates random <see cref="TimeOnly"/> values across the full range.</summary>
+    public static Strategy<TimeOnly> TimeOnlyValues()
+        => new TimeOnlyStrategy(TimeOnly.MinValue, TimeOnly.MaxValue);
+
+    /// <summary>Returns a strategy that generates random <see cref="TimeOnly"/> values in [<paramref name="min"/>, <paramref name="max"/>].</summary>
+    public static Strategy<TimeOnly> TimeOnlyValues(TimeOnly min, TimeOnly max)
+        => new TimeOnlyStrategy(min, max);
+
     /// <summary>Returns a strategy that generates identifier strings of the form <c>[a-z]+\d+</c>. The alpha prefix is drawn via IR string nodes so <c>StringAwarePass</c> can simplify it toward 'a', and the digit suffix is drawn so <c>NumericAwareShrinkPass</c> can minimize it.</summary>
     public static Strategy<string> Identifiers(
         int minPrefixLength = 1,

--- a/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
+++ b/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
@@ -167,6 +167,10 @@ internal static class SharedParameterStrategyResolver
             _ when type == typeof(float) => Generate.Floats().Generate(data),
             _ when type == typeof(double) => Generate.Doubles().Generate(data),
             _ when type == typeof(List<int>) => Generate.Lists(Generate.Integers<int>()).Generate(data),
+            _ when type == typeof(DateTimeOffset) => Generate.DateTimeOffsets().Generate(data),
+            _ when type == typeof(TimeSpan) => Generate.TimeSpans().Generate(data),
+            _ when type == typeof(DateOnly) => Generate.DateOnlyValues().Generate(data),
+            _ when type == typeof(TimeOnly) => Generate.TimeOnlyValues().Generate(data),
             { IsEnum: true } => GenerateEnum(type, data),
             _ when Nullable.GetUnderlyingType(type) is { } u
                                              => data.NextInteger(0, 9) == 0 ? null! : GenerateValue(u, data),

--- a/src/Conjecture.Core/Internal/TickRangeStrategy.cs
+++ b/src/Conjecture.Core/Internal/TickRangeStrategy.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core.Internal;
+
+internal abstract class TickRangeStrategy<T>(long minTicks, long maxTicks) : Strategy<T>
+{
+    internal sealed override T Generate(ConjectureData data)
+    {
+        ulong rangeMinus1 = unchecked((ulong)(maxTicks - minTicks));
+        ulong raw = data.NextInteger(0UL, rangeMinus1);
+        return FromTicks(minTicks + (long)raw);
+    }
+
+    protected abstract T FromTicks(long ticks);
+}

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
 #nullable enable
+static Conjecture.Core.Generate.DateOnlyValues() -> Conjecture.Core.Strategy<System.DateOnly>!
+static Conjecture.Core.Generate.DateOnlyValues(System.DateOnly min, System.DateOnly max) -> Conjecture.Core.Strategy<System.DateOnly>!
+static Conjecture.Core.Generate.DateTimeOffsets() -> Conjecture.Core.Strategy<System.DateTimeOffset>!
+static Conjecture.Core.Generate.DateTimeOffsets(System.DateTimeOffset min, System.DateTimeOffset max) -> Conjecture.Core.Strategy<System.DateTimeOffset>!
+static Conjecture.Core.Generate.TimeOnlyValues() -> Conjecture.Core.Strategy<System.TimeOnly>!
+static Conjecture.Core.Generate.TimeOnlyValues(System.TimeOnly min, System.TimeOnly max) -> Conjecture.Core.Strategy<System.TimeOnly>!
+static Conjecture.Core.Generate.TimeSpans() -> Conjecture.Core.Strategy<System.TimeSpan>!
+static Conjecture.Core.Generate.TimeSpans(System.TimeSpan min, System.TimeSpan max) -> Conjecture.Core.Strategy<System.TimeSpan>!

--- a/src/Conjecture.Core/TimeOnlyStrategy.cs
+++ b/src/Conjecture.Core/TimeOnlyStrategy.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class TimeOnlyStrategy : TickRangeStrategy<TimeOnly>
+{
+    internal TimeOnlyStrategy(TimeOnly min, TimeOnly max) : base(min.Ticks, max.Ticks)
+    {
+        if (min > max)
+        {
+            throw new ArgumentOutOfRangeException(nameof(min), "min must be less than or equal to max.");
+        }
+    }
+
+    protected override TimeOnly FromTicks(long ticks) => new(ticks);
+}

--- a/src/Conjecture.Core/TimeSpanStrategy.cs
+++ b/src/Conjecture.Core/TimeSpanStrategy.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class TimeSpanStrategy : TickRangeStrategy<TimeSpan>
+{
+    internal TimeSpanStrategy(TimeSpan min, TimeSpan max) : base(min.Ticks, max.Ticks)
+    {
+        if (min > max)
+        {
+            throw new ArgumentOutOfRangeException(nameof(min), "min must be less than or equal to max.");
+        }
+    }
+
+    protected override TimeSpan FromTicks(long ticks) => TimeSpan.FromTicks(ticks);
+}

--- a/src/Conjecture.Xunit.Tests/TemporalAutoInjectTests.cs
+++ b/src/Conjecture.Xunit.Tests/TemporalAutoInjectTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Xunit;
+
+namespace Conjecture.Xunit.Tests;
+
+/// <summary>
+/// Verifies that [Property] auto-injects temporal types via the built-in strategy resolver.
+/// These tests will compile only once the temporal strategies and resolver registrations exist.
+/// </summary>
+public class TemporalAutoInjectTests
+{
+    [Property(MaxExamples = 20, Seed = 1UL)]
+    public void Property_AutoInjects_DateTimeOffset(DateTimeOffset _)
+    {
+        Assert.True(true);
+    }
+
+    [Property(MaxExamples = 20, Seed = 1UL)]
+    public void Property_AutoInjects_TimeSpan(TimeSpan _)
+    {
+        Assert.True(true);
+    }
+
+    [Property(MaxExamples = 20, Seed = 1UL)]
+    public void Property_AutoInjects_DateOnly(DateOnly _)
+    {
+        Assert.True(true);
+    }
+
+    [Property(MaxExamples = 20, Seed = 1UL)]
+    public void Property_AutoInjects_TimeOnly(TimeOnly _)
+    {
+        Assert.True(true);
+    }
+}


### PR DESCRIPTION
## Description

Adds four temporal strategy types to `Conjecture.Core` with bounded/unbounded factory methods and auto-injection into `[Property]` tests:

- `Generate.DateTimeOffsets()` / `Generate.DateTimeOffsets(min, max)`
- `Generate.TimeSpans()` / `Generate.TimeSpans(min, max)`
- `Generate.DateOnlyValues()` / `Generate.DateOnlyValues(min, max)`
- `Generate.TimeOnlyValues()` / `Generate.TimeOnlyValues(min, max)`

`DateTimeOffset`, `TimeSpan`, `DateOnly`, and `TimeOnly` parameters are now auto-injected in `[Property]` tests without any attribute. `DateTimeOffset` results are always UTC-normalized; this is documented by tests. Three of the four strategies share a `TickRangeStrategy<T>` base with explicit `unchecked` tick arithmetic.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #150
Part of #78