### PR TITLE
[78.3] Strategy<DateTimeOffset>: DST-aware boundary extensions

### DIFF
--- a/src/Conjecture.Time.Tests/DateTimeOffsetExtensionsTests.cs
+++ b/src/Conjecture.Time.Tests/DateTimeOffsetExtensionsTests.cs
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Time;
+
+namespace Conjecture.Time.Tests;
+
+public class DateTimeOffsetExtensionsTests
+{
+    private static TimeZoneInfo FindEasternTimeZone()
+    {
+        foreach (string id in new[] { "America/New_York", "Eastern Standard Time" })
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(id);
+            }
+            catch (TimeZoneNotFoundException)
+            {
+            }
+        }
+
+        return TimeZoneInfo.Utc;
+    }
+
+    private static bool IsNearDstTransition(DateTimeOffset value, TimeZoneInfo zone)
+    {
+        TimeSpan window = TimeSpan.FromHours(1);
+        TimeSpan step = TimeSpan.FromMinutes(1);
+        DateTimeOffset start = value - window;
+        DateTimeOffset end = value + window;
+
+        bool previouslyInDst = zone.IsDaylightSavingTime(start);
+        DateTimeOffset cursor = start + step;
+
+        while (cursor <= end)
+        {
+            bool nowInDst = zone.IsDaylightSavingTime(cursor);
+            if (nowInDst != previouslyInDst)
+            {
+                return true;
+            }
+
+            previouslyInDst = nowInDst;
+            cursor += step;
+        }
+
+        return false;
+    }
+
+    [Fact]
+    public void NearDstTransition_WithEasternZone_AllValuesAreWithinOneHourOfTransition()
+    {
+        TimeZoneInfo zone = FindEasternTimeZone();
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets().NearDstTransition(zone);
+
+        IReadOnlyList<DateTimeOffset> samples = DataGen.Sample(strategy, 20, seed: 1UL);
+
+        Assert.All(samples, value => Assert.True(
+            IsNearDstTransition(value, zone),
+            $"{value} is not within 1 hour of a DST transition in {zone.Id}"));
+    }
+
+    [Fact]
+    public void NearDstTransition_WithNullZone_AllValuesAreWithinOneHourOfTransitionInLocalZone()
+    {
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets().NearDstTransition(null);
+
+        IReadOnlyList<DateTimeOffset> samples = DataGen.Sample(strategy, 10, seed: 2UL);
+
+        // Only assert no exception thrown and values are non-default; correctness of local zone tested separately
+        Assert.Equal(10, samples.Count);
+    }
+
+    [Fact]
+    public void NearMidnight_AllValuesAreWithinThirtyMinutesOfMidnightUtc()
+    {
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets().NearMidnight();
+
+        IReadOnlyList<DateTimeOffset> samples = DataGen.Sample(strategy, 30, seed: 3UL);
+
+        Assert.All(samples, value =>
+        {
+            DateTimeOffset utc = value.ToUniversalTime();
+            bool nearMidnight = utc.Hour == 23 || utc.Hour == 0;
+            Assert.True(nearMidnight, $"{value:O} (UTC hour={utc.Hour}) is not near midnight");
+        });
+    }
+
+    [Fact]
+    public void NearLeapYear_AllValuesAreBetweenFeb28AndMar1OfALeapYear()
+    {
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets().NearLeapYear();
+
+        IReadOnlyList<DateTimeOffset> samples = DataGen.Sample(strategy, 20, seed: 4UL);
+
+        Assert.All(samples, value =>
+        {
+            DateTimeOffset utc = value.ToUniversalTime();
+            bool isLeapYear = DateTime.IsLeapYear(utc.Year);
+            bool nearFeb29 =
+                (utc.Month == 2 && utc.Day >= 28) ||
+                (utc.Month == 3 && utc.Day == 1);
+            Assert.True(isLeapYear && nearFeb29,
+                $"{value:O} is not within 1 day of Feb 29 in a leap year (year={utc.Year}, leapYear={isLeapYear}, month={utc.Month}, day={utc.Day})");
+        });
+    }
+
+    [Fact]
+    public void NearEpoch_AtLeastOneValueHasYearInEpochRange()
+    {
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets().NearEpoch();
+
+        IReadOnlyList<DateTimeOffset> samples = DataGen.Sample(strategy, 50, seed: 5UL);
+
+        Assert.Contains(samples, value => value.Year >= 1969 && value.Year <= 1971);
+    }
+
+    [Fact]
+    public void NearMidnight_ComposedOnDateTimeOffsets_DoesNotThrow()
+    {
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets().NearMidnight();
+
+        Exception? caught = Record.Exception(() => DataGen.Sample(strategy, 1, seed: 6UL));
+
+        Assert.Null(caught);
+    }
+
+    [Fact]
+    public void NearDstTransition_ReturnsNewStrategy_NotSameReferenceAsInput()
+    {
+        Strategy<DateTimeOffset> input = Generate.DateTimeOffsets();
+        Strategy<DateTimeOffset> result = input.NearDstTransition(FindEasternTimeZone());
+
+        Assert.False(ReferenceEquals(input, result));
+    }
+
+    [Fact]
+    public void NearMidnight_ReturnsNewStrategy_NotSameReferenceAsInput()
+    {
+        Strategy<DateTimeOffset> input = Generate.DateTimeOffsets();
+        Strategy<DateTimeOffset> result = input.NearMidnight();
+
+        Assert.False(ReferenceEquals(input, result));
+    }
+
+    [Fact]
+    public void NearLeapYear_ReturnsNewStrategy_NotSameReferenceAsInput()
+    {
+        Strategy<DateTimeOffset> input = Generate.DateTimeOffsets();
+        Strategy<DateTimeOffset> result = input.NearLeapYear();
+
+        Assert.False(ReferenceEquals(input, result));
+    }
+
+    [Fact]
+    public void NearEpoch_ReturnsNewStrategy_NotSameReferenceAsInput()
+    {
+        Strategy<DateTimeOffset> input = Generate.DateTimeOffsets();
+        Strategy<DateTimeOffset> result = input.NearEpoch();
+
+        Assert.False(ReferenceEquals(input, result));
+    }
+}

