### PR TITLE
[75.1] ConjectureData: factory for deterministic replay from fixed byte[]

### DIFF
--- a/src/Conjecture.Core.Tests/Internal/ConjectureDataBufferReplayTests.cs
+++ b/src/Conjecture.Core.Tests/Internal/ConjectureDataBufferReplayTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Internal;
+
+public class ConjectureDataBufferReplayTests
+{
+    [Fact]
+    public void NextBytes_FirstCall_ReturnsExpectedSlice()
+    {
+        byte[] buffer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        ConjectureData data = ConjectureData.FromBuffer(buffer);
+
+        byte[] result = data.NextBytes(4);
+
+        Assert.Equal([0x01, 0x02, 0x03, 0x04], result);
+    }
+
+    [Fact]
+    public void NextBytes_SecondCall_ReturnsNextSlice()
+    {
+        byte[] buffer = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        ConjectureData data = ConjectureData.FromBuffer(buffer);
+
+        data.NextBytes(4);
+        byte[] second = data.NextBytes(4);
+
+        Assert.Equal([0x05, 0x06, 0x07, 0x08], second);
+    }
+
+    [Fact]
+    public void FromBuffer_TwoInstances_ProduceSameSequence()
+    {
+        byte[] buffer = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+
+        ConjectureData first = ConjectureData.FromBuffer(buffer);
+        ConjectureData second = ConjectureData.FromBuffer(buffer);
+
+        byte[] firstA = first.NextBytes(3);
+        byte[] firstB = first.NextBytes(3);
+
+        byte[] secondA = second.NextBytes(3);
+        byte[] secondB = second.NextBytes(3);
+
+        Assert.Equal(firstA, secondA);
+        Assert.Equal(firstB, secondB);
+    }
+
+    [Fact]
+    public void NextBytes_AfterBufferExhausted_ReturnsZeros()
+    {
+        byte[] buffer = [0x01, 0x02];
+        ConjectureData data = ConjectureData.FromBuffer(buffer);
+
+        data.NextBytes(2); // consumes all bytes
+
+        byte[] overflow = data.NextBytes(4);
+
+        Assert.Equal([0x00, 0x00, 0x00, 0x00], overflow);
+    }
+
+    [Fact]
+    public void NextBytes_PartiallyExhausted_PadsWithZeros()
+    {
+        byte[] buffer = [0x11, 0x22, 0x33];
+        ConjectureData data = ConjectureData.FromBuffer(buffer);
+
+        data.NextBytes(2); // consumes 0x11, 0x22
+
+        byte[] result = data.NextBytes(4); // only 0x33 remains
+
+        Assert.Equal([0x33, 0x00, 0x00, 0x00], result);
+    }
+
+    [Fact]
+    public void NextBytes_EmptyBuffer_AlwaysReturnsZeros()
+    {
+        ConjectureData data = ConjectureData.FromBuffer([]);
+
+        byte[] result = data.NextBytes(3);
+
+        Assert.Equal([0x00, 0x00, 0x00], result);
+    }
+
+    [Fact]
+    public void Status_RemainsValid_AfterBufferExhausted()
+    {
+        ConjectureData data = ConjectureData.FromBuffer([0x01]);
+
+        data.NextBytes(1);
+        data.NextBytes(4); // beyond buffer
+
+        Assert.Equal(Status.Valid, data.Status);
+    }
+
+    [Fact]
+    public void IRNodes_RecordsEachNextBytesCall()
+    {
+        byte[] buffer = [0x01, 0x02, 0x03, 0x04];
+        ConjectureData data = ConjectureData.FromBuffer(buffer);
+
+        data.NextBytes(2);
+        data.NextBytes(2);
+
+        Assert.Equal(2, data.IRNodes.Count);
+        Assert.All(data.IRNodes, n => Assert.Equal(IRNodeKind.Bytes, n.Kind));
+    }
+
+    [Fact]
+    public void NextInteger_KnownBuffer_ReturnsValueDerivedFromBytes()
+    {
+        // Buffer encodes raw ulong 6 (little-endian).
+        // PrngAdapter.NextUInt64(rng, max=9): threshold = (ulong.MaxValue - 9) % 10 = 6.
+        // x=6 >= threshold=6, so result = 6 % 10 = 6; final = 6 + min(0) = 6.
+        byte[] buffer = [0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        ConjectureData data = ConjectureData.FromBuffer(buffer);
+
+        ulong result = data.NextInteger(min: 0, max: 9);
+
+        Assert.Equal(6UL, result);
+    }
+
+    [Fact]
+    public void FromBuffer_SecondInstanceFromSameArray_StartsFromByteZeroRegardlessOfFirstInstanceCursor()
+    {
+        byte[] buffer = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22];
+        ConjectureData first = ConjectureData.FromBuffer(buffer);
+
+        first.NextBytes(6); // advance first instance's cursor
+
+        ConjectureData second = ConjectureData.FromBuffer(buffer);
+        byte[] secondResult = second.NextBytes(4);
+
+        Assert.Equal([0xAA, 0xBB, 0xCC, 0xDD], secondResult);
+    }
+}

--- a/src/Conjecture.Core/Internal/BufferRandom.cs
+++ b/src/Conjecture.Core/Internal/BufferRandom.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Runtime.InteropServices;
+
+namespace Conjecture.Core.Internal;
+
+internal sealed class BufferRandom : IRandom
+{
+    private readonly byte[] buffer;
+    private int position;
+
+    internal BufferRandom(byte[] buffer) => this.buffer = buffer;
+
+    public ulong NextUInt64()
+    {
+        Span<byte> scratch = stackalloc byte[8];
+        NextBytes(scratch);
+        return MemoryMarshal.Read<ulong>(scratch);
+    }
+
+    public void NextBytes(Span<byte> output)
+    {
+        int available = buffer.Length - position;
+        int fromBuffer = Math.Min(available, output.Length);
+        if (fromBuffer > 0)
+        {
+            buffer.AsSpan(position, fromBuffer).CopyTo(output);
+            position += fromBuffer;
+        }
+
+        output[fromBuffer..].Clear();
+    }
+
+    public IRandom Split() => new BufferRandom(buffer);
+}

--- a/src/Conjecture.Core/Internal/ConjectureData.cs
+++ b/src/Conjecture.Core/Internal/ConjectureData.cs
@@ -27,6 +27,7 @@ internal sealed class ConjectureData
 
     internal static ConjectureData ForGeneration(IRandom rng) => new(rng);
     internal static ConjectureData ForRecord(IReadOnlyList<IRNode> nodes) => new(nodes);
+    internal static ConjectureData FromBuffer(byte[] buffer) => new(new BufferRandom(buffer));
 
     internal ulong NextInteger(ulong min, ulong max)
     {


### PR DESCRIPTION
## Description

Adds `ConjectureData.FromBuffer(byte[])` — an internal factory that drives draws from a fixed `byte[]` rather than the RNG, enabling deterministic round-trip replay of `ExportReproOnFailure` output.

- New `BufferRandom : IRandom` reads bytes sequentially from the buffer, zero-pads when exhausted, and returns an independent cursor-reset copy from `Split()`
- One-line addition to `ConjectureData` wires it up alongside `ForGeneration` and `ForRecord`
- No public API surface; no `PublicAPI.Unshipped.txt` change needed

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #163
Part of #75