### PR TITLE
[78.4] Conjecture.Time: Generate.TimeZones() and Generate.ClockSet()

### DIFF
--- a/src/Conjecture.Time.Tests/TimeGenerateTests.cs
+++ b/src/Conjecture.Time.Tests/TimeGenerateTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Time;
+
+using Microsoft.Extensions.Time.Testing;
+
+namespace Conjecture.Time.Tests;
+
+public class TimeGenerateTests
+{
+    [Fact]
+    public void TimeZones_ReturnsStrategy()
+    {
+        Strategy<TimeZoneInfo> strategy = TimeGenerate.TimeZones();
+
+        Assert.NotNull(strategy);
+    }
+
+    [Fact]
+    public void TimeZones_GeneratesOnlySystemZones()
+    {
+        Strategy<TimeZoneInfo> strategy = TimeGenerate.TimeZones();
+        System.Collections.ObjectModel.ReadOnlyCollection<TimeZoneInfo> systemZones = TimeZoneInfo.GetSystemTimeZones();
+        System.Collections.Generic.HashSet<string> systemIds = [.. systemZones.Select(static z => z.Id)];
+
+        IReadOnlyList<TimeZoneInfo> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, z => Assert.Contains(z.Id, systemIds));
+    }
+
+    [Fact]
+    public void ClockSet_ReturnsArrayOfExactNodeCount()
+    {
+        Strategy<FakeTimeProvider[]> strategy = TimeGenerate.ClockSet(3, TimeSpan.FromSeconds(5));
+
+        FakeTimeProvider[] clocks = DataGen.SampleOne(strategy, seed: 1UL);
+
+        Assert.Equal(3, clocks.Length);
+    }
+
+    [Fact]
+    public void ClockSet_EachClockIsWithinMaxSkewOfOthers()
+    {
+        TimeSpan maxSkew = TimeSpan.FromSeconds(1);
+        Strategy<FakeTimeProvider[]> strategy = TimeGenerate.ClockSet(3, maxSkew);
+
+        FakeTimeProvider[] clocks = DataGen.SampleOne(strategy, seed: 1UL);
+
+        for (int i = 0; i < clocks.Length; i++)
+        {
+            for (int j = i + 1; j < clocks.Length; j++)
+            {
+                TimeSpan diff = (clocks[i].GetUtcNow() - clocks[j].GetUtcNow()).Duration();
+                Assert.True(diff <= maxSkew, $"Clock {i} and clock {j} differ by {diff}, exceeding maxSkew {maxSkew}");
+            }
+        }
+    }
+
+    [Fact]
+    public void ClockSet_NodeCountLessThanTwo_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            static () => TimeGenerate.ClockSet(1, TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public void ClockSet_ClocksAreIndependent()
+    {
+        Strategy<FakeTimeProvider[]> strategy = TimeGenerate.ClockSet(3, TimeSpan.FromSeconds(5));
+
+        FakeTimeProvider[] clocks = DataGen.SampleOne(strategy, seed: 1UL);
+
+        DateTimeOffset before0 = clocks[0].GetUtcNow();
+        DateTimeOffset before1 = clocks[1].GetUtcNow();
+        DateTimeOffset before2 = clocks[2].GetUtcNow();
+
+        clocks[0].Advance(TimeSpan.FromMinutes(10));
+
+        Assert.Equal(before1, clocks[1].GetUtcNow());
+        Assert.Equal(before2, clocks[2].GetUtcNow());
+    }
+
+    [Fact]
+    public void ClockSet_EachElementIsFakeTimeProvider()
+    {
+        Strategy<FakeTimeProvider[]> strategy = TimeGenerate.ClockSet(2, TimeSpan.FromSeconds(1));
+
+        FakeTimeProvider[] clocks = DataGen.SampleOne(strategy, seed: 1UL);
+
+        Assert.All(clocks, static c => Assert.IsType<FakeTimeProvider>(c));
+    }
+}

--- a/src/Conjecture.Time/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Unshipped.txt
@@ -8,3 +8,6 @@ Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<Syst
 Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).NearLeapYear() -> Conjecture.Core.Strategy<System.DateTimeOffset>!
 Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).NearEpoch() -> Conjecture.Core.Strategy<System.DateTimeOffset>!
 Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).NearDstTransition(System.TimeZoneInfo? zone = null) -> Conjecture.Core.Strategy<System.DateTimeOffset>!
