### PR TITLE
[67.4] StrategyExtensionsInteractive: .ShrinkTrace()

### DIFF
--- a/src/Conjecture.Core/Conjecture.Core.csproj
+++ b/src/Conjecture.Core/Conjecture.Core.csproj
@@ -76,6 +76,12 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Conjecture.SelfTests</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Conjecture.Interactive</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Conjecture.Interactive.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/src/Conjecture.Interactive.Tests/StrategyExtensionsInteractiveShrinkTraceTests.cs
+++ b/src/Conjecture.Interactive.Tests/StrategyExtensionsInteractiveShrinkTraceTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+
+using Conjecture.Core;
+
+namespace Conjecture.Interactive.Tests;
+
+public class StrategyExtensionsInteractiveShrinkTraceTests
+{
+    [Fact]
+    public void ShrinkTrace_PropertyPassesOnGeneratedValue_ThrowsArgumentException()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(0, 100);
+        ulong seed = FindSeedProducingValueBelow10(strategy);
+
+        // property returns false = value is NOT a counterexample, so nothing to shrink
+        Assert.Throws<ArgumentException>(
+            () => strategy.ShrinkTrace(seed, static x => x >= 10));
+    }
+
+    [Fact]
+    public void ShrinkTrace_NonTrivialShrink_ReturnsAtLeastOneStep()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(0, 100);
+        ulong seed = FindSeedProducingValueAtLeast10(strategy);
+
+        ShrinkTraceResult<int> result = strategy.ShrinkTrace(seed, static x => x >= 10);
+
+        Assert.True(result.Steps.Count >= 1, "Expected at least one shrink step.");
+    }
+
+    [Fact]
+    public void ShrinkTrace_FinalStep_ValueSatisfiesFailingProperty()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(0, 100);
+        ulong seed = FindSeedProducingValueAtLeast10(strategy);
+
+        ShrinkTraceResult<int> result = strategy.ShrinkTrace(seed, static x => x >= 10);
+
+        int finalValue = result.Steps[result.Steps.Count - 1].Value;
+        Assert.True(finalValue >= 10, $"Final shrunk value {finalValue} should satisfy the failing property (>= 10).");
+    }
+
+    [Fact]
+    public void ShrinkTrace_HtmlOutput_ContainsTableTag()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(0, 100);
+        ulong seed = FindSeedProducingValueAtLeast10(strategy);
+
+        ShrinkTraceResult<int> result = strategy.ShrinkTrace(seed, static x => x >= 10);
+
+        Assert.Contains("<table", result.Html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ulong FindSeedProducingValueAtLeast10(Strategy<int> strategy)
+    {
+        for (ulong seed = 0UL; seed < 10_000UL; seed++)
+        {
+            int value = DataGen.SampleOne(strategy, seed);
+            if (value >= 10)
+            {
+                return seed;
+            }
+        }
+
+        throw new InvalidOperationException("Could not find a seed that produces a value >= 10 within 10000 tries.");
+    }
+
+    private static ulong FindSeedProducingValueBelow10(Strategy<int> strategy)
+    {
+        for (ulong seed = 0UL; seed < 10_000UL; seed++)
+        {
+            int value = DataGen.SampleOne(strategy, seed);
+            if (value < 10)
+            {
+                return seed;
+            }
+        }
+
+        throw new InvalidOperationException("Could not find a seed that produces a value < 10 within 10000 tries.");
+    }
+}

--- a/src/Conjecture.Interactive/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Interactive/PublicAPI.Unshipped.txt
@@ -9,3 +9,13 @@ Conjecture.Interactive.SvgHistogram
 static Conjecture.Interactive.SvgHistogram.Render(System.Collections.Generic.IReadOnlyList<double>! values, int bucketCount = 20) -> string!
 static Conjecture.Interactive.StrategyExtensionsInteractive.Histogram<T>(this Conjecture.Core.Strategy<T>! strategy, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null) -> string!
 static Conjecture.Interactive.StrategyExtensionsInteractive.Histogram<T>(this Conjecture.Core.Strategy<T>! strategy, System.Func<T, double>! selector, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null) -> string!
+Conjecture.Interactive.ShrinkStep<T>
+Conjecture.Interactive.ShrinkStep<T>.ShrinkStep() -> void
+Conjecture.Interactive.ShrinkStep<T>.ShrinkStep(T Value) -> void
+Conjecture.Interactive.ShrinkStep<T>.Value.get -> T
+Conjecture.Interactive.ShrinkStep<T>.Value.init -> void
+Conjecture.Interactive.ShrinkTraceResult<T>
+Conjecture.Interactive.ShrinkTraceResult<T>.Html.get -> string!
+Conjecture.Interactive.ShrinkTraceResult<T>.Steps.get -> System.Collections.Generic.IReadOnlyList<Conjecture.Interactive.ShrinkStep<T>>!
+Conjecture.Interactive.ShrinkTraceResult<T>.ShrinkTraceResult(System.Collections.Generic.IReadOnlyList<Conjecture.Interactive.ShrinkStep<T>>! steps, string! html) -> void
+static Conjecture.Interactive.StrategyExtensionsInteractive.ShrinkTrace<T>(this Conjecture.Core.Strategy<T>! strategy, ulong seed, System.Func<T, bool>! failingProperty) -> Conjecture.Interactive.ShrinkTraceResult<T>!

