### PR TITLE
[75.2] Generate.FromBytes<T>: public span-accepting factory and strategy

### DIFF
--- a/src/Conjecture.Core.Tests/GenerateFromBytesTests.cs
+++ b/src/Conjecture.Core.Tests/GenerateFromBytesTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests;
+
+public class GenerateFromBytesTests
+{
+    [Fact]
+    public void FromBytes_ReturnsNonNullStrategy()
+    {
+        byte[] buffer = [0x01, 0x02, 0x03, 0x04];
+
+        Strategy<int> strategy = Generate.FromBytes<int>(buffer);
+
+        Assert.NotNull(strategy);
+    }
+
+    [Fact]
+    public void FromBytes_IsDeterministic_SameBufferProducesSameValue()
+    {
+        byte[] buffer = [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04];
+
+        Strategy<int> strategy = Generate.FromBytes<int>(buffer);
+
+        ConjectureData dataA = ConjectureData.FromBuffer(buffer);
+        ConjectureData dataB = ConjectureData.FromBuffer(buffer);
+
+        int first = strategy.Generate(dataA);
+        int second = strategy.Generate(dataB);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void FromBytes_AcceptsImplicitByteArrayConversion()
+    {
+        byte[] buffer = [0x00, 0x00, 0x00, 0x2A];
+
+        // Passes byte[] where ReadOnlySpan<byte> is expected — implicit C# conversion must compile.
+        Strategy<int> strategy = Generate.FromBytes<int>(buffer);
+        ConjectureData data = ConjectureData.FromBuffer(buffer);
+
+        int value = strategy.Generate(data);
+
+        Assert.IsType<int>(value);
+    }
+
+    [Fact]
+    public void FromBytes_AcceptsStackallocSpan()
+    {
+        ReadOnlySpan<byte> span = stackalloc byte[4] { 0x01, 0x02, 0x03, 0x04 };
+
+        // stackalloc must be accepted — signature must be ReadOnlySpan<byte>.
+        Strategy<int> strategy = Generate.FromBytes<int>(span);
+
+        ConjectureData data = ConjectureData.FromBuffer(new byte[] { 0x01, 0x02, 0x03, 0x04 });
+        int value = strategy.Generate(data);
+
+        Assert.IsType<int>(value);
+    }
+
+    [Fact]
+    public void FromBytes_Label_IsNonNullAndDescriptive()
+    {
+        byte[] buffer = [0x01, 0x02, 0x03, 0x04];
+
+        Strategy<int> strategy = Generate.FromBytes<int>(buffer);
+
+        Assert.NotNull(strategy.Label);
+        Assert.False(string.IsNullOrWhiteSpace(strategy.Label));
+    }
+
+    [Fact]
+    public void FromBytes_IgnoresCallerData_ProducesSameValueForDifferentData()
+    {
+        byte[] strategyBuffer = [0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04];
+        Strategy<int> strategy = Generate.FromBytes<int>(strategyBuffer);
+
+        ConjectureData dataA = ConjectureData.FromBuffer([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+        ConjectureData dataB = ConjectureData.FromBuffer([0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8]);
+
+        int first = strategy.Generate(dataA);
+        int second = strategy.Generate(dataB);
+
+        Assert.Equal(first, second);
+    }
+}

--- a/src/Conjecture.Core/Gen.cs
+++ b/src/Conjecture.Core/Gen.cs
@@ -237,4 +237,11 @@ public static class Generate
         int maxMinor = 9,
         int maxPatch = 9)
         => new VersionStringStrategy(maxMajor, maxMinor, maxPatch);
+
+    /// <summary>
+    /// Creates a strategy that replays values from a fixed byte buffer.
+    /// Useful for deterministic seed replay and round-trip testing.
+    /// </summary>
+    public static Strategy<T> FromBytes<T>(ReadOnlySpan<byte> buffer)
+        => new Internal.FromBytesStrategy<T>(buffer, Internal.SharedParameterStrategyResolver.GetDefault<T>());
 }

--- a/src/Conjecture.Core/Internal/DefaultStrategy.cs
+++ b/src/Conjecture.Core/Internal/DefaultStrategy.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Conjecture.Core.Internal;
+
+internal sealed class DefaultStrategy<T> : Strategy<T>
+{
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "DefaultStrategy is only reachable through RequiresUnreferencedCode-annotated paths.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "DefaultStrategy is only reachable through RequiresDynamicCode-annotated paths.")]
+    internal override T Generate(ConjectureData data) =>
+        (T)SharedParameterStrategyResolver.GenerateValueForDefault(typeof(T), data);
+}

--- a/src/Conjecture.Core/Internal/FromBytesStrategy.cs
+++ b/src/Conjecture.Core/Internal/FromBytesStrategy.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core.Internal;
+
+internal sealed class FromBytesStrategy<T>(ReadOnlySpan<byte> buffer, Strategy<T> inner)
+    : Strategy<T>("FromBytes")
+{
+    private readonly byte[] buffer = buffer.ToArray();
+
+    internal override T Generate(ConjectureData data)
+    {
+        ConjectureData seeded = ConjectureData.FromBuffer(buffer);
+        return inner.Generate(seeded);
+    }
+}

--- a/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
+++ b/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
@@ -162,6 +162,11 @@ internal static class SharedParameterStrategyResolver
         return strategy.Generate(data)!;
     }
 
