### PR TITLE
Scaffolds Conjecture.Time with AOT-safe generator support

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -59,10 +59,15 @@ Solution file: `src/Conjecture.slnx`
 | `src/Conjecture.MSTest/` | `src/Conjecture.MSTest.Tests/` |
 | `src/Conjecture.Generators/` | `src/Conjecture.Generators.Tests/` |
 | `src/Conjecture.Analyzers/` | `src/Conjecture.Analyzers.Tests/` |
+| `src/Conjecture.Analyzers.CodeFixes/` | `src/Conjecture.Analyzers.Tests/` |
 | `src/Conjecture.Mcp/` | `src/Conjecture.Mcp.Tests/` |
 | `src/Conjecture.Tool/` | `src/Conjecture.Tool.Tests/` |
+| `src/Conjecture.Formatters/` | `src/Conjecture.Formatters.Tests/` |
+| `src/Conjecture.Time/` | `src/Conjecture.Time.Tests/` |
 | `src/Conjecture.FSharp/` | `src/Conjecture.FSharp.Tests/` |
 | `src/Conjecture.FSharp.Expecto/` | `src/Conjecture.FSharp.Expecto.Tests/` |
+| `src/Conjecture.Benchmarks/` | _(benchmark project, not a test project)_ |
+| `src/Conjecture.SelfTests/` | _(integration self-tests, no paired prod project)_ |
 
 New test files go in the paired test project, mirroring the production file's relative path.
 