--- a/src/Conjecture.Interactive/ShrinkStep.cs
+++ b/src/Conjecture.Interactive/ShrinkStep.cs
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Interactive;
+
+/// <summary>A single step in a shrink trace.</summary>
+public readonly record struct ShrinkStep<T>(T Value);

--- a/src/Conjecture.Interactive/ShrinkTraceResult.cs
+++ b/src/Conjecture.Interactive/ShrinkTraceResult.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+
+namespace Conjecture.Interactive;
+
+/// <summary>The result of a shrink trace: the ordered steps and an HTML rendering.</summary>
+public sealed class ShrinkTraceResult<T>(IReadOnlyList<ShrinkStep<T>> steps, string html)
+{
+    /// <summary>The shrink steps, from initial failing value through each accepted reduction.</summary>
+    public IReadOnlyList<ShrinkStep<T>> Steps { get; } = steps;
+
+    /// <summary>An HTML table rendering of the shrink trace.</summary>
+    public string Html { get; } = html;
+}

--- a/src/Conjecture.Interactive/StrategyExtensionsInteractive.cs
+++ b/src/Conjecture.Interactive/StrategyExtensionsInteractive.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
+using System.Threading.Tasks;
 
 using Conjecture.Core;
+using Conjecture.Core.Internal;
 
 namespace Conjecture.Interactive;
 
@@ -76,6 +78,70 @@ public static class StrategyExtensionsInteractive
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>Runs a shrink trace for <paramref name="strategy"/> starting from <paramref name="seed"/>, recording each accepted reduction.</summary>
+    public static ShrinkTraceResult<T> ShrinkTrace<T>(
+        this Strategy<T> strategy,
+        ulong seed,
+        Func<T, bool> failingProperty)
+    {
+        SplittableRandom rng = new(seed);
+        ConjectureData initialData = ConjectureData.ForGeneration(rng.Split());
+        T initialValue = strategy.Generate(initialData);
+
+        if (!failingProperty(initialValue))
+        {
+            throw new ArgumentException("Property must fail on the generated value to produce a shrink trace.");
+        }
+
+        List<ShrinkStep<T>> steps = [new(initialValue)];
+
+        ValueTask<Status> IsInteresting(IReadOnlyList<IRNode> nodes)
+        {
+            try
+            {
+                ConjectureData data = ConjectureData.ForRecord(nodes);
+                T value = strategy.Generate(data);
+                if (data.Status == Status.Overrun)
+                {
+                    return ValueTask.FromResult(Status.Overrun);
+                }
+
+                if (failingProperty(value))
+                {
+                    steps.Add(new(value));
+                    return ValueTask.FromResult(Status.Interesting);
+                }
+
+                return ValueTask.FromResult(Status.Valid);
+            }
+            catch (UnsatisfiedAssumptionException)
+            {
+                return ValueTask.FromResult(Status.Invalid);
+            }
+            catch (InvalidOperationException)
+            {
+                return ValueTask.FromResult(Status.Overrun);
+            }
+        }
+
+        Shrinker.ShrinkAsync(initialData.IRNodes, IsInteresting).GetAwaiter().GetResult();
+
+        StringBuilder sb = new();
+        sb.Append("<table><thead><tr><th>Step</th><th>Value</th></tr></thead><tbody>");
+        for (int i = 0; i < steps.Count; i++)
+        {
+            sb.Append("<tr><td>");
+            sb.Append(i);
+            sb.Append("</td><td>");
+            sb.Append(WebUtility.HtmlEncode(steps[i].Value?.ToString() ?? string.Empty));
+            sb.Append("</td></tr>");
+        }
+
+        sb.Append("</tbody></table>");
+
+        return new ShrinkTraceResult<T>(steps, sb.ToString());
     }
 
 #pragma warning disable RS0026 // multiple overloads with optional parameters


### PR DESCRIPTION
## Description

Adds `ShrinkTrace<T>(ulong seed, Func<T, bool> failingProperty)` to `StrategyExtensionsInteractive`. Given a seed and a predicate that identifies counterexamples, it runs the internal shrinker and returns a `ShrinkTraceResult<T>` containing each accepted reduction as a typed `ShrinkStep<T>` plus an HTML table for notebook display.

Throws `ArgumentException` if the property passes on the generated value (nothing to shrink). `Conjecture.Interactive` is added to `InternalsVisibleTo` in Core to access `SplittableRandom`, `ConjectureData`, `Shrinker`, and `IRNode` without duplicating shrink logic.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #160
Part of #67