+    [RequiresUnreferencedCode("Accesses parameter type metadata via reflection; not trim-safe.")]
+    [RequiresDynamicCode("Uses MakeGenericMethod for typed strategy dispatch; not NativeAOT-safe.")]
+    internal static object GenerateValueForDefault(Type type, ConjectureData data) =>
+        GenerateValue(type, data);
+
     private static object GenerateValue(Type type, ConjectureData data)
     {
         return type switch
@@ -190,5 +195,12 @@ internal static class SharedParameterStrategyResolver
         Array values = Enum.GetValues(type);
         int idx = (int)data.NextInteger(0, (ulong)(values.Length - 1));
         return values.GetValue(idx)!;
+    }
+
+    internal static Strategy<T> GetDefault<T>() => DefaultStrategyCache<T>.Instance;
+
+    private static class DefaultStrategyCache<T>
+    {
+        internal static readonly DefaultStrategy<T> Instance = new();
     }
 }

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -17,6 +17,7 @@ static Conjecture.Core.Generate.DateOnlyValues() -> Conjecture.Core.Strategy<Sys
 static Conjecture.Core.Generate.DateOnlyValues(System.DateOnly min, System.DateOnly max) -> Conjecture.Core.Strategy<System.DateOnly>!
 static Conjecture.Core.Generate.DateTimeOffsets() -> Conjecture.Core.Strategy<System.DateTimeOffset>!
 static Conjecture.Core.Generate.DateTimeOffsets(System.DateTimeOffset min, System.DateTimeOffset max) -> Conjecture.Core.Strategy<System.DateTimeOffset>!
+static Conjecture.Core.Generate.FromBytes<T>(System.ReadOnlySpan<byte> buffer) -> Conjecture.Core.Strategy<T>!
 static Conjecture.Core.Generate.TimeOnlyValues() -> Conjecture.Core.Strategy<System.TimeOnly>!
 static Conjecture.Core.Generate.TimeOnlyValues(System.TimeOnly min, System.TimeOnly max) -> Conjecture.Core.Strategy<System.TimeOnly>!
 static Conjecture.Core.Generate.TimeSpans() -> Conjecture.Core.Strategy<System.TimeSpan>!


### PR DESCRIPTION
## Description

Adds `Generate.FromBytes<T>(ReadOnlySpan<byte>)` — the public entry point for deterministic byte-buffer replay, completing the feature started in #163.

- `FromBytesStrategy<T>` copies the span to `byte[]` at construction and ignores the engine's `ConjectureData` on each `Generate` call, always replaying from the stored buffer via `ConjectureData.FromBuffer`
- `DefaultStrategy<T>` wraps the reflection-based type dispatch with `[UnconditionalSuppressMessage]` (IL2026/IL3050) and is cached per-`T` via a static generic field to avoid per-call allocation
- `GenerateValueForDefault` exposes the annotated AOT surface for `DefaultStrategy<T>` to call through
- Public symbol declared in `PublicAPI.Unshipped.txt`

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #164
Part of #75