--- a/docs/decisions/0043-timeprovider-integration.md
+++ b/docs/decisions/0043-timeprovider-integration.md
@@ -28,7 +28,9 @@ Clock injection, `FakeTimeProvider` wrappers, DST-aware extensions, `Generate.Ti
 
 ### 3. Auto-injection via `TimeProviderArbitrary` naming convention
 
-`Conjecture.Time` ships `TimeProviderArbitrary : IStrategyProvider<TimeProvider>`. The existing assembly-scan naming convention in `SharedParameterStrategyResolver.TryGenerateFromArbitraryProvider` discovers `{TypeName}Arbitrary` classes in all loaded assemblies. Adding `Conjecture.Time` to a project automatically enables `TimeProvider` parameter auto-injection — zero changes to Core required.
+`Conjecture.Time` ships `TimeProviderArbitrary : IStrategyProvider<TimeProvider>`. The existing assembly-scan naming convention in `SharedParameterStrategyResolver.TryGenerateFromArbitraryProvider` discovers `{TypeName}Arbitrary` classes in all loaded assemblies. Adding `Conjecture.Time` to a project automatically enables `TimeProvider` parameter auto-injection.
+
+`ArbitraryProviderScanner.EnsureAssembliesLoaded()` was updated in Core to probe the app's base directory for any `*.dll` files not yet JIT-referenced and load them into the default `AssemblyLoadContext` before scanning. This ensures that assemblies like `Conjecture.Time.dll` — which may not have been referenced by any live type before the first property test runs — are visible to the scanner. The method is memoised behind a `static volatile bool` so the directory scan runs at most once per process. This required a small, intentional change to Core; the earlier claim "zero changes to Core required" no longer holds.
 
 ### 4. DST awareness: simplified heuristics via `TimeZoneInfo.GetAdjustmentRules()`
 

--- a/src/Conjecture.Core/Internal/ArbitraryProviderScanner.cs
+++ b/src/Conjecture.Core/Internal/ArbitraryProviderScanner.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.Loader;
 
 namespace Conjecture.Core.Internal;
 
@@ -10,10 +11,14 @@ internal static class ArbitraryProviderScanner
 {
     private static readonly Type OpenStrategyProvider = typeof(IStrategyProvider<>);
 
+    private static volatile bool assembliesLoaded;
+    private static readonly object LoadLock = new();
+
     /// <summary>
-    /// Scans all loaded assemblies for a type named <c>{paramType.Name}Arbitrary</c> that
-    /// implements <see cref="IStrategyProvider{T}"/> for <paramref name="paramType"/>, and
-    /// returns a closed <paramref name="generateFromProviderOpenMethod"/> ready to invoke.
+    /// Scans all loaded assemblies (and probes the app's base directory for any unloaded assemblies)
+    /// for a type named <c>{paramType.Name}Arbitrary</c> that implements
+    /// <see cref="IStrategyProvider{T}"/> for <paramref name="paramType"/>, and returns a closed
+    /// <paramref name="generateFromProviderOpenMethod"/> ready to invoke.
     /// Returns <see langword="null"/> when no matching provider is found.
     /// The caller is responsible for caching the result.
     /// </summary>
@@ -24,6 +29,8 @@ internal static class ArbitraryProviderScanner
         string candidateName = paramType.Name + "Arbitrary";
         // Source-generated providers put [Arbitrary] on the record, not the provider class.
         bool paramTypeMarked = paramType.GetCustomAttribute<ArbitraryAttribute>() is not null;
+
+        EnsureAssembliesLoaded();
 
         foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
@@ -61,5 +68,63 @@ internal static class ArbitraryProviderScanner
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Probes all <c>*.dll</c> files in the application's base directory and loads any that
+    /// have not yet been loaded into the default <see cref="AssemblyLoadContext"/>.
+    /// This ensures that assemblies containing <c>[Arbitrary]</c> providers are visible to the
+    /// scanner even if no type in those assemblies has been JIT-referenced yet.
+    /// Guaranteed to run at most once per process via double-checked locking.
+    /// </summary>
+    [RequiresUnreferencedCode("Loads assemblies from disk by path; not trim-safe.")]
+    private static void EnsureAssembliesLoaded()
+    {
+        if (assembliesLoaded)
+        {
+            return;
+        }
+
+        lock (LoadLock)
+        {
+            if (assembliesLoaded)
+            {
+                return;
+            }
+
+            string? baseDir = AppDomain.CurrentDomain.BaseDirectory;
+            if (baseDir is null)
+            {
+                assembliesLoaded = true;
+                return;
+            }
+
+            HashSet<string> loaded = new(StringComparer.OrdinalIgnoreCase);
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (!assembly.IsDynamic && assembly.Location is { Length: > 0 } loc)
+                {
+                    loaded.Add(Path.GetFullPath(loc));
+                }
+            }
+
+            foreach (string dll in Directory.EnumerateFiles(baseDir, "*.dll"))
+            {
+                if (loaded.Contains(Path.GetFullPath(dll)))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    AssemblyLoadContext.Default.LoadFromAssemblyPath(dll);
+                }
+                catch (BadImageFormatException) { }
+                catch (FileLoadException) { }
+                catch (IOException) { }
+            }
+
+            assembliesLoaded = true;
+        }
     }
 }

--- a/src/Conjecture.Generators.Tests/ExternalStrategyProviderTests.cs
+++ b/src/Conjecture.Generators.Tests/ExternalStrategyProviderTests.cs
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Conjecture.Generators.Tests;
+
+/// <summary>
+/// Tests that records/classes with members whose types are covered by an external
+/// <c>IStrategyProvider&lt;T&gt;</c> (e.g. <c>TimeProvider</c> → <c>TimeProviderArbitrary</c>)
+/// are classified and emitted correctly, enabling AOT-safe code generation.
+/// </summary>
+public sealed class ExternalStrategyProviderTests
+{
+    [Fact]
+    public void Extract_MemberWithRegistryEntry_ClassifiesAsExternalStrategyProvider()
+    {
+        INamedTypeSymbol symbol = CompileAndGetSymbol(
+            "namespace MyApp; public partial record Request(System.TimeProvider Clock);",
+            "MyApp.Request");
+
+        Dictionary<string, string> registry = new()
+        {
+            ["System.TimeProvider"] = "Conjecture.Time.TimeProviderArbitrary",
+        };
+
+        (TypeModel? model, ImmutableArray<Diagnostic> diagnostics) = TypeModelExtractor.Extract(symbol, registry);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(model);
+        MemberModel member = Assert.Single(model.Members);
+        Assert.Equal(MemberGenerationKind.ExternalStrategyProvider, member.Kind);
+        Assert.Equal("Conjecture.Time.TimeProviderArbitrary", member.AuxiliaryTypeName);
+    }
+
+    [Fact]
+    public void Extract_MemberWithNoRegistryEntry_ClassifiesAsUnsupported()
+    {
+        INamedTypeSymbol symbol = CompileAndGetSymbol(
+            "namespace MyApp; public partial record Request(System.TimeProvider Clock);",
+            "MyApp.Request");
+
+        (TypeModel? model, ImmutableArray<Diagnostic> diagnostics) = TypeModelExtractor.Extract(symbol);
+
+        Assert.NotNull(model);
+        Assert.Equal(MemberGenerationKind.Unsupported, model.Members[0].Kind);
+    }
+
+    [Fact]
+    public void Generator_RecordWithTimeProviderMember_EmitsProviderCallInGeneratedCode()
+    {
+        string text = GetGeneratedText(
+            "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Request(System.TimeProvider Clock);",
+            "Request.g.cs");
+
+        Assert.Contains("(global::Conjecture.Core.IStrategyProvider<global::System.TimeProvider>)new global::Conjecture.Time.TimeProviderArbitrary()).Create()", text);
+    }
+
+    [Fact]
+    public void Generator_RecordWithTimeProviderMember_OutputCompilationHasNoErrors()
+    {
+        (_, Compilation output, _) = RunGenerator(
+            "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Request(System.TimeProvider Clock);");
+
+        IEnumerable<Diagnostic> errors = output.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ProviderRegistry_Build_FindsTimeProviderArbitrary()
+    {
+        CSharpCompilation compilation = CreateCompilation("", includeTime: true);
+
+        ImmutableDictionary<string, string> registry = ProviderRegistry.Build(compilation);
+
+        Assert.True(registry.ContainsKey("System.TimeProvider"));
+        Assert.Equal("Conjecture.Time.TimeProviderArbitrary", registry["System.TimeProvider"]);
+    }
+
+    private static string GetGeneratedText(string source, string fileName)
+    {
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+        SyntaxTree? tree = trees.FirstOrDefault(
+            t => t.FilePath.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(tree);
+        return tree.GetText().ToString();
+    }
+
+    private static (ImmutableArray<SyntaxTree> GeneratedTrees, Compilation Output, ImmutableArray<Diagnostic> GeneratorDiagnostics) RunGenerator(string source)
+    {
+        CSharpCompilation inputCompilation = CreateCompilation(source, includeTime: true);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new ArbitraryGenerator());
+        GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
+        Compilation outputCompilation = inputCompilation.AddSyntaxTrees(result.GeneratedTrees);
+        return (result.GeneratedTrees, outputCompilation, result.Diagnostics);
+    }
+
+    private static CSharpCompilation CreateCompilation(string source, bool includeTime = false)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        List<MetadataReference> references =
+        [
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+            MetadataReference.CreateFromFile(typeof(Conjecture.Core.ArbitraryAttribute).Assembly.Location),
+        ];
+
+        if (includeTime)
+        {
+            references.Add(MetadataReference.CreateFromFile(typeof(Conjecture.Time.TimeProviderArbitrary).Assembly.Location));
+        }
+
+        return CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: source.Length > 0 ? [CSharpSyntaxTree.ParseText(source)] : [],
+            references: references,
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+    }
+
+    private static INamedTypeSymbol CompileAndGetSymbol(string source, string metadataName)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+            ],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        INamedTypeSymbol? symbol = compilation.GetTypeByMetadataName(metadataName);
+        Assert.NotNull(symbol);
+        return symbol;
+    }
+}

--- a/src/Conjecture.Generators/ArbitraryGenerator.cs
+++ b/src/Conjecture.Generators/ArbitraryGenerator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using System.Collections.Immutable;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -19,9 +21,16 @@ public sealed class ArbitraryGenerator : IIncrementalGenerator
                 predicate: static (node, _) => node is TypeDeclarationSyntax,
                 transform: static (ctx, _) => (INamedTypeSymbol)ctx.TargetSymbol);
 
-        context.RegisterSourceOutput(types, static (ctx, symbol) =>
+        IncrementalValueProvider<ImmutableDictionary<string, string>> registry =
+            context.CompilationProvider.Select(static (compilation, _) => ProviderRegistry.Build(compilation));
+
+        IncrementalValuesProvider<(INamedTypeSymbol Symbol, ImmutableDictionary<string, string> Registry)> combined =
+            types.Combine(registry);
+
+        context.RegisterSourceOutput(combined, static (ctx, item) =>
         {
-            (TypeModel? model, System.Collections.Immutable.ImmutableArray<Diagnostic> diagnostics) = TypeModelExtractor.Extract(symbol);
+            (INamedTypeSymbol symbol, ImmutableDictionary<string, string> reg) = item;
+            (TypeModel? model, ImmutableArray<Diagnostic> diagnostics) = TypeModelExtractor.Extract(symbol, reg);
 
             bool hasError = false;
             foreach (Diagnostic d in diagnostics)

--- a/src/Conjecture.Generators/ProviderRegistry.cs
+++ b/src/Conjecture.Generators/ProviderRegistry.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+
+namespace Conjecture.Generators;
+
+/// <summary>
+/// Builds a compile-time registry mapping target types to their <c>IStrategyProvider&lt;T&gt;</c>
+/// implementations, enabling AOT-safe member classification without runtime reflection.
+/// </summary>
+internal static class ProviderRegistry
+{
+    /// <summary>
+    /// Scans all assemblies in <paramref name="compilation"/> for types whose name ends with
+    /// <c>Arbitrary</c>, carry <c>[Arbitrary]</c>, and implement <c>IStrategyProvider&lt;T&gt;</c>.
+    /// Returns a dictionary keyed by the fully-qualified target type name.
+    /// </summary>
+    internal static ImmutableDictionary<string, string> Build(Compilation compilation)
+    {
+        INamedTypeSymbol? openInterface =
+            compilation.GetTypeByMetadataName("Conjecture.Core.IStrategyProvider`1");
+
+        if (openInterface is null)
+        {
+            return ImmutableDictionary<string, string>.Empty;
+        }
+
+        ImmutableDictionary<string, string>.Builder builder =
+            ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+
+        CollectFromNamespace(compilation.Assembly.GlobalNamespace, openInterface, builder);
+
+        foreach (MetadataReference reference in compilation.References)
+        {
+            if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+            {
+                CollectFromNamespace(assembly.GlobalNamespace, openInterface, builder);
+            }
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static void CollectFromNamespace(
+        INamespaceSymbol ns,
+        INamedTypeSymbol openInterface,
+        ImmutableDictionary<string, string>.Builder builder)
+    {
+        foreach (INamedTypeSymbol type in ns.GetTypeMembers())
+        {
+            if (!type.Name.EndsWith("Arbitrary", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!SymbolHelpers.HasArbitraryAttribute(type))
+            {
+                continue;
+            }
+
+            foreach (INamedTypeSymbol iface in type.AllInterfaces)
+            {
+                if (!iface.IsGenericType)
+                {
+                    continue;
+                }
+
+                if (!SymbolEqualityComparer.Default.Equals(iface.OriginalDefinition, openInterface))
+                {
+                    continue;
+                }
+
+                ITypeSymbol targetType = iface.TypeArguments[0];
+                string targetFqn = targetType.ToDisplayString(TypeModelExtractor.TypeNameFormat);
+                string providerFqn = type.ToDisplayString(TypeModelExtractor.TypeNameFormat);
+
+                if (!builder.ContainsKey(targetFqn))
+                {
+                    builder.Add(targetFqn, providerFqn);
+                }
+
+                break;
+            }
+        }
+
+        foreach (INamespaceSymbol subNamespace in ns.GetNamespaceMembers())
+        {
+            CollectFromNamespace(subNamespace, openInterface, builder);
+        }
+    }
+
+}

--- a/src/Conjecture.Generators/StrategyEmitter.cs
+++ b/src/Conjecture.Generators/StrategyEmitter.cs
@@ -89,12 +89,14 @@ internal static class StrategyEmitter
         MemberGenerationKind.Enum =>
             "global::" + member.TypeFullName,
         MemberGenerationKind.NullableValue =>
-            PrimitiveData.TryGetValue(member.InnerTypeFullName, out (string GenExpr, string ShortName) n) ? n.ShortName + "?" : "/* unsupported */",
+            PrimitiveData.TryGetValue(member.AuxiliaryTypeName, out (string GenExpr, string ShortName) n) ? n.ShortName + "?" : "/* unsupported */",
         MemberGenerationKind.List =>
-            PrimitiveData.TryGetValue(member.InnerTypeFullName, out (string GenExpr, string ShortName) l)
+            PrimitiveData.TryGetValue(member.AuxiliaryTypeName, out (string GenExpr, string ShortName) l)
                 ? "global::System.Collections.Generic.List<" + l.ShortName + ">"
                 : "/* unsupported */",
         MemberGenerationKind.ArbitraryReference =>
+            "global::" + member.TypeFullName,
+        MemberGenerationKind.ExternalStrategyProvider =>
             "global::" + member.TypeFullName,
         _ =>
             "/* unsupported */",
@@ -107,11 +109,13 @@ internal static class StrategyEmitter
             MemberGenerationKind.Enum =>
                 "global::Conjecture.Core.Generate.Enums<global::" + member.TypeFullName + ">()",
             MemberGenerationKind.NullableValue =>
-                BuildWrappedExpr(member.InnerTypeFullName, "Nullable"),
+                BuildWrappedExpr(member.AuxiliaryTypeName, "Nullable"),
             MemberGenerationKind.List =>
-                BuildWrappedExpr(member.InnerTypeFullName, "Lists"),
+                BuildWrappedExpr(member.AuxiliaryTypeName, "Lists"),
             MemberGenerationKind.ArbitraryReference =>
                 "new global::" + member.TypeFullName + "Arbitrary().Create()",
+            MemberGenerationKind.ExternalStrategyProvider =>
+                "((global::Conjecture.Core.IStrategyProvider<global::" + member.TypeFullName + ">)new global::" + member.AuxiliaryTypeName + "()).Create()",
             MemberGenerationKind.Primitive =>
                 PrimitiveData.TryGetValue(member.TypeFullName, out (string GenExpr, string ShortName) d) ? d.GenExpr : $"/* unsupported type: {member.TypeFullName} */",
             _ =>

--- a/src/Conjecture.Generators/SymbolHelpers.cs
+++ b/src/Conjecture.Generators/SymbolHelpers.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.CodeAnalysis;
+
+namespace Conjecture.Generators;
+
+internal static class SymbolHelpers
+{
+    /// <summary>Returns <see langword="true"/> if <paramref name="symbol"/> carries <c>[Conjecture.Core.Arbitrary]</c>.</summary>
+    internal static bool HasArbitraryAttribute(INamedTypeSymbol symbol)
+    {
+        foreach (AttributeData attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass is
+                {
+                    Name: "ArbitraryAttribute",
+                    ContainingNamespace.Name: "Core",
+                    ContainingNamespace.ContainingNamespace.Name: "Conjecture",
+                })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Conjecture.Generators/TypeModel.cs
+++ b/src/Conjecture.Generators/TypeModel.cs
@@ -9,7 +9,7 @@ namespace Conjecture.Generators;
 
 internal enum ConstructionMode { Constructor, ObjectInitializer }
 
-internal enum MemberGenerationKind { Primitive, Enum, NullableValue, List, ArbitraryReference, Unsupported }
+internal enum MemberGenerationKind { Primitive, Enum, NullableValue, List, ArbitraryReference, ExternalStrategyProvider, Unsupported }
 
 internal sealed record TypeModel(
     string FullyQualifiedName,
@@ -25,4 +25,4 @@ internal sealed record MemberModel(
     string TypeFullName,
     bool IsNullable,
     MemberGenerationKind Kind = MemberGenerationKind.Primitive,
-    string InnerTypeFullName = "");
+    string AuxiliaryTypeName = "");

--- a/src/Conjecture.Generators/TypeModelExtractor.cs
+++ b/src/Conjecture.Generators/TypeModelExtractor.cs
@@ -12,13 +12,15 @@ namespace Conjecture.Generators;
 
 internal static class TypeModelExtractor
 {
-    private static readonly SymbolDisplayFormat TypeNameFormat = new(
+    internal static readonly SymbolDisplayFormat TypeNameFormat = new(
         globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
         typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
         genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
         miscellaneousOptions: SymbolDisplayMiscellaneousOptions.ExpandNullable);
 
-    internal static (TypeModel? Model, ImmutableArray<Diagnostic> Diagnostics) Extract(INamedTypeSymbol symbol)
+    internal static (TypeModel? Model, ImmutableArray<Diagnostic> Diagnostics) Extract(
+        INamedTypeSymbol symbol,
+        IReadOnlyDictionary<string, string>? providerRegistry = null)
     {
         Location location = symbol.Locations.Length > 0 ? symbol.Locations[0] : Location.None;
 
@@ -41,12 +43,12 @@ internal static class TypeModelExtractor
 
         if (bestCtor is not null)
         {
-            members = BuildMembers(bestCtor, warnings);
+            members = BuildMembers(bestCtor, warnings, providerRegistry);
             mode = ConstructionMode.Constructor;
         }
         else
         {
-            members = BuildInitPropertyMembers(symbol, warnings);
+            members = BuildInitPropertyMembers(symbol, warnings, providerRegistry);
             if (members.IsEmpty)
             {
                 return (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con200, location, symbol.Name)));
@@ -121,7 +123,10 @@ internal static class TypeModelExtractor
         return builder.ToImmutable();
     }
 
-    private static ImmutableArray<MemberModel> BuildMembers(IMethodSymbol ctor, List<Diagnostic> warnings)
+    private static ImmutableArray<MemberModel> BuildMembers(
+        IMethodSymbol ctor,
+        List<Diagnostic> warnings,
+        IReadOnlyDictionary<string, string>? providerRegistry)
     {
         if (ctor.Parameters.IsEmpty)
         {
@@ -133,7 +138,7 @@ internal static class TypeModelExtractor
         {
             string typeName = param.Type.ToDisplayString(TypeNameFormat);
             bool isNullable = param.NullableAnnotation == NullableAnnotation.Annotated;
-            (MemberGenerationKind kind, string innerFqn) = ClassifyMemberType(param.Type);
+            (MemberGenerationKind kind, string innerFqn) = ClassifyMemberType(param.Type, providerRegistry);
 
             if (kind == MemberGenerationKind.Unsupported)
             {
@@ -147,7 +152,10 @@ internal static class TypeModelExtractor
         return builder.ToImmutable();
     }
 
-    private static ImmutableArray<MemberModel> BuildInitPropertyMembers(INamedTypeSymbol symbol, List<Diagnostic> warnings)
+    private static ImmutableArray<MemberModel> BuildInitPropertyMembers(
+        INamedTypeSymbol symbol,
+        List<Diagnostic> warnings,
+        IReadOnlyDictionary<string, string>? providerRegistry)
     {
         ImmutableArray<MemberModel>.Builder builder = ImmutableArray.CreateBuilder<MemberModel>();
         foreach (ISymbol member in symbol.GetMembers())
@@ -169,7 +177,7 @@ internal static class TypeModelExtractor
 
             string typeName = prop.Type.ToDisplayString(TypeNameFormat);
             bool isNullable = prop.NullableAnnotation == NullableAnnotation.Annotated;
-            (MemberGenerationKind kind, string innerFqn) = ClassifyMemberType(prop.Type);
+            (MemberGenerationKind kind, string innerFqn) = ClassifyMemberType(prop.Type, providerRegistry);
 
             if (kind == MemberGenerationKind.Unsupported)
             {
@@ -183,7 +191,9 @@ internal static class TypeModelExtractor
         return builder.ToImmutable();
     }
 
-    private static (MemberGenerationKind Kind, string InnerFqn) ClassifyMemberType(ITypeSymbol type)
+    private static (MemberGenerationKind Kind, string InnerFqn) ClassifyMemberType(
+        ITypeSymbol type,
+        IReadOnlyDictionary<string, string>? providerRegistry)
     {
         if (IsPrimitive(type.SpecialType))
         {
@@ -213,16 +223,17 @@ internal static class TypeModelExtractor
             return (MemberGenerationKind.List, innerFqn);
         }
 
-        foreach (AttributeData attr in type.GetAttributes())
+        if (type is INamedTypeSymbol namedType && SymbolHelpers.HasArbitraryAttribute(namedType))
         {
-            if (attr.AttributeClass is
-                {
-                    Name: "ArbitraryAttribute",
-                    ContainingNamespace.Name: "Core",
-                    ContainingNamespace.ContainingNamespace.Name: "Conjecture"
-                })
+            return (MemberGenerationKind.ArbitraryReference, "");
+        }
+
+        if (providerRegistry is not null)
+        {
+            string typeFqn = type.ToDisplayString(TypeNameFormat);
+            if (providerRegistry.TryGetValue(typeFqn, out string? providerFqn))
             {
-                return (MemberGenerationKind.ArbitraryReference, "");
+                return (MemberGenerationKind.ExternalStrategyProvider, providerFqn);
             }
         }
 

--- a/src/Conjecture.Time.Tests/Conjecture.Time.Tests.csproj
+++ b/src/Conjecture.Time.Tests/Conjecture.Time.Tests.csproj
@@ -1,29 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
     <ProjectReference Include="..\Conjecture.Time\Conjecture.Time.csproj" />
-    <ProjectReference Include="..\Conjecture.Generators\Conjecture.Generators.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="true" />
+    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
-
 </Project>

--- a/src/Conjecture.Time.Tests/TimeProviderArbitraryTests.cs
+++ b/src/Conjecture.Time.Tests/TimeProviderArbitraryTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Concurrent;
+
+using Conjecture.Core;
+using Conjecture.Time;
+using Conjecture.Xunit;
+
+using Microsoft.Extensions.Time.Testing;
+
+namespace Conjecture.Time.Tests;
+
+public class TimeProviderArbitraryTests
+{
+    [Fact]
+    public void Create_ReturnsNonNullStrategy()
+    {
+        Strategy<TimeProvider> strategy = TimeProviderArbitrary.Create();
+
+        Assert.NotNull(strategy);
+    }
+
+    [Fact]
+    public void Create_ReturnedStrategy_GeneratesFakeTimeProvider()
+    {
+        Strategy<TimeProvider> strategy = TimeProviderArbitrary.Create();
+
+        TimeProvider generated = DataGen.SampleOne(strategy, seed: 1UL);
+
+        Assert.IsType<FakeTimeProvider>(generated);
+    }
+
+    [Property(MaxExamples = 20, Seed = 1UL)]
+    public void Property_AutoInjects_TimeProvider_AsFakeTimeProvider(TimeProvider provider)
+    {
+        DateTimeOffset start = provider.GetUtcNow();
+        FakeTimeProvider fake = Assert.IsType<FakeTimeProvider>(provider);
+
+        fake.Advance(TimeSpan.FromSeconds(1));
+
+        Assert.True(provider.GetUtcNow() > start);
+    }
+
+    private static readonly ConcurrentBag<FakeTimeProvider> SeenInstances = [];
+
+    [Property(MaxExamples = 10, Seed = 2UL)]
+    public void Property_EachInvocation_ReceivesFreshFakeTimeProvider(TimeProvider provider)
+    {
+        FakeTimeProvider fake = Assert.IsType<FakeTimeProvider>(provider);
+
+        Assert.DoesNotContain(fake, SeenInstances);
+
+        SeenInstances.Add(fake);
+    }
+}

--- a/src/Conjecture.Time/Conjecture.Time.csproj
+++ b/src/Conjecture.Time/Conjecture.Time.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.Time/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.Time/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+Conjecture.Time.TimeProviderArbitrary
+Conjecture.Time.TimeProviderArbitrary.TimeProviderArbitrary() -> void
+static Conjecture.Time.TimeProviderArbitrary.Create() -> Conjecture.Core.Strategy<System.TimeProvider!>!

--- a/src/Conjecture.Time/TimeProviderArbitrary.cs
+++ b/src/Conjecture.Time/TimeProviderArbitrary.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+using Microsoft.Extensions.Time.Testing;
+
+namespace Conjecture.Time;
+
+/// <summary>
+/// Auto-injected <see cref="IStrategyProvider{T}"/> for <see cref="TimeProvider"/>.
+/// Each generated value is a fresh <see cref="FakeTimeProvider"/> with a fixed epoch start,
+/// so tests that replay a seed receive an identical, independently-advanceable clock.
+/// </summary>
+[Arbitrary]
+public sealed class TimeProviderArbitrary : IStrategyProvider<TimeProvider>
+{
+    /// <summary>Returns a strategy that generates fresh <see cref="FakeTimeProvider"/> instances.</summary>
+    public static Strategy<TimeProvider> Create()
+    {
+        return Generate.Compose<TimeProvider>(static _ => new FakeTimeProvider());
+    }
+
+    Strategy<TimeProvider> IStrategyProvider<TimeProvider>.Create()
+    {
+        return Create();
+    }
+}

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -22,4 +22,6 @@
   <Project Path="Conjecture.Formatters.Tests/Conjecture.Formatters.Tests.csproj" />
   <Project Path="Conjecture.Tool/Conjecture.Tool.csproj" />
   <Project Path="Conjecture.Tool.Tests/Conjecture.Tool.Tests.csproj" />
+  <Project Path="Conjecture.Time/Conjecture.Time.csproj" />
+  <Project Path="Conjecture.Time.Tests/Conjecture.Time.Tests.csproj" />
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -45,6 +45,9 @@
     <PackageVersion Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.1.0" />
 
+    <!-- Time provider testing -->
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.6.0" />
+
     <!-- Logging -->
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
 


### PR DESCRIPTION
## Description

Adds the `Conjecture.Time` package, which ships `TimeProviderArbitrary` — an `IStrategyProvider<TimeProvider>` that auto-injects `FakeTimeProvider` instances for `TimeProvider` parameters in property tests via the existing assembly-scan naming convention.

**Runtime path (`[Property]` parameters):** `EnsureAssembliesLoaded()` is added to `ArbitraryProviderScanner` to probe the app base directory for unloaded DLLs before the first scan, ensuring `Conjecture.Time.dll` is visible even if no live type has referenced it yet. Memoised behind a `static volatile bool` so the directory scan runs at most once per process. Paths are normalised via `Path.GetFullPath` on both sides to avoid short/long path mismatches.

**Compile-time path (AOT-safe member generation):** `ProviderRegistry` scans all referenced assemblies at compile time for `[Arbitrary]`-annotated `IStrategyProvider<T>` implementations. `TypeModelExtractor.ClassifyMemberType` now resolves these as `ExternalStrategyProvider`, and `StrategyEmitter` emits a static interface-cast call — `((IStrategyProvider<T>)new Provider()).Create()` — so `[Arbitrary]` records with `TimeProvider` members generate AOT-safe code without reflection.

`SymbolHelpers.HasArbitraryAttribute` extracts the duplicated attribute-presence check shared between `ProviderRegistry` and `TypeModelExtractor`. `MemberModel.InnerTypeFullName` is renamed to `AuxiliaryTypeName` to reflect its dual role (element type for collections/nullables; provider FQN for `ExternalStrategyProvider`).

Tracks #179 for the remaining work: static dispatch generator for `[Property]` parameter auto-injection (the runtime reflection path is still used there).

Also updates CLAUDE.md project table with missing projects, and corrects ADR-0043 to reflect that Core did require a small intentional change.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style