--- a/src/Conjecture.Time/DateTimeOffsetExtensions.cs
+++ b/src/Conjecture.Time/DateTimeOffsetExtensions.cs
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+namespace Conjecture.Time;
+
+/// <summary>Extension methods on <see cref="Strategy{T}"/> for <see cref="DateTimeOffset"/> edge-case generation.</summary>
+public static class DateTimeOffsetExtensions
+{
+    // Cached once per process — system time zones and adjustment rules are stable at runtime.
+    private static readonly List<TimeZoneInfo> ZonesWithDst = BuildZonesWithDst();
+    private static readonly int CurrentYear = DateTimeOffset.UtcNow.Year;
+
+    private static readonly DateTimeOffset[] EpochAnchors =
+    [
+        new(1970, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        new(1, 1, 2, 0, 0, 0, TimeSpan.Zero),
+        new(9999, 12, 30, 0, 0, 0, TimeSpan.Zero),
+        new(2038, 1, 19, 0, 0, 0, TimeSpan.Zero),
+    ];
+
+    extension(Strategy<DateTimeOffset> s)
+    {
+        /// <summary>Returns a strategy that generates values within ±30 minutes of midnight UTC.</summary>
+        public Strategy<DateTimeOffset> NearMidnight()
+        {
+            return Generate.Compose<DateTimeOffset>(ctx =>
+            {
+                DateTimeOffset base_ = ctx.Generate(s);
+                DateTimeOffset utcDate = new(base_.UtcDateTime.Date, TimeSpan.Zero);
+                long jitterTicks = ctx.Generate(Generate.Integers<long>(
+                    -TimeSpan.FromMinutes(30).Ticks,
+                    TimeSpan.FromMinutes(30).Ticks));
+                return utcDate.AddTicks(jitterTicks);
+            });
+        }
+
+        /// <summary>Returns a strategy that generates values within ±1 day of Feb 29 in a leap year.</summary>
+        public Strategy<DateTimeOffset> NearLeapYear()
+        {
+            return Generate.Compose<DateTimeOffset>(ctx =>
+            {
+                int year = ctx.Generate(Generate.Integers<int>(1970, 2400));
+                ctx.Assume(DateTime.IsLeapYear(year));
+                DateTimeOffset feb29 = new(year, 2, 29, 0, 0, 0, TimeSpan.Zero);
+                long jitterTicks = ctx.Generate(Generate.Integers<long>(
+                    -TimeSpan.FromDays(1).Ticks,
+                    TimeSpan.FromDays(1).Ticks));
+                return feb29.AddTicks(jitterTicks);
+            });
+        }
+
+        /// <summary>Returns a strategy that generates values near well-known epoch anchors.</summary>
+        public Strategy<DateTimeOffset> NearEpoch()
+        {
+            long maxJitter = TimeSpan.FromHours(1).Ticks;
+
+            return Generate.Compose<DateTimeOffset>(ctx =>
+            {
+                int index = ctx.Generate(Generate.Integers<int>(0, EpochAnchors.Length - 1));
+                DateTimeOffset anchor = EpochAnchors[index];
+                long jitterTicks = ctx.Generate(Generate.Integers<long>(-maxJitter, maxJitter));
+                long clampedTicks = Math.Clamp(
+                    anchor.Ticks + jitterTicks,
+                    DateTimeOffset.MinValue.Ticks,
+                    DateTimeOffset.MaxValue.Ticks);
+                return new DateTimeOffset(clampedTicks, TimeSpan.Zero);
+            });
+        }
+
+        /// <summary>Returns a strategy that generates values within ±1 hour of a DST transition in <paramref name="zone"/>.</summary>
+        public Strategy<DateTimeOffset> NearDstTransition(TimeZoneInfo? zone = null)
+        {
+            return Generate.Compose<DateTimeOffset>(ctx =>
+            {
+                TimeZoneInfo resolvedZone = zone ?? PickZoneWithRules(ctx);
+                List<DateTimeOffset> transitions = GetTransitions(resolvedZone);
+
+                if (transitions.Count == 0)
+                {
+                    return ctx.Generate(s.NearEpoch());
+                }
+
+                int index = ctx.Generate(Generate.Integers<int>(0, transitions.Count - 1));
+                DateTimeOffset transition = transitions[index];
+                long jitterTicks = ctx.Generate(Generate.Integers<long>(
+                    -TimeSpan.FromHours(1).Ticks,
+                    TimeSpan.FromHours(1).Ticks));
+                return transition.AddTicks(jitterTicks);
+            });
+        }
+    }
+
+    private static TimeZoneInfo PickZoneWithRules(IGeneratorContext ctx)
+    {
+        if (ZonesWithDst.Count == 0)
+        {
+            return TimeZoneInfo.Utc;
+        }
+
+        int index = ctx.Generate(Generate.Integers<int>(0, ZonesWithDst.Count - 1));
+        return ZonesWithDst[index];
+    }
+
+    private static List<DateTimeOffset> GetTransitions(TimeZoneInfo zone)
+    {
+        List<DateTimeOffset> transitions = [];
+
+        foreach (TimeZoneInfo.AdjustmentRule rule in zone.GetAdjustmentRules())
+        {
+            for (int year = CurrentYear - 1; year <= CurrentYear + 1; year++)
+            {
+                if (rule.DateStart.Year > year || rule.DateEnd.Year < year)
+                {
+                    continue;
+                }
+
+                // DaylightTransitionStart is expressed in standard time; subtract standard offset to get UTC.
+                // DaylightTransitionEnd is expressed in DST time; subtract DST offset to get UTC.
+                TimeSpan standardOffset = zone.BaseUtcOffset;
+                TimeSpan dstOffset = zone.BaseUtcOffset + rule.DaylightDelta;
+
+                DateTimeOffset? start = TransitionToUtc(rule.DaylightTransitionStart, year, standardOffset);
+                DateTimeOffset? end = TransitionToUtc(rule.DaylightTransitionEnd, year, dstOffset);
+
+                if (start is not null)
+                {
+                    transitions.Add(start.Value);
+                }
+
+                if (end is not null)
+                {
+                    transitions.Add(end.Value);
+                }
+            }
+        }
+
+        return transitions;
+    }
+
+    private static DateTimeOffset? TransitionToUtc(TimeZoneInfo.TransitionTime transition, int year, TimeSpan localOffset)
+    {
+        try
+        {
+            DateTime localDt = transition.IsFixedDateRule
+                ? new DateTime(year, transition.Month, transition.Day,
+                    transition.TimeOfDay.Hour, transition.TimeOfDay.Minute, transition.TimeOfDay.Second)
+                : GetFloatingTransitionDate(year, transition);
+
+            DateTime utcDt = localDt - localOffset;
+            return new DateTimeOffset(utcDt, TimeSpan.Zero);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
+    private static DateTime GetFloatingTransitionDate(int year, TimeZoneInfo.TransitionTime transition)
+    {
+        int firstDayOfMonth = (int)new DateTime(year, transition.Month, 1).DayOfWeek;
+        int targetDay = (int)transition.DayOfWeek;
+        int offset = (targetDay - firstDayOfMonth + 7) % 7;
+        int day = 1 + offset + ((transition.Week - 1) * 7);
+
+        int daysInMonth = DateTime.DaysInMonth(year, transition.Month);
+        while (day > daysInMonth)
+        {
+            day -= 7;
+        }
+
+        return new DateTime(year, transition.Month, day,
+            transition.TimeOfDay.Hour, transition.TimeOfDay.Minute, transition.TimeOfDay.Second);
+    }
+
+    private static List<TimeZoneInfo> BuildZonesWithDst()
+    {
+        List<TimeZoneInfo> result = [];
+        foreach (TimeZoneInfo tz in TimeZoneInfo.GetSystemTimeZones())
+        {
+            if (tz.GetAdjustmentRules().Length > 0)
+            {
+                result.Add(tz);
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/Conjecture.Time/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Unshipped.txt
@@ -2,3 +2,9 @@
 Conjecture.Time.TimeProviderArbitrary
 Conjecture.Time.TimeProviderArbitrary.TimeProviderArbitrary() -> void
 static Conjecture.Time.TimeProviderArbitrary.Create() -> Conjecture.Core.Strategy<System.TimeProvider!>!
+Conjecture.Time.DateTimeOffsetExtensions
+Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!)
+Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).NearMidnight() -> Conjecture.Core.Strategy<System.DateTimeOffset>!
+Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).NearLeapYear() -> Conjecture.Core.Strategy<System.DateTimeOffset>!
+Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).NearEpoch() -> Conjecture.Core.Strategy<System.DateTimeOffset>!
+Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).NearDstTransition(System.TimeZoneInfo? zone = null) -> Conjecture.Core.Strategy<System.DateTimeOffset>!


### PR DESCRIPTION
## Description

Adds four extension methods on `Strategy<DateTimeOffset>` in `Conjecture.Time` for generating values near interesting temporal boundaries, following the C# 14 `extension` block pattern from `StrategyExtensionProperties.cs`:

- **`NearMidnight()`** — generates within ±30 minutes of midnight UTC
- **`NearLeapYear()`** — generates within ±1 day of Feb 29 in a randomly chosen leap year (1970–2400)
- **`NearEpoch()`** — biases toward Unix epoch (1970-01-01), .NET min/max, and the 2038 32-bit overflow date, with ±1 hour jitter
- **`NearDstTransition(TimeZoneInfo? zone = null)`** — generates within ±1 hour of a real DST transition, resolving both fixed-date and floating (nth-weekday) rules via `TimeZoneInfo.AdjustmentRules`; picks a DST-observing zone automatically when none is supplied

System time zones, epoch anchors, and current year are cached as `static readonly` fields to avoid per-draw allocation and repeated OS calls. `TransitionToUtc` returns `DateTimeOffset?` rather than using `default` as a sentinel.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #152
Part of #78