+Conjecture.Time.TimeGenerate
+static Conjecture.Time.TimeGenerate.ClockSet(int nodeCount, System.TimeSpan maxSkew) -> Conjecture.Core.Strategy<Microsoft.Extensions.Time.Testing.FakeTimeProvider![]!>!
+static Conjecture.Time.TimeGenerate.TimeZones() -> Conjecture.Core.Strategy<System.TimeZoneInfo!>!

--- a/src/Conjecture.Time/TimeGenerate.cs
+++ b/src/Conjecture.Time/TimeGenerate.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+using Microsoft.Extensions.Time.Testing;
+
+namespace Conjecture.Time;
+
+/// <summary>Factory methods for generating time-related test values.</summary>
+public static class TimeGenerate
+{
+    // UTC at index 0 so SampledFrom shrinks toward it; deduplicated in case GetSystemTimeZones already includes UTC.
+    private static readonly TimeZoneInfo[] SystemTimeZones = BuildSystemTimeZones();
+
+    private static TimeZoneInfo[] BuildSystemTimeZones()
+    {
+        // UTC is placed first so SampledFrom shrinks toward it; non-UTC zones follow in system order.
+        System.Collections.ObjectModel.ReadOnlyCollection<TimeZoneInfo> zones = TimeZoneInfo.GetSystemTimeZones();
+        List<TimeZoneInfo> result = [TimeZoneInfo.Utc];
+        foreach (TimeZoneInfo tz in zones)
+        {
+            if (tz.Id != TimeZoneInfo.Utc.Id)
+            {
+                result.Add(tz);
+            }
+        }
+
+        return [.. result];
+    }
+
+    /// <summary>Returns a strategy that picks uniformly from the system time zones, shrinking toward UTC.</summary>
+    public static Strategy<TimeZoneInfo> TimeZones()
+    {
+        return Generate.SampledFrom(SystemTimeZones);
+    }
+
+    /// <summary>
+    /// Returns a strategy that generates an array of <paramref name="nodeCount"/> independent
+    /// <see cref="FakeTimeProvider"/> instances, each with a clock skew drawn from
+    /// [<c>-maxSkew/2</c>, <c>+maxSkew/2</c>] relative to <see cref="DateTimeOffset.UtcNow"/>.
+    /// </summary>
+    /// <param name="nodeCount">Number of clocks to generate. Must be at least 2.</param>
+    /// <param name="maxSkew">Maximum pairwise clock difference.</param>
+    public static Strategy<FakeTimeProvider[]> ClockSet(int nodeCount, TimeSpan maxSkew)
+    {
+        if (nodeCount < 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(nodeCount), nodeCount, "nodeCount must be at least 2.");
+        }
+
+        long halfSkewTicks = maxSkew.Ticks / 2;
+        Strategy<long> skewStrategy = Generate.Integers<long>(-halfSkewTicks, halfSkewTicks);
+
+        return Generate.Compose<FakeTimeProvider[]>(ctx =>
+        {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            FakeTimeProvider[] clocks = new FakeTimeProvider[nodeCount];
+            for (int i = 0; i < nodeCount; i++)
+            {
+                long skewTicks = ctx.Generate(skewStrategy);
+                clocks[i] = new FakeTimeProvider(now + TimeSpan.FromTicks(skewTicks));
+            }
+
+            return clocks;
+        });
+    }
+}


### PR DESCRIPTION
## Description

Adds `TimeGenerate.TimeZones()` and `TimeGenerate.ClockSet()` to `Conjecture.Time` — a separate static class from Core's `Generate` to avoid pulling `Microsoft.Extensions.*` into Core.

**`TimeGenerate.TimeZones()`** — returns `Strategy<TimeZoneInfo>`. Picks uniformly from `TimeZoneInfo.GetSystemTimeZones()` (cached as a `static readonly` field). UTC is placed at index 0 so `SampledFrom` shrinks toward it; duplicates are filtered out in case the platform already includes UTC in the system list.

**`TimeGenerate.ClockSet(int nodeCount, TimeSpan maxSkew)`** — returns `Strategy<FakeTimeProvider[]>`. Throws `ArgumentOutOfRangeException` for `nodeCount < 2`. Each clock is an independent `FakeTimeProvider` offset from `DateTimeOffset.UtcNow` by a seed-reproducible skew in `[-maxSkew/2, +maxSkew/2]`, guaranteeing all pairwise differences stay within `maxSkew`. Natural use: distributed system tests with bounded clock skew.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #153
Part of #78