### PR TITLE
[67.1] Conjecture.Interactive: scaffold project and KernelExtension

### DIFF
--- a/src/Conjecture.Interactive.Tests/Conjecture.Interactive.Tests.csproj
+++ b/src/Conjecture.Interactive.Tests/Conjecture.Interactive.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.DotNet.Interactive" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Interactive\Conjecture.Interactive.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.Interactive.Tests/ConjectureKernelExtensionTests.cs
+++ b/src/Conjecture.Interactive.Tests/ConjectureKernelExtensionTests.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.IO;
+
+using Conjecture.Interactive;
+
+using Microsoft.DotNet.Interactive;
+
+namespace Conjecture.Interactive.Tests;
+
+public class ConjectureKernelExtensionTests
+{
+    [Fact]
+    public void ConjectureKernelExtension_ImplementsIKernelExtension()
+    {
+        Assert.True(typeof(IKernelExtension).IsAssignableFrom(typeof(ConjectureKernelExtension)));
+    }
+
+    [Fact]
+    public void ExtensionDib_ExistsInOutputDirectory()
+    {
+        string dibPath = Path.Combine(AppContext.BaseDirectory, "extension.dib");
+        Assert.True(File.Exists(dibPath), $"extension.dib not found at {dibPath}");
+    }
+
+    [Fact]
+    public async Task OnLoadAsync_CompletesWithoutThrowing()
+    {
+        ConjectureKernelExtension extension = new();
+        using CompositeKernel kernel = new();
+
+        await extension.OnLoadAsync(kernel);
+    }
+}

--- a/src/Conjecture.Interactive/Conjecture.Interactive.csproj
+++ b/src/Conjecture.Interactive/Conjecture.Interactive.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Interactive" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Packed into interactive-extensions/dotnet so Polyglot auto-loads on #r nuget: -->
+    <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
+    <!-- Also copy to output so the test can find it -->
+    <Content Include="extension.dib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.Interactive/ConjectureKernelExtension.cs
+++ b/src/Conjecture.Interactive/ConjectureKernelExtension.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.IO;
+using System.Threading.Tasks;
+
+using Conjecture.Core;
+
+using Microsoft.DotNet.Interactive;
+using Microsoft.DotNet.Interactive.Formatting;
+
+namespace Conjecture.Interactive;
+
+/// <summary>Registers Conjecture formatters with the .NET Interactive kernel.</summary>
+public sealed class ConjectureKernelExtension : IKernelExtension
+{
+    /// <summary>Registers HTML formatters for Conjecture types and completes.</summary>
+    public Task OnLoadAsync(Kernel kernel)
+    {
+        Formatter.Register(
+            typeof(Strategy<>),
+            static (object obj, TextWriter writer) => writer.Write(StrategyHtmlFormatter.Format(obj)),
+            HtmlFormatter.MimeType);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Conjecture.Interactive/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Interactive/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.Interactive/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Interactive/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+#nullable enable
+Conjecture.Interactive.ConjectureKernelExtension
+Conjecture.Interactive.ConjectureKernelExtension.ConjectureKernelExtension() -> void
+Conjecture.Interactive.ConjectureKernelExtension.OnLoadAsync(Microsoft.DotNet.Interactive.Kernel! kernel) -> System.Threading.Tasks.Task!

--- a/src/Conjecture.Interactive/StrategyHtmlFormatter.cs
+++ b/src/Conjecture.Interactive/StrategyHtmlFormatter.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Interactive;
+
+internal static class StrategyHtmlFormatter
+{
+    internal static string Format(object _) => string.Empty;
+}

--- a/src/Conjecture.Interactive/extension.dib
+++ b/src/Conjecture.Interactive/extension.dib
@@ -1,0 +1,6 @@
+#!meta
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp"}]}}
+
+#!csharp
+await new Conjecture.Interactive.ConjectureKernelExtension()
+    .OnLoadAsync(Microsoft.DotNet.Interactive.Kernel.Root);

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -24,4 +24,6 @@
   <Project Path="Conjecture.Tool.Tests/Conjecture.Tool.Tests.csproj" />
   <Project Path="Conjecture.Time/Conjecture.Time.csproj" />
   <Project Path="Conjecture.Time.Tests/Conjecture.Time.Tests.csproj" />
+  <Project Path="Conjecture.Interactive/Conjecture.Interactive.csproj" />
+  <Project Path="Conjecture.Interactive.Tests/Conjecture.Interactive.Tests.csproj" />
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -51,6 +51,9 @@
     <!-- Logging -->
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
 
+    <!-- .NET Interactive -->
+    <PackageVersion Include="Microsoft.DotNet.Interactive" Version="1.0.0-beta.26120.1" />
+
     <!-- MCP server -->
     <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />


### PR DESCRIPTION
## Description

Scaffolds the `Conjecture.Interactive` NuGet package for Polyglot Notebooks support.

- `ConjectureKernelExtension` implements `IKernelExtension`, registering a `text/html` formatter for the open generic `Strategy<>` on kernel load
- `extension.dib` is packed to `interactive-extensions/dotnet` — the modern Polyglot auto-load mechanism on `#r nuget:` (the `[assembly: KernelExtension]` attribute approach was removed from `Microsoft.DotNet.Interactive` in favour of this `.dib` pattern)
- `StrategyHtmlFormatter.Format` is a stub returning `string.Empty` — the real rendering lands in cycles 67.2–67.4
- `Microsoft.DotNet.Interactive 1.0.0-beta.26120.1` added to `Directory.Packages.props`

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #157
Part of #67