### PR TITLE
Adds AOT-safe strategy registry generator and IPropertyTest interface

### DIFF
--- a/src/Conjecture.Analyzers/PropertyAttributeHelper.cs
+++ b/src/Conjecture.Analyzers/PropertyAttributeHelper.cs
@@ -12,13 +12,28 @@ internal static class PropertyAttributeHelper
 {
     internal static bool HasPropertyAttribute(MethodDeclarationSyntax method, SemanticModel model)
     {
+        INamedTypeSymbol? markerInterface =
+            model.Compilation.GetTypeByMetadataName("Conjecture.Core.IPropertyTest");
+
         foreach (AttributeListSyntax attrList in method.AttributeLists)
         {
             foreach (AttributeSyntax attr in attrList.Attributes)
             {
                 SymbolInfo info = model.GetSymbolInfo(attr);
                 ISymbol? symbol = info.Symbol ?? info.CandidateSymbols.FirstOrDefault();
-                if (symbol?.ContainingType?.Name == "PropertyAttribute")
+                INamedTypeSymbol? attrType = symbol?.ContainingType;
+
+                if (attrType is not null && markerInterface is not null)
+                {
+                    foreach (INamedTypeSymbol iface in attrType.AllInterfaces)
+                    {
+                        if (SymbolEqualityComparer.Default.Equals(iface, markerInterface))
+                        {
+                            return true;
+                        }
+                    }
+                }
+                else if (attrType?.Name == "PropertyAttribute")
                 {
                     return true;
                 }

--- a/src/Conjecture.Core.Tests/ConjectureStrategyRegistrarTests.cs
+++ b/src/Conjecture.Core.Tests/ConjectureStrategyRegistrarTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests;
+
+/// <summary>
+/// Tests for <see cref="ConjectureStrategyRegistrar"/>, the static dispatch hook that allows
+/// generated code to register an AOT-safe resolver for <c>[Property]</c> parameter types.
+/// </summary>
+[Collection("StrategyRegistrar")]
+public sealed class ConjectureStrategyRegistrarTests
+{
+    [Fact]
+    public void TryResolve_WithNoRegistration_ReturnsNull()
+    {
+        ConjectureStrategyRegistrar.Register(static (_, _) => null);
+
+        object? result = ConjectureStrategyRegistrar.TryResolve(typeof(string), null!);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Register_ThenTryResolve_WithMatchingType_ReturnsResolvedValue()
+    {
+        object expected = new();
+        ConjectureStrategyRegistrar.Register((type, _) => type == typeof(int) ? expected : null);
+
+        object? result = ConjectureStrategyRegistrar.TryResolve(typeof(int), null!);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Register_ThenTryResolve_WithNonMatchingType_ReturnsNull()
+    {
+        ConjectureStrategyRegistrar.Register(static (type, _) => type == typeof(int) ? new object() : null);
+
+        object? result = ConjectureStrategyRegistrar.TryResolve(typeof(string), null!);
+
+        Assert.Null(result);
+    }
+}
+
+[CollectionDefinition("StrategyRegistrar")]
+public sealed class StrategyRegistrarCollection : ICollectionFixture<StrategyRegistrarFixture>;
+
+/// <summary>
+/// Resets the global <see cref="ConjectureStrategyRegistrar"/> state before and after
+/// each test in the <c>StrategyRegistrar</c> collection.
+/// </summary>
+public sealed class StrategyRegistrarFixture : IDisposable
+{
+    public StrategyRegistrarFixture()
+    {
+        ConjectureStrategyRegistrar.Register(static (_, _) => null);
+    }
+
+    public void Dispose()
+    {
+        ConjectureStrategyRegistrar.Register(static (_, _) => null);
+    }
+}

--- a/src/Conjecture.Core/ConjectureSettings.cs
+++ b/src/Conjecture.Core/ConjectureSettings.cs
@@ -68,6 +68,28 @@ public record ConjectureSettings
         }
     } = 0.5;
 
+    /// <summary>
+    /// Creates a <see cref="ConjectureSettings"/> from an <see cref="IPropertyTest"/> attribute.
+    /// If <paramref name="attr"/> also implements <see cref="IReproductionExport"/>, those
+    /// settings are included; otherwise they default to <see langword="false"/> and the default path.
+    /// </summary>
+    public static ConjectureSettings From(IPropertyTest attr, ILogger? logger = null)
+    {
+        return new ConjectureSettings
+        {
+            MaxExamples = attr.MaxExamples,
+            Seed = attr.Seed != 0UL ? attr.Seed : null,
+            UseDatabase = attr.UseDatabase,
+            MaxStrategyRejections = attr.MaxStrategyRejections,
+            Deadline = attr.DeadlineMs > 0 ? TimeSpan.FromMilliseconds(attr.DeadlineMs) : null,
+            Targeting = attr.Targeting,
+            TargetingProportion = attr.TargetingProportion,
+            Logger = logger ?? NullLogger.Instance,
+            ExportReproOnFailure = (attr as IReproductionExport)?.ExportReproOnFailure ?? false,
+            ReproOutputPath = (attr as IReproductionExport)?.ReproOutputPath ?? ".conjecture/repros/",
+        };
+    }
+
     private static int ValidateNonNegative(int value, string paramName) =>
         value >= 0 ? value : throw new ArgumentOutOfRangeException(paramName, value, "Must be non-negative.");
 

--- a/src/Conjecture.Core/ConjectureStrategyRegistrar.cs
+++ b/src/Conjecture.Core/ConjectureStrategyRegistrar.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+/// <summary>
+/// Registration hook for source-generated AOT-safe strategy resolvers.
+/// The source generator emits a <c>[ModuleInitializer]</c> that calls
+/// <see cref="Register(Func{Type, object?})"/> at startup, replacing the
+/// runtime-reflection path in <see cref="SharedParameterStrategyResolver"/>.
+/// </summary>
+public static class ConjectureStrategyRegistrar
+{
+    private static Func<Type, ConjectureData, object?>? activeResolver;
+
+    /// <summary>Registers a generated strategy factory. Called by source-generated module initializers.</summary>
+    /// <param name="strategyFactory">Returns a boxed <see cref="Strategy{T}"/> for the given type, or <see langword="null"/> if unsupported.</param>
+    public static void Register(Func<Type, object?> strategyFactory)
+    {
+        activeResolver = (type, data) =>
+        {
+            object? strategy = strategyFactory(type);
+            return strategy is IGeneratableStrategy gen ? gen.GenerateBoxed(data) : null;
+        };
+    }
+
+    internal static void Register(Func<Type, ConjectureData, object?> resolver)
+    {
+        activeResolver = resolver;
+    }
+
+    internal static object? TryResolve(Type type, ConjectureData data) =>
+        activeResolver?.Invoke(type, data);
+}

--- a/src/Conjecture.Core/IPropertyTest.cs
+++ b/src/Conjecture.Core/IPropertyTest.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core;
+
+/// <summary>
+/// Implemented by all framework-specific <c>[Property]</c> attributes.
+/// Allows tooling to detect property-based test methods and read common
+/// test configuration without depending on framework-specific types.
+/// </summary>
+public interface IPropertyTest
+{
+    /// <summary>Maximum number of examples to generate.</summary>
+    int MaxExamples { get; }
+
+    /// <summary>Optional fixed seed for deterministic runs. 0 means use a random seed.</summary>
+    ulong Seed { get; }
+
+    /// <summary>Whether to use the example database.</summary>
+    bool UseDatabase { get; }
+
+    /// <summary>Maximum number of times a strategy may reject a value before the test is abandoned.</summary>
+    int MaxStrategyRejections { get; }
+
+    /// <summary>Deadline for each test run in milliseconds. 0 means no deadline.</summary>
+    int DeadlineMs { get; }
+
+    /// <summary>Whether to run a targeting phase after the main generation phase.</summary>
+    bool Targeting { get; }
+
+    /// <summary>Fraction of the <see cref="MaxExamples"/> budget allocated to the targeting phase.</summary>
+    double TargetingProportion { get; }
+}

--- a/src/Conjecture.Core/IReproductionExport.cs
+++ b/src/Conjecture.Core/IReproductionExport.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core;
+
+/// <summary>
+/// Optional interface for <c>[Property]</c> attributes that support exporting
+/// reproduction files on test failure. Implement alongside <see cref="IPropertyTest"/>
+/// to opt in to this capability.
+/// </summary>
+public interface IReproductionExport
+{
+    /// <summary>Whether to export a reproduction file when the test fails.</summary>
+    bool ExportReproOnFailure { get; }
+
+    /// <summary>Output path for exported reproduction files.</summary>
+    string ReproOutputPath { get; }
+}

--- a/src/Conjecture.Core/Internal/IGeneratableStrategy.cs
+++ b/src/Conjecture.Core/Internal/IGeneratableStrategy.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core.Internal;
+
+internal interface IGeneratableStrategy
+{
+    object? GenerateBoxed(ConjectureData data);
+}

--- a/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
+++ b/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
@@ -118,6 +118,13 @@ internal static class SharedParameterStrategyResolver
     [RequiresDynamicCode("Calls MakeGenericMethod to construct typed generate helper.")]
     private static object? TryGenerateFromArbitraryProvider(ParameterInfo parameter, ConjectureData data)
     {
+        // Check the source-generated AOT-safe registry first.
+        object? registered = ConjectureStrategyRegistrar.TryResolve(parameter.ParameterType, data);
+        if (registered is not null)
+        {
+            return registered;
+        }
+
         Type paramType = parameter.ParameterType;
         MethodInfo? drawMethod = ArbitraryProviderCache.GetOrAdd(paramType, FindArbitraryGenerateMethod);
         if (drawMethod is null)

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,18 @@
 #nullable enable
+Conjecture.Core.ConjectureStrategyRegistrar
+Conjecture.Core.IPropertyTest
+Conjecture.Core.IPropertyTest.DeadlineMs.get -> int
+Conjecture.Core.IPropertyTest.MaxExamples.get -> int
+Conjecture.Core.IPropertyTest.MaxStrategyRejections.get -> int
+Conjecture.Core.IPropertyTest.Seed.get -> ulong
+Conjecture.Core.IPropertyTest.Targeting.get -> bool
+Conjecture.Core.IPropertyTest.TargetingProportion.get -> double
+Conjecture.Core.IPropertyTest.UseDatabase.get -> bool
+Conjecture.Core.IReproductionExport
+Conjecture.Core.IReproductionExport.ExportReproOnFailure.get -> bool
+Conjecture.Core.IReproductionExport.ReproOutputPath.get -> string!
+static Conjecture.Core.ConjectureSettings.From(Conjecture.Core.IPropertyTest! attr, Microsoft.Extensions.Logging.ILogger? logger = null) -> Conjecture.Core.ConjectureSettings!
+static Conjecture.Core.ConjectureStrategyRegistrar.Register(System.Func<System.Type!, object?>! strategyFactory) -> void
 static Conjecture.Core.Generate.DateOnlyValues() -> Conjecture.Core.Strategy<System.DateOnly>!
 static Conjecture.Core.Generate.DateOnlyValues(System.DateOnly min, System.DateOnly max) -> Conjecture.Core.Strategy<System.DateOnly>!
 static Conjecture.Core.Generate.DateTimeOffsets() -> Conjecture.Core.Strategy<System.DateTimeOffset>!

--- a/src/Conjecture.Core/Strategy.cs
+++ b/src/Conjecture.Core/Strategy.cs
@@ -11,10 +11,12 @@ namespace Conjecture.Core;
 /// <summary>Base class for all Conjecture strategies that generate values of type <typeparamref name="T"/>.</summary>
 /// <typeparam name="T">The type of value produced by this strategy.</typeparam>
 /// <param name="label">Optional label for counterexample output.</param>
-public abstract class Strategy<T>(string? label = null)
+public abstract class Strategy<T>(string? label = null) : IGeneratableStrategy
 {
     /// <summary>Label used in counterexample output, or null if unlabeled.</summary>
     public string? Label { get; } = label;
 
     internal abstract T Generate(ConjectureData data);
+
+    object? IGeneratableStrategy.GenerateBoxed(ConjectureData data) => Generate(data);
 }

--- a/src/Conjecture.Generators.Tests/PropertyStrategyRegistryGeneratorTests.cs
+++ b/src/Conjecture.Generators.Tests/PropertyStrategyRegistryGeneratorTests.cs
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Conjecture.Generators.Tests;
+
+/// <summary>
+/// Tests for <see cref="PropertyStrategyRegistryGenerator"/>, which emits an AOT-safe
+/// <c>ConjectureStrategyRegistry.g.cs</c> for any <c>[Property]</c> method whose parameter
+/// types have a known <c>IStrategyProvider&lt;T&gt;</c> in the referenced assemblies.
+/// </summary>
+public sealed class PropertyStrategyRegistryGeneratorTests
+{
+    // Stubs Conjecture.Xunit.PropertyAttribute in source — the real assembly is not
+    // referenced by the generator test project, so there is no duplicate-type conflict.
+    // Implements IPropertyTest so the generator's interface-based detection fires.
+    private const string PropertyAttributeStub = """
+        namespace Conjecture.Xunit
+        {
+            [System.AttributeUsage(System.AttributeTargets.Method)]
+            public sealed class PropertyAttribute : System.Attribute, global::Conjecture.Core.IPropertyTest
+            {
+                public int MaxExamples { get; set; }
+                public ulong Seed { get; set; }
+                public bool UseDatabase { get; set; }
+                public int MaxStrategyRejections { get; set; }
+                public int DeadlineMs { get; set; }
+                public bool Targeting { get; set; }
+                public double TargetingProportion { get; set; }
+            }
+        }
+        """;
+
+    [Fact]
+    public void Generator_WithPropertyMethodHavingTimeProviderParam_EmitsRegistryFile()
+    {
+        string source = """
+            using Conjecture.Xunit;
+            namespace MyTests
+            {
+                public class PropertyTests
+                {
+                    [Property]
+                    public void ClockTest(System.TimeProvider clock) { }
+                }
+            }
+            """;
+
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+
+        Assert.Contains(trees, t => t.FilePath.EndsWith("ConjectureStrategyRegistry.g.cs", System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Generator_WithPropertyMethodHavingTimeProviderParam_EmittedCodeContainsTimeProviderResolveArm()
+    {
+        string source = """
+            using Conjecture.Xunit;
+            namespace MyTests
+            {
+                public class PropertyTests
+                {
+                    [Property]
+                    public void ClockTest(System.TimeProvider clock) { }
+                }
+            }
+            """;
+
+        string text = GetGeneratedText(source, "ConjectureStrategyRegistry.g.cs");
+
+        Assert.Contains("typeof(global::System.TimeProvider)", text);
+    }
+
+    [Fact]
+    public void Generator_WithPropertyMethodHavingTimeProviderParam_EmittedCodeContainsModuleInitializer()
+    {
+        string source = """
+            using Conjecture.Xunit;
+            namespace MyTests
+            {
+                public class PropertyTests
+                {
+                    [Property]
+                    public void ClockTest(System.TimeProvider clock) { }
+                }
+            }
+            """;
+
+        string text = GetGeneratedText(source, "ConjectureStrategyRegistry.g.cs");
+
+        Assert.Contains("ModuleInitializer", text);
+    }
+
+    [Fact]
+    public void Generator_WithPropertyMethodHavingTimeProviderParam_EmittedCodeRegistersWithConjectureStrategyRegistrar()
+    {
+        string source = """
+            using Conjecture.Xunit;
+            namespace MyTests
+            {
+                public class PropertyTests
+                {
+                    [Property]
+                    public void ClockTest(System.TimeProvider clock) { }
+                }
+            }
+            """;
+
+        string text = GetGeneratedText(source, "ConjectureStrategyRegistry.g.cs");
+
+        Assert.Contains("global::Conjecture.Core.ConjectureStrategyRegistrar.Register", text);
+    }
+
+    [Fact]
+    public void Generator_WithNoPropertyMethods_EmitsNoRegistryFile()
+    {
+        string source = """
+            namespace MyTests
+            {
+                public class PlainTests
+                {
+                    public void PlainMethod(System.TimeProvider clock) { }
+                }
+            }
+            """;
+
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+
+        Assert.DoesNotContain(trees, t => t.FilePath.EndsWith("ConjectureStrategyRegistry.g.cs", System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Generator_WithPropertyMethodHavingOnlyBuiltInParams_EmitsNoRegistryFile()
+    {
+        string source = """
+            using Conjecture.Xunit;
+            namespace MyTests
+            {
+                public class PropertyTests
+                {
+                    [Property]
+                    public void SimpleTest(int x, string y) { }
+                }
+            }
+            """;
+
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+
+        Assert.DoesNotContain(trees, t => t.FilePath.EndsWith("ConjectureStrategyRegistry.g.cs", System.StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Generator_WithPropertyMethodHavingTimeProviderParam_OutputCompilationHasNoErrors()
+    {
+        string source = """
+            using Conjecture.Xunit;
+            namespace MyTests
+            {
+                public class PropertyTests
+                {
+                    [Property]
+                    public void ClockTest(System.TimeProvider clock) { }
+                }
+            }
+            """;
+
+        (_, Compilation output, _) = RunGenerator(source);
+
+        IEnumerable<Diagnostic> errors = output.GetDiagnostics()
+            .Where(static d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Empty(errors);
+    }
+
+    private static string GetGeneratedText(string source, string fileName)
+    {
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+        SyntaxTree? tree = trees.FirstOrDefault(
+            t => t.FilePath.EndsWith(fileName, System.StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(tree);
+        return tree.GetText().ToString();
+    }
+
+    private static (ImmutableArray<SyntaxTree> GeneratedTrees, Compilation Output, ImmutableArray<Diagnostic> GeneratorDiagnostics) RunGenerator(string source)
+    {
+        CSharpCompilation inputCompilation = CreateCompilation(source, includeTime: true);
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new PropertyStrategyRegistryGenerator());
+        GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
+        Compilation outputCompilation = inputCompilation.AddSyntaxTrees(result.GeneratedTrees);
+        return (result.GeneratedTrees, outputCompilation, result.Diagnostics);
+    }
+
+    private static CSharpCompilation CreateCompilation(string source, bool includeTime = false)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        List<MetadataReference> references =
+        [
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+            MetadataReference.CreateFromFile(typeof(Conjecture.Core.ArbitraryAttribute).Assembly.Location),
+        ];
+
+        if (includeTime)
+        {
+            references.Add(MetadataReference.CreateFromFile(typeof(Conjecture.Time.TimeProviderArbitrary).Assembly.Location));
+        }
+
+        List<SyntaxTree> trees = [CSharpSyntaxTree.ParseText(PropertyAttributeStub)];
+        if (source.Length > 0)
+        {
+            trees.Add(CSharpSyntaxTree.ParseText(source));
+        }
+
+        return CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: trees,
+            references: references,
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+    }
+}

--- a/src/Conjecture.Generators/PropertyStrategyRegistryGenerator.cs
+++ b/src/Conjecture.Generators/PropertyStrategyRegistryGenerator.cs
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Conjecture.Generators;
+
+/// <summary>Incremental source generator that emits an AOT-safe <c>ConjectureStrategyRegistry.g.cs</c> for <c>[Property]</c> methods whose parameter types have a known <c>IStrategyProvider&lt;T&gt;</c>.</summary>
+[Generator(LanguageNames.CSharp)]
+public sealed class PropertyStrategyRegistryGenerator : IIncrementalGenerator
+{
+    /// <inheritdoc/>
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        IncrementalValuesProvider<IMethodSymbol> propertyMethods = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                predicate: static (node, _) => IsPropertyMethodCandidate(node),
+                transform: static (ctx, _) => TryGetPropertyMethodSymbol(ctx))
+            .Where(static m => m is not null)
+            .Select(static (m, _) => m!);
+
+        IncrementalValueProvider<ImmutableDictionary<string, string>> registry =
+            context.CompilationProvider.Select(static (compilation, _) => ProviderRegistry.Build(compilation));
+
+        IncrementalValuesProvider<(string TypeFqn, string ProviderFqn)> pairs =
+            propertyMethods
+                .Combine(registry)
+                .SelectMany(static (item, _) =>
+                {
+                    IMethodSymbol method = item.Left;
+                    ImmutableDictionary<string, string> reg = item.Right;
+                    List<(string, string)> result = [];
+                    foreach (IParameterSymbol param in method.Parameters)
+                    {
+                        string typeFqn = param.Type.ToDisplayString(TypeModelExtractor.TypeNameFormat);
+                        if (reg.TryGetValue(typeFqn, out string? providerFqn))
+                        {
+                            result.Add((typeFqn, providerFqn));
+                        }
+                    }
+
+                    return result;
+                });
+
+        IncrementalValueProvider<ImmutableArray<(string TypeFqn, string ProviderFqn)>> collected =
+            pairs.Collect();
+
+        context.RegisterSourceOutput(collected, static (ctx, allPairs) =>
+        {
+            if (allPairs.IsEmpty)
+            {
+                return;
+            }
+
+            // Deduplicate by type FQN
+            Dictionary<string, string> unique = new(StringComparer.Ordinal);
+            foreach ((string typeFqn, string providerFqn) in allPairs)
+            {
+                if (!unique.ContainsKey(typeFqn))
+                {
+                    unique[typeFqn] = providerFqn;
+                }
+            }
+
+            string source = EmitRegistry(unique);
+            ctx.AddSource("ConjectureStrategyRegistry.g.cs", source);
+        });
+    }
+
+    private static bool IsPropertyMethodCandidate(SyntaxNode node)
+    {
+        if (node is not MethodDeclarationSyntax method || method.AttributeLists.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (AttributeListSyntax attrList in method.AttributeLists)
+        {
+            foreach (AttributeSyntax attr in attrList.Attributes)
+            {
+                string name = attr.Name.ToString();
+                if (name == "Property" || name == "PropertyAttribute")
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static IMethodSymbol? TryGetPropertyMethodSymbol(GeneratorSyntaxContext ctx)
+    {
+        INamedTypeSymbol? markerInterface =
+            ctx.SemanticModel.Compilation.GetTypeByMetadataName("Conjecture.Core.IPropertyTest");
+
+        MethodDeclarationSyntax method = (MethodDeclarationSyntax)ctx.Node;
+        foreach (AttributeListSyntax attrList in method.AttributeLists)
+        {
+            foreach (AttributeSyntax attr in attrList.Attributes)
+            {
+                SymbolInfo info = ctx.SemanticModel.GetSymbolInfo(attr);
+                ISymbol? sym = info.Symbol;
+                if (sym is null && info.CandidateSymbols.Length > 0)
+                {
+                    sym = info.CandidateSymbols[0];
+                }
+
+                INamedTypeSymbol? attrType = sym?.ContainingType;
+                if (attrType is null)
+                {
+                    continue;
+                }
+
+                if (markerInterface is null)
+                {
+                    if (attrType.Name == "PropertyAttribute")
+                    {
+                        return ctx.SemanticModel.GetDeclaredSymbol(method) as IMethodSymbol;
+                    }
+
+                    continue;
+                }
+
+                foreach (INamedTypeSymbol iface in attrType.AllInterfaces)
+                {
+                    if (SymbolEqualityComparer.Default.Equals(iface, markerInterface))
+                    {
+                        return ctx.SemanticModel.GetDeclaredSymbol(method) as IMethodSymbol;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string EmitRegistry(Dictionary<string, string> pairs)
+    {
+        StringBuilder sb = new();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.");
+        sb.AppendLine();
+        sb.AppendLine("using System.Runtime.CompilerServices;");
+        sb.AppendLine();
+        sb.AppendLine("namespace Conjecture.Generated;");
+        sb.AppendLine();
+        sb.AppendLine("internal static class ConjectureStrategyRegistry");
+        sb.AppendLine("{");
+        sb.AppendLine("    [ModuleInitializer]");
+        sb.AppendLine("    internal static void Register()");
+        sb.AppendLine("    {");
+        sb.AppendLine("        global::Conjecture.Core.ConjectureStrategyRegistrar.Register(Resolve);");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    private static object? Resolve(global::System.Type type)");
+        sb.AppendLine("    {");
+        foreach (KeyValuePair<string, string> pair in pairs)
+        {
+            sb.AppendLine($"        if (type == typeof(global::{pair.Key}))");
+            sb.AppendLine($"            return ((global::Conjecture.Core.IStrategyProvider<global::{pair.Key}>)new global::{pair.Value}()).Create();");
+        }
+
+        sb.AppendLine("        return null;");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+}

--- a/src/Conjecture.MSTest/PropertyAttribute.cs
+++ b/src/Conjecture.MSTest/PropertyAttribute.cs
@@ -19,7 +19,7 @@ namespace Conjecture.MSTest;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public sealed class PropertyAttribute(
     [CallerFilePath] string sourceFile = "",
-    [CallerLineNumber] int sourceLine = -1) : TestMethodAttribute(sourceFile, sourceLine)
+    [CallerLineNumber] int sourceLine = -1) : TestMethodAttribute(sourceFile, sourceLine), IPropertyTest
 {
 
     /// <summary>Maximum number of examples to generate. Defaults to 100.</summary>
@@ -62,17 +62,7 @@ public sealed class PropertyAttribute(
         }
 
         ILogger logger = TestOutputHelperLogger.FromWriteLine(Console.WriteLine);
-        ConjectureSettings settings = new()
-        {
-            MaxExamples = MaxExamples,
-            Seed = Seed == 0UL ? null : Seed,
-            UseDatabase = UseDatabase,
-            MaxStrategyRejections = MaxStrategyRejections,
-            Deadline = DeadlineMs > 0 ? TimeSpan.FromMilliseconds(DeadlineMs) : null,
-            Targeting = Targeting,
-            TargetingProportion = TargetingProportion,
-            Logger = logger,
-        };
+        ConjectureSettings settings = ConjectureSettings.From(this, logger);
 
         string dbPath = Path.Combine(settings.DatabasePath, "conjecture.db");
         string testIdHash = TestCaseHelper.ComputeTestId(methodInfo);

--- a/src/Conjecture.NUnit/Internal/PropertyTestCommand.cs
+++ b/src/Conjecture.NUnit/Internal/PropertyTestCommand.cs
@@ -16,35 +16,9 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Conjecture.NUnit.Internal;
 
-internal sealed class PropertyTestCommand : DelegatingTestCommand
+internal sealed class PropertyTestCommand(TestCommand innerCommand, IPropertyTest attr)
+    : DelegatingTestCommand(innerCommand)
 {
-    private readonly int maxExamples;
-    private readonly ulong? seed;
-    private readonly bool useDatabase;
-    private readonly int maxStrategyRejections;
-    private readonly int deadlineMs;
-    private readonly bool targeting;
-    private readonly double targetingProportion;
-
-    internal PropertyTestCommand(
-        TestCommand innerCommand,
-        int maxExamples,
-        ulong? seed,
-        bool useDatabase,
-        int maxStrategyRejections,
-        int deadlineMs,
-        bool targeting,
-        double targetingProportion)
-        : base(innerCommand)
-    {
-        this.maxExamples = maxExamples;
-        this.seed = seed;
-        this.useDatabase = useDatabase;
-        this.maxStrategyRejections = maxStrategyRejections;
-        this.deadlineMs = deadlineMs;
-        this.targeting = targeting;
-        this.targetingProportion = targetingProportion;
-    }
 
     [RequiresDynamicCode("Property test execution uses MakeGenericMethod for typed strategy dispatch.")]
     [RequiresUnreferencedCode("Property test execution accesses parameter type metadata that may be trimmed.")]
@@ -65,17 +39,7 @@ internal sealed class PropertyTestCommand : DelegatingTestCommand
         }
 
         ILogger logger = TestOutputHelperLogger.FromWriteLine(msg => TestContext.Out.WriteLine(msg));
-        ConjectureSettings settings = new()
-        {
-            MaxExamples = maxExamples,
-            Seed = seed,
-            UseDatabase = useDatabase,
-            MaxStrategyRejections = maxStrategyRejections,
-            Deadline = deadlineMs > 0 ? TimeSpan.FromMilliseconds(deadlineMs) : null,
-            Targeting = targeting,
-            TargetingProportion = targetingProportion,
-            Logger = logger,
-        };
+        ConjectureSettings settings = ConjectureSettings.From(attr, logger);
 
         string dbPath = Path.Combine(settings.DatabasePath, "conjecture.db");
         string testIdHash = TestCaseHelper.ComputeTestId(methodInfo);

--- a/src/Conjecture.NUnit/PropertyAttribute.cs
+++ b/src/Conjecture.NUnit/PropertyAttribute.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using Conjecture.Core;
 using Conjecture.NUnit.Internal;
 
 using NUnit.Framework.Interfaces;
@@ -12,7 +13,7 @@ namespace Conjecture.NUnit;
 
 /// <summary>Marks a method as a Conjecture property-based test (NUnit).</summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-public sealed class PropertyAttribute : global::NUnit.Framework.NUnitAttribute, ITestBuilder, IWrapTestMethod
+public sealed class PropertyAttribute : global::NUnit.Framework.NUnitAttribute, ITestBuilder, IWrapTestMethod, IPropertyTest
 {
     /// <summary>Maximum number of examples to generate. Defaults to 100.</summary>
     public int MaxExamples { get; set; } = 100;
@@ -52,16 +53,5 @@ public sealed class PropertyAttribute : global::NUnit.Framework.NUnitAttribute, 
     }
 
     /// <inheritdoc/>
-    TestCommand ICommandWrapper.Wrap(TestCommand command)
-    {
-        return new PropertyTestCommand(
-            command,
-            MaxExamples,
-            Seed != 0 ? Seed : null,
-            UseDatabase,
-            MaxStrategyRejections,
-            DeadlineMs,
-            Targeting,
-            TargetingProportion);
-    }
+    TestCommand ICommandWrapper.Wrap(TestCommand command) => new PropertyTestCommand(command, this);
 }

--- a/src/Conjecture.Xunit.V3/Internal/PropertyTestCaseDiscoverer.cs
+++ b/src/Conjecture.Xunit.V3/Internal/PropertyTestCaseDiscoverer.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using Conjecture.Core;
+
 using Xunit.Sdk;
 using Xunit.v3;
 
@@ -13,15 +15,16 @@ internal sealed class PropertyTestCaseDiscoverer : IXunitTestCaseDiscoverer
         IXunitTestMethod testMethod,
         IFactAttribute factAttribute)
     {
+        IPropertyTest propTest = (IPropertyTest)factAttribute;
         PropertyAttribute attr = (PropertyAttribute)factAttribute;
 
-        int maxExamples = attr.MaxExamples > 0 ? attr.MaxExamples : 100;
-        ulong? seed = attr.Seed != 0UL ? attr.Seed : null;
-        bool useDatabase = attr.UseDatabase;
-        int maxStrategyRejections = attr.MaxStrategyRejections > 0 ? attr.MaxStrategyRejections : 5;
-        int deadlineMs = attr.DeadlineMs;
-        bool targeting = attr.Targeting;
-        double targetingProportion = attr.TargetingProportion;
+        int maxExamples = propTest.MaxExamples > 0 ? propTest.MaxExamples : 100;
+        ulong? seed = propTest.Seed != 0UL ? propTest.Seed : null;
+        bool useDatabase = propTest.UseDatabase;
+        int maxStrategyRejections = propTest.MaxStrategyRejections > 0 ? propTest.MaxStrategyRejections : 5;
+        int deadlineMs = propTest.DeadlineMs;
+        bool targeting = propTest.Targeting;
+        double targetingProportion = propTest.TargetingProportion;
 
         string displayName = testMethod.GetDisplayName(attr.DisplayName ?? testMethod.Method.Name, null, null, null);
         string uniqueID = testMethod.UniqueID;

--- a/src/Conjecture.Xunit.V3/PropertyAttribute.cs
+++ b/src/Conjecture.Xunit.V3/PropertyAttribute.cs
@@ -3,6 +3,8 @@
 
 using System.Runtime.CompilerServices;
 
+using Conjecture.Core;
+
 using Xunit;
 using Xunit.v3;
 
@@ -13,7 +15,7 @@ namespace Conjecture.Xunit.V3;
 [XunitTestCaseDiscovererAttribute(typeof(Internal.PropertyTestCaseDiscoverer))]
 public sealed class PropertyAttribute(
     [CallerFilePath] string? sourceFilePath = null,
-    [CallerLineNumber] int sourceLineNumber = -1) : FactAttribute(sourceFilePath, sourceLineNumber)
+    [CallerLineNumber] int sourceLineNumber = -1) : FactAttribute(sourceFilePath, sourceLineNumber), IPropertyTest
 {
     /// <summary>Maximum number of examples to generate. Defaults to 100.</summary>
     public int MaxExamples { get; set; } = 100;

--- a/src/Conjecture.Xunit/Internal/AttributeInfoPropertyTestAdapter.cs
+++ b/src/Conjecture.Xunit/Internal/AttributeInfoPropertyTestAdapter.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+using Xunit.Abstractions;
+
+namespace Conjecture.Xunit.Internal;
+
+/// <summary>
+/// Adapts xUnit v2's <see cref="IAttributeInfo"/> to <see cref="IPropertyTest"/> and
+/// <see cref="IReproductionExport"/>, allowing attribute properties to be read through
+/// the shared interfaces without coupling to a concrete <c>PropertyAttribute</c> type.
+/// </summary>
+internal sealed class AttributeInfoPropertyTestAdapter(IAttributeInfo info) : IPropertyTest, IReproductionExport
+{
+    public int MaxExamples => info.GetNamedArgument<int>("MaxExamples");
+    public ulong Seed => info.GetNamedArgument<ulong>("Seed");
+    public bool UseDatabase => info.GetNamedArgument<bool>("UseDatabase");
+    public int MaxStrategyRejections => info.GetNamedArgument<int>("MaxStrategyRejections");
+    public int DeadlineMs => info.GetNamedArgument<int>("DeadlineMs");
+    public bool Targeting => info.GetNamedArgument<bool>("Targeting");
+    public double TargetingProportion => info.GetNamedArgument<double>("TargetingProportion");
+    public bool ExportReproOnFailure => info.GetNamedArgument<bool>("ExportReproOnFailure");
+    public string ReproOutputPath => info.GetNamedArgument<string>("ReproOutputPath") ?? ".conjecture/repros/";
+}

--- a/src/Conjecture.Xunit/Internal/PropertyTestCaseDiscoverer.cs
+++ b/src/Conjecture.Xunit/Internal/PropertyTestCaseDiscoverer.cs
@@ -13,20 +13,17 @@ internal sealed class PropertyTestCaseDiscoverer(IMessageSink diagnosticMessageS
         ITestMethod testMethod,
         IAttributeInfo factAttribute)
     {
-        int maxExamples = factAttribute.GetNamedArgument<int>("MaxExamples");
-        if (maxExamples <= 0) { maxExamples = 100; }
+        AttributeInfoPropertyTestAdapter adapter = new(factAttribute);
 
-        ulong rawSeed = factAttribute.GetNamedArgument<ulong>("Seed");
-        ulong? seed = rawSeed == 0UL ? null : rawSeed;
-
-        bool useDatabase = factAttribute.GetNamedArgument<bool>("UseDatabase");
-        int maxStrategyRejections = factAttribute.GetNamedArgument<int>("MaxStrategyRejections");
-        if (maxStrategyRejections <= 0) { maxStrategyRejections = 5; }
-        int deadlineMs = factAttribute.GetNamedArgument<int>("DeadlineMs");
-        bool targeting = factAttribute.GetNamedArgument<bool>("Targeting");
-        double targetingProportion = factAttribute.GetNamedArgument<double>("TargetingProportion");
-        bool exportReproOnFailure = factAttribute.GetNamedArgument<bool>("ExportReproOnFailure");
-        string reproOutputPath = factAttribute.GetNamedArgument<string>("ReproOutputPath") ?? ".conjecture/repros/";
+        int maxExamples = adapter.MaxExamples > 0 ? adapter.MaxExamples : 100;
+        ulong? seed = adapter.Seed != 0UL ? adapter.Seed : null;
+        bool useDatabase = adapter.UseDatabase;
+        int maxStrategyRejections = adapter.MaxStrategyRejections > 0 ? adapter.MaxStrategyRejections : 5;
+        int deadlineMs = adapter.DeadlineMs;
+        bool targeting = adapter.Targeting;
+        double targetingProportion = adapter.TargetingProportion;
+        bool exportReproOnFailure = adapter.ExportReproOnFailure;
+        string reproOutputPath = adapter.ReproOutputPath;
 
         yield return new PropertyTestCase(
             diagnosticMessageSink,

--- a/src/Conjecture.Xunit/PropertyAttribute.cs
+++ b/src/Conjecture.Xunit/PropertyAttribute.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using Conjecture.Core;
+
 using Xunit;
 using Xunit.Sdk;
 
@@ -9,7 +11,7 @@ namespace Conjecture.Xunit;
 /// <summary>Marks a method as a Conjecture property-based test.</summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 [XunitTestCaseDiscoverer("Conjecture.Xunit.Internal.PropertyTestCaseDiscoverer", "Conjecture.Xunit")]
-public sealed class PropertyAttribute : FactAttribute
+public sealed class PropertyAttribute : FactAttribute, IPropertyTest, IReproductionExport
 {
     /// <summary>Maximum number of examples to generate. Defaults to 100.</summary>
     public int MaxExamples { get; set; } = 100;


### PR DESCRIPTION
## Summary

- Adds `PropertyStrategyRegistryGenerator` (Roslyn `IIncrementalGenerator`) that emits `ConjectureStrategyRegistry.g.cs` at compile time — a `[ModuleInitializer]` registers a type-switch factory over all `IStrategyProvider<T>` implementations visible to the user's assembly, enabling NativeAOT-safe parameter injection without reflection
- Adds `ConjectureStrategyRegistrar` to Core with a public 1-arg `Register(Func<Type, object?>)` for generated code and an internal 2-arg overload for tests; `TryResolve` is consulted first in `SharedParameterStrategyResolver`
- Adds `IGeneratableStrategy` internal bridge interface so generated code can call `Strategy<T>.Generate(data)` through a boxed reference without exposing `ConjectureData` publicly
- Adds `IPropertyTest` and `IReproductionExport` (getter-only) to Core; all four framework `PropertyAttribute` classes implement them, enabling type-safe attribute detection in the generator and analyzer (replaces string-based `ContainingType.Name` check)
- Adds `ConjectureSettings.From(IPropertyTest, ILogger?)` factory, eliminating duplicated 7-field settings construction across MSTest, NUnit, and xunit adapters
- Adds `AttributeInfoPropertyTestAdapter` for xUnit v2, wrapping `IAttributeInfo` to implement `IPropertyTest`/`IReproductionExport` and replacing 9 raw `GetNamedArgument<T>` calls in the discoverer

## Test plan

- [x] `dotnet build src/` — 0 warnings, 0 errors
- [x] `dotnet test src/ --filter "FullyQualifiedName~ConjectureStrategyRegistrar|FullyQualifiedName~PropertyStrategyRegistry"` — 10 tests green
- [x] `dotnet test src/` — full suite green (1504 tests)

Closes #179 
Closes #78 