### PR TITLE
[67.3] StrategyExtensionsInteractive: .Histogram() with SVG renderer

### DIFF
--- a/src/Conjecture.Interactive.Tests/StrategyExtensionsInteractiveHistogramTests.cs
+++ b/src/Conjecture.Interactive.Tests/StrategyExtensionsInteractiveHistogramTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+namespace Conjecture.Interactive.Tests;
+
+public class StrategyExtensionsInteractiveHistogramTests
+{
+    [Fact]
+    public void Histogram_DoubleStrategy_ReturnsSvgString()
+    {
+        Strategy<double> strategy = Generate.Doubles(0.0, 100.0);
+
+        string svg = strategy.Histogram(sampleSize: 200, seed: 1UL);
+
+        Assert.Contains("<svg", svg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Histogram_IntStrategy_ReturnsSvgString()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+
+        string svg = strategy.Histogram(sampleSize: 200, seed: 1UL);
+
+        Assert.Contains("<svg", svg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Histogram_SelectorOverload_ReturnsSvgString()
+    {
+        Strategy<string> strategy = Generate.Strings(minLength: 1, maxLength: 20);
+
+        string svg = strategy.Histogram(static x => (double)x.Length, sampleSize: 200, seed: 1UL);
+
+        Assert.Contains("<svg", svg, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Conjecture.Interactive.Tests/SvgHistogramTests.cs
+++ b/src/Conjecture.Interactive.Tests/SvgHistogramTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+
+namespace Conjecture.Interactive.Tests;
+
+public class SvgHistogramTests
+{
+    // A spread across 20 buckets: 20 evenly-spaced values from 0.5 to 19.5
+    // ensures each bucket [0,1), [1,2), … [19,20) gets exactly one hit.
+    private static IReadOnlyList<double> SpreadAcross20Buckets()
+    {
+        double[] values = new double[20];
+        for (int i = 0; i < 20; i++)
+        {
+            values[i] = i + 0.5;
+        }
+
+        return values;
+    }
+
+    [Fact]
+    public void Render_AnyInput_OutputContainsSvgTag()
+    {
+        IReadOnlyList<double> values = SpreadAcross20Buckets();
+
+        string svg = SvgHistogram.Render(values);
+
+        Assert.Contains("<svg", svg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Render_ValuesSpreadAcrossAllBuckets_ContainsExactlyBucketCountRects()
+    {
+        IReadOnlyList<double> values = SpreadAcross20Buckets();
+        int bucketCount = 20;
+
+        string svg = SvgHistogram.Render(values, bucketCount);
+
+        int rectCount = CountOccurrences(svg, "<rect");
+        Assert.Equal(bucketCount, rectCount);
+    }
+
+    [Fact]
+    public void Render_AllSameValue_DoesNotThrow()
+    {
+        IReadOnlyList<double> values = [5.0, 5.0, 5.0, 5.0, 5.0];
+
+        string svg = SvgHistogram.Render(values);
+
+        Assert.NotNull(svg);
+    }
+
+    [Fact]
+    public void Render_EmptyInput_DoesNotThrow()
+    {
+        IReadOnlyList<double> values = [];
+
+        string svg = SvgHistogram.Render(values);
+
+        Assert.NotNull(svg);
+    }
+
+    private static int CountOccurrences(string source, string token)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = source.IndexOf(token, index, StringComparison.OrdinalIgnoreCase)) >= 0)
+        {
+            count++;
+            index += token.Length;
+        }
+
+        return count;
+    }
+}

--- a/src/Conjecture.Interactive/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Interactive/PublicAPI.Unshipped.txt
@@ -5,3 +5,7 @@ Conjecture.Interactive.ConjectureKernelExtension.OnLoadAsync(Microsoft.DotNet.In
 Conjecture.Interactive.StrategyExtensionsInteractive
 static Conjecture.Interactive.StrategyExtensionsInteractive.Preview<T>(this Conjecture.Core.Strategy<T>! strategy, int count = 20, ulong? seed = null) -> string!
 static Conjecture.Interactive.StrategyExtensionsInteractive.SampleTable<T>(this Conjecture.Core.Strategy<T>! strategy, int count = 10, ulong? seed = null) -> string!
+Conjecture.Interactive.SvgHistogram
+static Conjecture.Interactive.SvgHistogram.Render(System.Collections.Generic.IReadOnlyList<double>! values, int bucketCount = 20) -> string!
+static Conjecture.Interactive.StrategyExtensionsInteractive.Histogram<T>(this Conjecture.Core.Strategy<T>! strategy, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null) -> string!
+static Conjecture.Interactive.StrategyExtensionsInteractive.Histogram<T>(this Conjecture.Core.Strategy<T>! strategy, System.Func<T, double>! selector, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null) -> string!

--- a/src/Conjecture.Interactive/StrategyExtensionsInteractive.cs
+++ b/src/Conjecture.Interactive/StrategyExtensionsInteractive.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
@@ -76,4 +77,33 @@ public static class StrategyExtensionsInteractive
 
         return sb.ToString();
     }
+
+#pragma warning disable RS0026 // multiple overloads with optional parameters
+    /// <summary>Renders a histogram SVG of sampled values from <paramref name="strategy"/>.</summary>
+    public static string Histogram<T>(this Strategy<T> strategy, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null)
+        where T : IConvertible
+    {
+        IReadOnlyList<T> samples = DataGen.Sample(strategy, sampleSize, seed);
+        List<double> doubles = new(samples.Count);
+        foreach (T value in samples)
+        {
+            doubles.Add(Convert.ToDouble(value));
+        }
+
+        return SvgHistogram.Render(doubles, bucketCount);
+    }
+
+    /// <summary>Renders a histogram SVG of sampled values projected by <paramref name="selector"/>.</summary>
+    public static string Histogram<T>(this Strategy<T> strategy, Func<T, double> selector, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null)
+    {
+        IReadOnlyList<T> samples = DataGen.Sample(strategy, sampleSize, seed);
+        List<double> doubles = new(samples.Count);
+        foreach (T value in samples)
+        {
+            doubles.Add(selector(value));
+        }
+
+        return SvgHistogram.Render(doubles, bucketCount);
+    }
+#pragma warning restore RS0026
 }

--- a/src/Conjecture.Interactive/SvgHistogram.cs
+++ b/src/Conjecture.Interactive/SvgHistogram.cs
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Conjecture.Interactive;
+
+/// <summary>Renders a histogram of numeric values as an SVG string.</summary>
+public static class SvgHistogram
+{
+    private const int SvgWidth = 400;
+    private const int SvgHeight = 150;
+
+    /// <summary>Renders a histogram of <paramref name="values"/> as an SVG string.</summary>
+    public static string Render(IReadOnlyList<double> values, int bucketCount = 20)
+    {
+        if (values.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        double min = values[0];
+        double max = values[0];
+        foreach (double v in values)
+        {
+            if (v < min)
+            {
+                min = v;
+            }
+
+            if (v > max)
+            {
+                max = v;
+            }
+        }
+
+        double effectiveMax = min == max ? min + 1.0 : max;
+
+        int[] counts = new int[bucketCount];
+        double range = effectiveMax - min;
+
+        foreach (double v in values)
+        {
+            int bucket = (int)((v - min) / range * bucketCount);
+            if (bucket >= bucketCount)
+            {
+                bucket = bucketCount - 1;
+            }
+
+            counts[bucket]++;
+        }
+
+        int maxCount = 0;
+        foreach (int c in counts)
+        {
+            if (c > maxCount)
+            {
+                maxCount = c;
+            }
+        }
+
+        double barWidth = (double)SvgWidth / bucketCount;
+
+        StringBuilder sb = new();
+        sb.Append("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"");
+        sb.Append(SvgWidth);
+        sb.Append("\" height=\"");
+        sb.Append(SvgHeight);
+        sb.Append("\">");
+
+        for (int i = 0; i < bucketCount; i++)
+        {
+            if (counts[i] == 0)
+            {
+                continue;
+            }
+
+            double barHeight = (double)counts[i] / maxCount * SvgHeight;
+            double x = i * barWidth;
+            double y = SvgHeight - barHeight;
+            double bucketMin = min + i * range / bucketCount;
+            double bucketMax = min + (i + 1) * range / bucketCount;
+
+            sb.Append("<rect x=\"");
+            sb.Append(x.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" y=\"");
+            sb.Append(y.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" width=\"");
+            sb.Append(barWidth.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" height=\"");
+            sb.Append(barHeight.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" fill=\"steelblue\">");
+            sb.Append("<title>");
+            sb.Append(bucketMin.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append(" – ");
+            sb.Append(bucketMax.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append(": ");
+            sb.Append(counts[i]);
+            sb.Append("</title></rect>");
+        }
+
+        sb.Append("</svg>");
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## Description

Adds `.Histogram()` extension methods on `Strategy<T>` for Polyglot Notebook use, backed by a new `SvgHistogram` helper that renders inline SVG bar charts.

- `SvgHistogram.Render(IReadOnlyList<double>, int bucketCount = 20)` — 400×150 SVG with steelblue bars and `<title>` tooltips; handles empty and all-same-value inputs without throwing
- `.Histogram<T>(sampleSize, bucketCount, seed)` — `IConvertible` constraint, projects via `Convert.ToDouble`
- `.Histogram<T>(Func<T, double> selector, ...)` — selector overload for non-numeric `T` (e.g. `Strategy<string>` with `x => x.Length`)
- RS0026 suppressed on both overloads — signatures are genuinely distinct (required `selector` param vs. constraint)

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #159
Part of #67