### PR TITLE
[67.5] QuickStart.dib: notebook template in docs/notebooks/

### DIFF
--- a/docs/notebooks/Conjecture-QuickStart.dib
+++ b/docs/notebooks/Conjecture-QuickStart.dib
@@ -1,0 +1,95 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"aliases":[],"languageName":"csharp","name":"csharp"},{"aliases":[],"languageName":"markdown","name":"markdown"}]}}
+
+#!markdown
+
+# Conjecture Quick Start
+
+**Conjecture** is a property-based testing library for .NET. This notebook demonstrates the interactive
+exploration utilities in `Conjecture.Interactive`: preview samples, histograms, sample tables,
+and shrink traces — all rendered inline without writing a test file.
+
+#!csharp
+
+#r "nuget: Conjecture.Interactive"
+
+using Conjecture.Core;
+using Conjecture.Interactive;
+
+#!markdown
+
+## 1. Preview — at-a-glance samples
+
+`Preview` draws `n` values from a strategy and renders them in a single-row HTML table.
+Useful for a quick sanity-check on a new strategy.
+
+#!csharp
+
+Generate.Integers<int>(0, 100).Preview(20, seed: 1UL)
+
+#!markdown
+
+## 2. Histogram — visualise the distribution
+
+`Histogram` draws `sampleSize` values and buckets them into a 400 × 150 px SVG bar chart.
+Use this to confirm that your strategy has the shape you expect (uniform, skewed, etc.).
+
+#!csharp
+
+Generate.Integers<int>(0, 100).Histogram(sampleSize: 1_000, seed: 1UL)
+
+#!markdown
+
+## 3. SampleTable — indexed value list
+
+`SampleTable` renders up to `count` samples in a two-column table (index + value).
+Handy for composite or structured strategies where you want to read each value clearly.
+
+#!csharp
+
+Strategy<(int Id, string Label)> strategy = Generate.Tuples(
+    Generate.Integers<int>(1, 999),
+    Generate.Strings(minLength: 3, maxLength: 12));
+
+strategy.SampleTable(10, seed: 1UL)
+
+#!markdown
+
+## 4. ShrinkTrace — watch the minimiser in action
+
+`ShrinkTrace` generates one value with the given seed, then runs the shrinker to find
+the minimal counterexample for `failingProperty`. Each accepted reduction is a row in
+the output table, so you can see exactly how the engine simplifies a failing input.
+
+`failingProperty` should return `true` for values that are counterexamples (i.e. values
+on which your property *fails*). An `ArgumentException` is thrown if the generated value
+does not satisfy the property — pick a different seed in that case.
+
+#!csharp
+
+Strategy<List<int>> lists = Generate.Lists(Generate.Integers<int>(0, 100), minSize: 1);
+
+ShrinkTraceResult<List<int>> trace = lists.ShrinkTrace(
+    seed: 42UL,
+    failingProperty: static xs => xs.Sum() >= 50);
+
+trace.Html
+
+#!markdown
+
+## 5. Seed pinning — reproducible output
+
+Pass an explicit `seed` to any method to lock the random choices and get identical output
+on every run. Omit `seed` (or pass `null`) for a fresh random draw each time.
+
+#!csharp
+
+ulong pinnedSeed = 99UL;
+
+string runA = Generate.Doubles(0.0, 1.0).Preview(10, seed: pinnedSeed);
+string runB = Generate.Doubles(0.0, 1.0).Preview(10, seed: pinnedSeed);
+
+// runA and runB are identical HTML strings
+bool identical = runA == runB;
+$"Both runs identical: {identical}"


### PR DESCRIPTION
## Description

Adds `docs/notebooks/Conjecture-QuickStart.dib` — a .NET Interactive notebook demonstrating all five `Conjecture.Interactive` extension methods with inline explanations. Covers `Preview`, `Histogram`, `SampleTable`, `ShrinkTrace`, and seed pinning, each with a preceding markdown cell.

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #161
Part of #67