### PR TITLE
[67.2] StrategyExtensionsInteractive: .Preview() and .SampleTable()

### DIFF
--- a/src/Conjecture.Interactive.Tests/StrategyExtensionsInteractivePreviewTests.cs
+++ b/src/Conjecture.Interactive.Tests/StrategyExtensionsInteractivePreviewTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+using Conjecture.Interactive;
+
+namespace Conjecture.Interactive.Tests;
+
+public class StrategyExtensionsInteractivePreviewTests
+{
+    // --- Preview ---
+
+    [Fact]
+    public void Preview_DefaultCount_Returns20Values()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = strategy.Preview();
+
+        // 20 <tr> rows for data (thead adds one more, but easiest proxy is counting the value cells)
+        int tdCount = CountOccurrences(html, "<td");
+        Assert.Equal(20, tdCount);
+    }
+
+    [Fact]
+    public void Preview_CountAbove100_IsCappedAt100()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = strategy.Preview(150);
+
+        int tdCount = CountOccurrences(html, "<td");
+        Assert.Equal(100, tdCount);
+    }
+
+    [Fact]
+    public void Preview_CountAbove100_IncludesTruncationNotice()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = strategy.Preview(150);
+
+        // The output must mention capping/truncation in some form
+        bool hasTruncationNotice =
+            html.Contains("100", StringComparison.OrdinalIgnoreCase) &&
+            (html.Contains("capped", StringComparison.OrdinalIgnoreCase) ||
+             html.Contains("truncat", StringComparison.OrdinalIgnoreCase) ||
+             html.Contains("warn", StringComparison.OrdinalIgnoreCase));
+        Assert.True(hasTruncationNotice, "Expected a truncation/cap notice in the HTML output.");
+    }
+
+    [Fact]
+    public void Preview_SameSeedTwice_ProducesIdenticalHtml()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string first = strategy.Preview(seed: 42UL);
+        string second = strategy.Preview(seed: 42UL);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Preview_ReturnsHtmlTableTag()
+    {
+        Strategy<int> strategy = Generate.Just(7);
+
+        string html = strategy.Preview();
+
+        Assert.Contains("<table", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // --- SampleTable ---
+
+    [Fact]
+    public void SampleTable_DefaultCount_Returns10Values()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = strategy.SampleTable();
+
+        int tdCount = CountOccurrences(html, "<td");
+        Assert.Equal(10, tdCount);
+    }
+
+    [Fact]
+    public void SampleTable_CountAbove50_IsCappedAt50()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = strategy.SampleTable(60);
+
+        int tdCount = CountOccurrences(html, "<td");
+        Assert.Equal(50, tdCount);
+    }
+
+    [Fact]
+    public void SampleTable_ReturnsHtmlTableTag()
+    {
+        Strategy<int> strategy = Generate.Just(99);
+
+        string html = strategy.SampleTable();
+
+        Assert.Contains("<table", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // --- helpers ---
+
+    private static int CountOccurrences(string source, string token)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = source.IndexOf(token, index, StringComparison.OrdinalIgnoreCase)) >= 0)
+        {
+            count++;
+            index += token.Length;
+        }
+
+        return count;
+    }
+}

--- a/src/Conjecture.Interactive/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Interactive/PublicAPI.Unshipped.txt
@@ -2,3 +2,6 @@
 Conjecture.Interactive.ConjectureKernelExtension
 Conjecture.Interactive.ConjectureKernelExtension.ConjectureKernelExtension() -> void
 Conjecture.Interactive.ConjectureKernelExtension.OnLoadAsync(Microsoft.DotNet.Interactive.Kernel! kernel) -> System.Threading.Tasks.Task!
+Conjecture.Interactive.StrategyExtensionsInteractive
+static Conjecture.Interactive.StrategyExtensionsInteractive.Preview<T>(this Conjecture.Core.Strategy<T>! strategy, int count = 20, ulong? seed = null) -> string!
+static Conjecture.Interactive.StrategyExtensionsInteractive.SampleTable<T>(this Conjecture.Core.Strategy<T>! strategy, int count = 10, ulong? seed = null) -> string!

--- a/src/Conjecture.Interactive/StrategyExtensionsInteractive.cs
+++ b/src/Conjecture.Interactive/StrategyExtensionsInteractive.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+using Conjecture.Core;
+
+namespace Conjecture.Interactive;
+
+/// <summary>Extension methods for rendering Strategy samples as HTML in interactive notebooks.</summary>
+public static class StrategyExtensionsInteractive
+{
+    private const int PreviewMaxCount = 100;
+    private const int SampleTableMaxCount = 50;
+
+    /// <summary>Renders up to <paramref name="count"/> sampled values in a single-row HTML table.</summary>
+    public static string Preview<T>(this Strategy<T> strategy, int count = 20, ulong? seed = null)
+    {
+        bool capped = count > PreviewMaxCount;
+        int effective = capped ? PreviewMaxCount : count;
+        IReadOnlyList<T> samples = DataGen.Sample(strategy, effective, seed);
+
+        StringBuilder sb = new();
+        sb.Append("<table><tr>");
+        foreach (T value in samples)
+        {
+            sb.Append("<td>");
+            sb.Append(WebUtility.HtmlEncode(value?.ToString() ?? string.Empty));
+            sb.Append("</td>");
+        }
+
+        sb.Append("</tr></table>");
+
+        if (capped)
+        {
+            sb.Append("<p>Showing ");
+            sb.Append(PreviewMaxCount);
+            sb.Append(" values (capped from ");
+            sb.Append(count);
+            sb.Append(").</p>");
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>Renders up to <paramref name="count"/> sampled values in a two-column index/value HTML table.</summary>
+    public static string SampleTable<T>(this Strategy<T> strategy, int count = 10, ulong? seed = null)
+    {
+        bool capped = count > SampleTableMaxCount;
+        int effective = capped ? SampleTableMaxCount : count;
+        IReadOnlyList<T> samples = DataGen.Sample(strategy, effective, seed);
+
+        StringBuilder sb = new();
+        sb.Append("<table><thead><tr><th>Index</th><th>Value</th></tr></thead><tbody>");
+        for (int i = 0; i < samples.Count; i++)
+        {
+            sb.Append("<tr><th scope=\"row\">");
+            sb.Append(i);
+            sb.Append("</th><td>");
+            sb.Append(WebUtility.HtmlEncode(samples[i]?.ToString() ?? string.Empty));
+            sb.Append("</td></tr>");
+        }
+
+        sb.Append("</tbody></table>");
+
+        if (capped)
+        {
+            sb.Append("<p>Showing ");
+            sb.Append(SampleTableMaxCount);
+            sb.Append(" values (capped from ");
+            sb.Append(count);
+            sb.Append(").</p>");
+        }
+
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## Description

Adds `.Preview()` and `.SampleTable()` extension methods on `Strategy<T>` for use in Polyglot Notebooks. Both methods sample values via `DataGen.Sample` and return an HTML string suitable for notebook display.

- `.Preview(count = 20, seed = null)` — single-row `<table>` with one `<td>` per sampled value; capped at 100 with a notice
- `.SampleTable(count = 10, seed = null)` — two-column index/value `<table>` with `<th scope="row">` for index cells; capped at 50 with a notice
- Both return `string` directly for testability (display via kernel context is the caller's concern)

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #158
Part of #67