### PR TITLE
[61.1] TestInfra: Migrate Conjecture.Analyzers.Tests to Microsoft.CodeAnalysis.Testing

### DIFF
--- a/src/Conjecture.Analyzers.Tests/CJ0050Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CJ0050Tests.cs
@@ -1,40 +1,28 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
-using Conjecture.Analyzers;
-
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Conjecture.Analyzers.Tests;
 
 public sealed class CJ0050Tests
 {
+    // Types defined at file scope — CJ0050Analyzer checks type.Name == "Strategy", not namespace.
+    // Using a namespace + trailing `using` would cause CS1529 under the new test framework.
     private const string Preamble = """
         using System;
         using System.Collections.Generic;
-        namespace Conjecture.Core {
-            public class Strategy<T> {
-                public Strategy<T> Where(Func<T, bool> predicate) => this;
-            }
-            public static class Generate {
-                public static Strategy<int> Integers() => new();
-                public static Strategy<string> Strings() => new();
-                public static Strategy<List<T>> Lists<T>() => new();
-            }
+        public class Strategy<T> {
+            public Strategy<T> Where(Func<T, bool> predicate) => this;
+            public Strategy<T> Positive => this;
         }
-        using Conjecture.Core;
+        public static class Generate {
+            public static Strategy<int> Integers() => new();
+            public static Strategy<string> Strings() => new();
+            public static Strategy<List<T>> Lists<T>() => new();
+        }
         """;
 
     // --- .Where(x => x > 0) on Strategy<int> → CJ0050 ---
@@ -42,15 +30,11 @@ public sealed class CJ0050Tests
     [Fact]
     public async Task WhereXGreaterThan0_OnStrategyInt_EmitsCJ0050()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
-                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x > 0); }
+                void Foo() { Strategy<int> s = {|CJ0050:Generate.Integers().Where(x => x > 0)|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+            """);
     }
 
     // --- .Where(x => x < 0) on Strategy<int> → CJ0050 ---
@@ -58,15 +42,11 @@ public sealed class CJ0050Tests
     [Fact]
     public async Task WhereXLessThan0_OnStrategyInt_EmitsCJ0050()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
-                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x < 0); }
+                void Foo() { Strategy<int> s = {|CJ0050:Generate.Integers().Where(x => x < 0)|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+            """);
     }
 
     // --- .Where(x => x != 0) on Strategy<int> → CJ0050 ---
@@ -74,15 +54,11 @@ public sealed class CJ0050Tests
     [Fact]
     public async Task WhereXNotEqualTo0_OnStrategyInt_EmitsCJ0050()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
-                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x != 0); }
+                void Foo() { Strategy<int> s = {|CJ0050:Generate.Integers().Where(x => x != 0)|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+            """);
     }
 
     // --- .Where(x => x.Length > 0) on Strategy<string> → CJ0050 ---
@@ -90,15 +66,11 @@ public sealed class CJ0050Tests
     [Fact]
     public async Task WhereXLengthGreaterThan0_OnStrategyString_EmitsCJ0050()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
-                void Foo() { Strategy<string> s = Generate.Strings().Where(x => x.Length > 0); }
+                void Foo() { Strategy<string> s = {|CJ0050:Generate.Strings().Where(x => x.Length > 0)|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+            """);
     }
 
     // --- .Where(x => x.Count > 0) on Strategy<List<int>> → CJ0050 ---
@@ -106,15 +78,11 @@ public sealed class CJ0050Tests
     [Fact]
     public async Task WhereXCountGreaterThan0_OnStrategyList_EmitsCJ0050()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
-                void Foo() { Strategy<List<int>> s = Generate.Lists<int>().Where(x => x.Count > 0); }
+                void Foo() { Strategy<List<int>> s = {|CJ0050:Generate.Lists<int>().Where(x => x.Count > 0)|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CJ0050");
+            """);
     }
 
     // --- .Where(x => x > 1) on Strategy<int> → no CJ0050 (custom predicate) ---
@@ -122,15 +90,11 @@ public sealed class CJ0050Tests
     [Fact]
     public async Task WhereCustomPredicate_OnStrategyInt_NoCJ0050()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
                 void Foo() { Strategy<int> s = Generate.Integers().Where(x => x > 1); }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CJ0050");
+            """);
     }
 
     // --- .Where(x => x > 0) on IEnumerable<int> (plain LINQ) → no CJ0050 ---
@@ -138,20 +102,18 @@ public sealed class CJ0050Tests
     [Fact]
     public async Task WhereXGreaterThan0_OnIEnumerableInt_NoCJ0050()
     {
-        string source = Preamble + """
-            using System.Collections.Generic;
-            using System.Linq;
+        // Use fully-qualified names to avoid placing `using` directives after the Preamble's
+        // type declarations (which would cause CS1529 under the new test framework).
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
                 void Foo() {
-                    IEnumerable<int> source = new List<int>();
-                    IEnumerable<int> result = source.Where(x => x > 0);
+                    System.Collections.Generic.IEnumerable<int> source
+                        = new System.Collections.Generic.List<int>();
+                    System.Collections.Generic.IEnumerable<int> result
+                        = System.Linq.Enumerable.Where(source, x => x > 0);
                 }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CJ0050");
+            """);
     }
 
     // --- Severity is Info ---
@@ -159,17 +121,13 @@ public sealed class CJ0050Tests
     [Fact]
     public async Task CJ0050_IsInfoSeverity()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(
+            Preamble + """
             class Tests {
-                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x > 0); }
+                void Foo() { Strategy<int> s = {|#0:Generate.Integers().Where(x => x > 0)|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? cj0050 = diagnostics.FirstOrDefault(d => d.Id == "CJ0050");
-
-        Assert.NotNull(cj0050);
-        Assert.Equal(DiagnosticSeverity.Info, cj0050.Severity);
+            """,
+            new DiagnosticResult("CJ0050", DiagnosticSeverity.Info).WithLocation(0));
     }
 
     // --- Code fix: .Where(x => x > 0) → .Positive ---
@@ -177,111 +135,38 @@ public sealed class CJ0050Tests
     [Fact]
     public async Task CodeFix_WherePositive_ReplacesWithPositiveProperty()
     {
-        string source = Preamble + """
+        await VerifyCodeFixAsync(
+            Preamble + """
             class Tests {
-                void Foo() { Strategy<int> s = Generate.Integers().Where(x => x > 0); }
+                void Foo() { Strategy<int> s = {|CJ0050:Generate.Integers().Where(x => x > 0)|}; }
             }
-            """;
-
-        string? result = await ApplyCodeFixAsync(source);
-
-        Assert.NotNull(result);
-        Assert.Contains(".Positive", result);
-        Assert.DoesNotContain(".Where", result);
+            """,
+            Preamble + """
+            class Tests {
+                void Foo() { Strategy<int> s = Generate.Integers().Positive; }
+            }
+            """);
     }
 
     // --- Helpers ---
 
-    private static ImmutableArray<MetadataReference> GetReferences()
+    private static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
-        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        return
-        [
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Linq.dll")),
-        ];
+        CSharpAnalyzerTest<CJ0050Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
     }
 
-    private static CSharpCompilation CreateCompilation(string source) =>
-        CSharpCompilation.Create(
-            assemblyName: "TestAssembly",
-            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
-            references: GetReferences(),
-            options: new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                nullableContextOptions: NullableContextOptions.Enable));
-
-    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
+    private static Task VerifyCodeFixAsync(string source, string fixedSource)
     {
-        CSharpCompilation compilation = CreateCompilation(source);
-        CJ0050Analyzer analyzer = new();
-        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-    }
-
-    private static async Task<string?> ApplyCodeFixAsync(string source)
-    {
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? target = diagnostics.FirstOrDefault(d => d.Id == "CJ0050");
-        if (target is null)
+        CSharpCodeFixTest<CJ0050Analyzer, CJ0050CodeFix, DefaultVerifier> test = new()
         {
-            return null;
-        }
-
-        CSharpCompilation compilation = CreateCompilation(source);
-
-        using Microsoft.CodeAnalysis.AdhocWorkspace workspace = new();
-        ProjectId projectId = ProjectId.CreateNewId();
-        Solution solution = workspace.CurrentSolution
-            .AddProject(ProjectInfo.Create(
-                projectId, VersionStamp.Create(), "Test", "Test", LanguageNames.CSharp,
-                compilationOptions: compilation.Options,
-                metadataReferences: GetReferences()));
-
-        DocumentId documentId = DocumentId.CreateNewId(projectId);
-        solution = solution.AddDocument(
-            DocumentInfo.Create(documentId, "Test.cs",
-                loader: TextLoader.From(TextAndVersion.Create(
-                    SourceText.From(source), VersionStamp.Create()))));
-
-        workspace.TryApplyChanges(solution);
-        Document document = workspace.CurrentSolution.GetDocument(documentId)!;
-
-        Compilation workspaceCompilation = (await document.Project.GetCompilationAsync())!;
-        CompilationWithAnalyzers cwAnalyzers = workspaceCompilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(new CJ0050Analyzer()));
-        ImmutableArray<Diagnostic> mapped = await cwAnalyzers.GetAnalyzerDiagnosticsAsync();
-        Diagnostic? mappedDiagnostic = mapped.FirstOrDefault(d => d.Id == "CJ0050");
-        if (mappedDiagnostic is null)
-        {
-            return null;
-        }
-
-        CJ0050CodeFix fix = new();
-        List<CodeAction> actions = [];
-        CodeFixContext context = new(
-            document, mappedDiagnostic,
-            (action, _) => actions.Add(action),
-            CancellationToken.None);
-        await fix.RegisterCodeFixesAsync(context);
-
-        if (!actions.Any())
-        {
-            return null;
-        }
-
-        ImmutableArray<CodeActionOperation> operations =
-            await actions[0].GetOperationsAsync(CancellationToken.None);
-        foreach (CodeActionOperation op in operations)
-        {
-            op.Apply(workspace, CancellationToken.None);
-        }
-
-        Document updated = workspace.CurrentSolution.GetDocument(documentId)!;
-        SourceText text = await updated.GetTextAsync();
-        return text.ToString();
+            TestCode = source,
+            FixedCode = fixedSource,
+        };
+        return test.RunAsync();
     }
 }

--- a/src/Conjecture.Analyzers.Tests/CON100Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON100Tests.cs
@@ -1,14 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using System.Collections.Immutable;
-using System.IO;
-
-using Conjecture.Analyzers;
-
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Conjecture.Analyzers.Tests;
 
@@ -34,33 +29,25 @@ public sealed class CON100Tests
     [Fact]
     public async Task VoidPropertyMethod_WithAssertEqual_EmitsCon100()
     {
-        string source = Preamble + """
+        await VerifyAsync(Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Assert.Equal(x, x); }
+                public void Foo(int x) { {|CON100:Assert.Equal(x, x)|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON100");
+            """);
     }
 
     [Fact]
     public async Task VoidPropertyMethod_WithAssertEqual_Con100IsWarning()
     {
-        string source = Preamble + """
+        await VerifyAsync(
+            Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Assert.Equal(x, x); }
+                public void Foo(int x) { {|#0:Assert.Equal(x, x)|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? hyp100 = diagnostics.FirstOrDefault(d => d.Id == "CON100");
-
-        Assert.NotNull(hyp100);
-        Assert.Equal(DiagnosticSeverity.Warning, hyp100.Severity);
+            """,
+            new DiagnosticResult("CON100", DiagnosticSeverity.Warning).WithLocation(0));
     }
 
     // --- Void [Property] method with Assert.True -> CON100 ---
@@ -68,16 +55,12 @@ public sealed class CON100Tests
     [Fact]
     public async Task VoidPropertyMethod_WithAssertTrue_EmitsCon100()
     {
-        string source = Preamble + """
+        await VerifyAsync(Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Assert.True(x > 0); }
+                public void Foo(int x) { {|CON100:Assert.True(x > 0)|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON100");
+            """);
     }
 
     // --- Void [Property] method with Fluent Assertions -> CON100 ---
@@ -85,16 +68,12 @@ public sealed class CON100Tests
     [Fact]
     public async Task VoidPropertyMethod_WithFluentShould_EmitsCon100()
     {
-        string source = Preamble + """
+        await VerifyAsync(Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { x.Should().Be(x); }
+                public void Foo(int x) { {|CON100:x.Should()|}.Be(x); }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON100");
+            """);
     }
 
     // --- Non-[Property] method with Assert.Equal -> no diagnostic ---
@@ -102,45 +81,22 @@ public sealed class CON100Tests
     [Fact]
     public async Task NonPropertyMethod_WithAssertEqual_NoCon100()
     {
-        string source = Preamble + """
+        await VerifyAsync(Preamble + """
             class Tests {
                 public void Foo(int x) { Assert.Equal(x, x); }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON100");
+            """);
     }
 
     // --- Helpers ---
 
-    private static ImmutableArray<MetadataReference> GetReferences()
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
     {
-        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        return
-        [
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
-        ];
-    }
-
-    private static CSharpCompilation CreateCompilation(string source) =>
-        CSharpCompilation.Create(
-            assemblyName: "TestAssembly",
-            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
-            references: GetReferences(),
-            options: new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                nullableContextOptions: NullableContextOptions.Enable));
-
-    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
-    {
-        CSharpCompilation compilation = CreateCompilation(source);
-        var analyzer = new CON100Analyzer();
-        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        CSharpAnalyzerTest<CON100Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
     }
 }

--- a/src/Conjecture.Analyzers.Tests/CON101Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON101Tests.cs
@@ -1,15 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-
-using Conjecture.Analyzers;
-
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Conjecture.Analyzers.Tests;
 
@@ -20,29 +14,21 @@ public sealed class CON101Tests
     [Fact]
     public async Task Integers_EqualityPredicate_EmitsCon101()
     {
-        string source = """
+        await VerifyAsync("""
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Integers<int>().Where(x => x == 42); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON101");
+            class Test { void M() { var s = {|CON101:Generate.Integers<int>().Where(x => x == 42)|}; } }
+            """);
     }
 
     [Fact]
     public async Task Integers_EqualityPredicate_Con101IsWarning()
     {
-        string source = """
+        await VerifyAsync(
+            """
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Integers<int>().Where(x => x == 42); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? con101 = diagnostics.FirstOrDefault(d => d.Id == "CON101");
-
-        Assert.NotNull(con101);
-        Assert.Equal(DiagnosticSeverity.Warning, con101.Severity);
+            class Test { void M() { var s = {|#0:Generate.Integers<int>().Where(x => x == 42)|}; } }
+            """,
+            new DiagnosticResult("CON101", DiagnosticSeverity.Warning).WithLocation(0));
     }
 
     // --- Boolean equality ---
@@ -50,14 +36,10 @@ public sealed class CON101Tests
     [Fact]
     public async Task Booleans_EqualityToTrue_EmitsCon101()
     {
-        string source = """
+        await VerifyAsync("""
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Booleans().Where(b => b == true); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON101");
+            class Test { void M() { var s = {|CON101:Generate.Booleans().Where(b => b == true)|}; } }
+            """);
     }
 
     // --- False literal predicate ---
@@ -65,14 +47,10 @@ public sealed class CON101Tests
     [Fact]
     public async Task Where_FalseLiteralPredicate_EmitsCon101()
     {
-        string source = """
+        await VerifyAsync("""
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Integers<int>().Where(x => false); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON101");
+            class Test { void M() { var s = {|CON101:Generate.Integers<int>().Where(x => false)|}; } }
+            """);
     }
 
     // --- Complex predicates: no diagnostic ---
@@ -80,46 +58,23 @@ public sealed class CON101Tests
     [Fact]
     public async Task Where_ComplexPredicate_NoCon101()
     {
-        string source = """
+        await VerifyAsync("""
             using Conjecture.Core;
             class Test { void M() { var s = Generate.Integers<int>().Where(x => x > 0 && x < 100); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON101");
+            """);
     }
 
     // --- Helpers ---
 
-    private static ImmutableArray<MetadataReference> GetReferences()
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
     {
-        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        return
-        [
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Numerics.dll")),
-            MetadataReference.CreateFromFile(typeof(Conjecture.Core.Generate).Assembly.Location),
-        ];
-    }
-
-    private static CSharpCompilation CreateCompilation(string source) =>
-        CSharpCompilation.Create(
-            assemblyName: "TestAssembly",
-            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
-            references: GetReferences(),
-            options: new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                nullableContextOptions: NullableContextOptions.Enable));
-
-    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
-    {
-        CSharpCompilation compilation = CreateCompilation(source);
-        var analyzer = new CON101Analyzer();
-        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        CSharpAnalyzerTest<CON101Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
     }
 }

--- a/src/Conjecture.Analyzers.Tests/CON102Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON102Tests.cs
@@ -1,21 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
-using Conjecture.Analyzers;
-
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Conjecture.Analyzers.Tests;
 
@@ -34,33 +22,25 @@ public sealed class CON102Tests
     [Fact]
     public async Task GetAwaiterGetResult_InsidePropertyMethod_EmitsCon102()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Task.Delay(0).GetAwaiter().GetResult(); }
+                public void Foo(int x) { {|CON102:Task.Delay(0).GetAwaiter().GetResult()|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON102");
+            """);
     }
 
     [Fact]
     public async Task GetAwaiterGetResult_InsidePropertyMethod_Con102IsInfo()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(
+            Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Task.Delay(0).GetAwaiter().GetResult(); }
+                public void Foo(int x) { {|#0:Task.Delay(0).GetAwaiter().GetResult()|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? con102 = diagnostics.FirstOrDefault(d => d.Id == "CON102");
-
-        Assert.NotNull(con102);
-        Assert.Equal(DiagnosticSeverity.Info, con102.Severity);
+            """,
+            new DiagnosticResult("CON102", DiagnosticSeverity.Info).WithLocation(0));
     }
 
     // --- .Result on Task inside [Property] → CON102 ---
@@ -68,33 +48,25 @@ public sealed class CON102Tests
     [Fact]
     public async Task TaskResult_InsidePropertyMethod_EmitsCon102()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { int r = Task.FromResult(x).Result; }
+                public void Foo(int x) { int r = {|CON102:Task.FromResult(x).Result|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON102");
+            """);
     }
 
     [Fact]
     public async Task TaskResult_InsidePropertyMethod_Con102IsInfo()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(
+            Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { int r = Task.FromResult(x).Result; }
+                public void Foo(int x) { int r = {|#0:Task.FromResult(x).Result|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? con102 = diagnostics.FirstOrDefault(d => d.Id == "CON102");
-
-        Assert.NotNull(con102);
-        Assert.Equal(DiagnosticSeverity.Info, con102.Severity);
+            """,
+            new DiagnosticResult("CON102", DiagnosticSeverity.Info).WithLocation(0));
     }
 
     // --- .Wait() on Task inside [Property] → CON102 ---
@@ -102,33 +74,25 @@ public sealed class CON102Tests
     [Fact]
     public async Task TaskWait_InsidePropertyMethod_EmitsCon102()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Task.Delay(0).Wait(); }
+                public void Foo(int x) { {|CON102:Task.Delay(0).Wait()|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON102");
+            """);
     }
 
     [Fact]
     public async Task TaskWait_InsidePropertyMethod_Con102IsInfo()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(
+            Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Task.Delay(0).Wait(); }
+                public void Foo(int x) { {|#0:Task.Delay(0).Wait()|}; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? con102 = diagnostics.FirstOrDefault(d => d.Id == "CON102");
-
-        Assert.NotNull(con102);
-        Assert.Equal(DiagnosticSeverity.Info, con102.Severity);
+            """,
+            new DiagnosticResult("CON102", DiagnosticSeverity.Info).WithLocation(0));
     }
 
     // --- Same patterns outside [Property] → no diagnostic ---
@@ -136,43 +100,31 @@ public sealed class CON102Tests
     [Fact]
     public async Task GetAwaiterGetResult_OutsidePropertyMethod_NoCon102()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
                 public void Foo(int x) { Task.Delay(0).GetAwaiter().GetResult(); }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON102");
+            """);
     }
 
     [Fact]
     public async Task TaskResult_OutsidePropertyMethod_NoCon102()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
                 public void Foo(int x) { int r = Task.FromResult(x).Result; }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON102");
+            """);
     }
 
     [Fact]
     public async Task TaskWait_OutsidePropertyMethod_NoCon102()
     {
-        string source = Preamble + """
+        await VerifyAnalyzerAsync(Preamble + """
             class Tests {
                 public void Foo(int x) { Task.Delay(0).Wait(); }
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON102");
+            """);
     }
 
     // --- Code fix: GetAwaiter().GetResult() → async Task + await ---
@@ -183,17 +135,17 @@ public sealed class CON102Tests
         string source = Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Task.Delay(0).GetAwaiter().GetResult(); }
+                public void Foo(int x) { {|CON102:Task.Delay(0).GetAwaiter().GetResult()|}; }
+            }
+            """;
+        string fixedSource = Preamble + """
+            class Tests {
+                [Property]
+                public async Task Foo(int x) { await Task.Delay(0); }
             }
             """;
 
-        string? result = await ApplyCodeFixAsync(source);
-
-        Assert.NotNull(result);
-        Assert.Contains("async", result);
-        Assert.Contains("await", result);
-        Assert.DoesNotContain(".GetAwaiter()", result);
-        Assert.DoesNotContain(".GetResult()", result);
+        await VerifyCodeFixAsync(source, fixedSource);
     }
 
     [Fact]
@@ -202,14 +154,17 @@ public sealed class CON102Tests
         string source = Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Task.Delay(0).GetAwaiter().GetResult(); }
+                public void Foo(int x) { {|CON102:Task.Delay(0).GetAwaiter().GetResult()|}; }
+            }
+            """;
+        string fixedSource = Preamble + """
+            class Tests {
+                [Property]
+                public async Task Foo(int x) { await Task.Delay(0); }
             }
             """;
 
-        string? result = await ApplyCodeFixAsync(source);
-
-        Assert.NotNull(result);
-        Assert.Contains("Task", result);
+        await VerifyCodeFixAsync(source, fixedSource);
     }
 
     // --- Code fix: .Result → async Task + await ---
@@ -220,16 +175,17 @@ public sealed class CON102Tests
         string source = Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { int r = Task.FromResult(x).Result; }
+                public void Foo(int x) { int r = {|CON102:Task.FromResult(x).Result|}; }
+            }
+            """;
+        string fixedSource = Preamble + """
+            class Tests {
+                [Property]
+                public async Task Foo(int x) { int r = await Task.FromResult(x); }
             }
             """;
 
-        string? result = await ApplyCodeFixAsync(source);
-
-        Assert.NotNull(result);
-        Assert.Contains("async", result);
-        Assert.Contains("await", result);
-        Assert.DoesNotContain(".Result", result);
+        await VerifyCodeFixAsync(source, fixedSource);
     }
 
     // --- Code fix: .Wait() → async Task + await ---
@@ -240,110 +196,38 @@ public sealed class CON102Tests
         string source = Preamble + """
             class Tests {
                 [Property]
-                public void Foo(int x) { Task.Delay(0).Wait(); }
+                public void Foo(int x) { {|CON102:Task.Delay(0).Wait()|}; }
+            }
+            """;
+        string fixedSource = Preamble + """
+            class Tests {
+                [Property]
+                public async Task Foo(int x) { await Task.Delay(0); }
             }
             """;
 
-        string? result = await ApplyCodeFixAsync(source);
-
-        Assert.NotNull(result);
-        Assert.Contains("async", result);
-        Assert.Contains("await", result);
-        Assert.DoesNotContain(".Wait()", result);
+        await VerifyCodeFixAsync(source, fixedSource);
     }
 
     // --- Helpers ---
 
-    private static ImmutableArray<MetadataReference> GetReferences()
+    private static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
-        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        return
-        [
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Threading.Tasks.dll")),
-        ];
+        CSharpAnalyzerTest<CON102Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+        };
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
     }
 
-    private static CSharpCompilation CreateCompilation(string source) =>
-        CSharpCompilation.Create(
-            assemblyName: "TestAssembly",
-            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
-            references: GetReferences(),
-            options: new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                nullableContextOptions: NullableContextOptions.Enable));
-
-    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
+    private static Task VerifyCodeFixAsync(string source, string fixedSource)
     {
-        CSharpCompilation compilation = CreateCompilation(source);
-        var analyzer = new CON102Analyzer();
-        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-    }
-
-    private static async Task<string?> ApplyCodeFixAsync(string source)
-    {
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? target = diagnostics.FirstOrDefault(d => d.Id == "CON102");
-        if (target is null)
+        CSharpCodeFixTest<CON102Analyzer, CON102CodeFix, DefaultVerifier> test = new()
         {
-            return null;
-        }
-
-        CSharpCompilation compilation = CreateCompilation(source);
-
-        using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
-        ProjectId projectId = ProjectId.CreateNewId();
-        Solution solution = workspace.CurrentSolution
-            .AddProject(ProjectInfo.Create(
-                projectId, VersionStamp.Create(), "Test", "Test", LanguageNames.CSharp,
-                compilationOptions: compilation.Options,
-                metadataReferences: GetReferences()));
-
-        DocumentId documentId = DocumentId.CreateNewId(projectId);
-        solution = solution.AddDocument(
-            DocumentInfo.Create(documentId, "Test.cs",
-                loader: TextLoader.From(TextAndVersion.Create(
-                    SourceText.From(source), VersionStamp.Create()))));
-
-        workspace.TryApplyChanges(solution);
-        Document document = workspace.CurrentSolution.GetDocument(documentId)!;
-
-        Compilation workspaceCompilation = (await document.Project.GetCompilationAsync())!;
-        CompilationWithAnalyzers cwAnalyzers = workspaceCompilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(new CON102Analyzer()));
-        ImmutableArray<Diagnostic> mapped = await cwAnalyzers.GetAnalyzerDiagnosticsAsync();
-        Diagnostic? mappedDiagnostic = mapped.FirstOrDefault(d => d.Id == "CON102");
-        if (mappedDiagnostic is null)
-        {
-            return null;
-        }
-
-        var fix = new CON102CodeFix();
-        var actions = new List<CodeAction>();
-        CodeFixContext context = new(
-            document, mappedDiagnostic,
-            (action, _) => actions.Add(action),
-            CancellationToken.None);
-        await fix.RegisterCodeFixesAsync(context);
-
-        if (!actions.Any())
-        {
-            return null;
-        }
-
-        ImmutableArray<CodeActionOperation> operations =
-            await actions[0].GetOperationsAsync(CancellationToken.None);
-        foreach (CodeActionOperation op in operations)
-        {
-            op.Apply(workspace, CancellationToken.None);
-        }
-
-        Document updated = workspace.CurrentSolution.GetDocument(documentId)!;
-        SourceText text = await updated.GetTextAsync();
-        return text.ToString();
+            TestCode = source,
+            FixedCode = fixedSource,
+        };
+        return test.RunAsync();
     }
 }

--- a/src/Conjecture.Analyzers.Tests/CON103Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON103Tests.cs
@@ -1,21 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
-using Conjecture.Analyzers;
-
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Conjecture.Analyzers.Tests;
 
@@ -26,55 +14,39 @@ public sealed class CON103Tests
     [Fact]
     public async Task Integers_InvertedConstantBounds_EmitsCon103()
     {
-        string source = """
+        await VerifyAnalyzerAsync("""
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Integers(10, 5); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON103");
+            class Test { void M() { var s = {|CON103:Generate.Integers(10, 5)|}; } }
+            """);
     }
 
     [Fact]
     public async Task Integers_InvertedConstantBounds_Con103IsError()
     {
-        string source = """
+        await VerifyAnalyzerAsync(
+            """
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Integers(10, 5); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? hyp103 = diagnostics.FirstOrDefault(d => d.Id == "CON103");
-
-        Assert.NotNull(hyp103);
-        Assert.Equal(DiagnosticSeverity.Error, hyp103.Severity);
+            class Test { void M() { var s = {|#0:Generate.Integers(10, 5)|}; } }
+            """,
+            new DiagnosticResult("CON103", DiagnosticSeverity.Error).WithLocation(0));
     }
 
     [Fact]
     public async Task Integers_ValidBounds_NoCon103()
     {
-        string source = """
+        await VerifyAnalyzerAsync("""
             using Conjecture.Core;
             class Test { void M() { var s = Generate.Integers(0, 100); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON103");
+            """);
     }
 
     [Fact]
     public async Task Integers_NonConstantArgs_NoCon103()
     {
-        string source = """
+        await VerifyAnalyzerAsync("""
             using Conjecture.Core;
             class Test { void M(int a, int b) { var s = Generate.Integers(a, b); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON103");
+            """);
     }
 
     // --- Doubles: inverted bounds ---
@@ -82,14 +54,10 @@ public sealed class CON103Tests
     [Fact]
     public async Task Doubles_InvertedConstantBounds_EmitsCon103()
     {
-        string source = """
+        await VerifyAnalyzerAsync("""
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Doubles(1.0, 0.5); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON103");
+            class Test { void M() { var s = {|CON103:Generate.Doubles(1.0, 0.5)|}; } }
+            """);
     }
 
     // --- Floats: inverted bounds ---
@@ -97,14 +65,10 @@ public sealed class CON103Tests
     [Fact]
     public async Task Floats_InvertedConstantBounds_EmitsCon103()
     {
-        string source = """
+        await VerifyAnalyzerAsync("""
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Floats(1f, 0f); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON103");
+            class Test { void M() { var s = {|CON103:Generate.Floats(1f, 0f)|}; } }
+            """);
     }
 
     // --- Strings: inverted bounds (named parameters) ---
@@ -112,27 +76,19 @@ public sealed class CON103Tests
     [Fact]
     public async Task Strings_InvertedNamedBounds_EmitsCon103()
     {
-        string source = """
+        await VerifyAnalyzerAsync("""
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Strings(minLength: 10, maxLength: 5); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON103");
+            class Test { void M() { var s = {|CON103:Generate.Strings(minLength: 10, maxLength: 5)|}; } }
+            """);
     }
 
     [Fact]
     public async Task Strings_ValidBounds_NoCon103()
     {
-        string source = """
+        await VerifyAnalyzerAsync("""
             using Conjecture.Core;
             class Test { void M() { var s = Generate.Strings(minLength: 0, maxLength: 20); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON103");
+            """);
     }
 
     // --- Code fix: swaps arguments ---
@@ -140,139 +96,69 @@ public sealed class CON103Tests
     [Fact]
     public async Task CodeFix_SwapsArguments_ForIntegers()
     {
-        string source = """
+        await VerifyCodeFixAsync(
+            """
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Integers(10, 5); } }
-            """;
-
-        string? result = await ApplyCodeFixAsync(source);
-
-        Assert.NotNull(result);
-        Assert.Contains("Generate.Integers(5, 10)", result);
+            class Test { void M() { var s = {|CON103:Generate.Integers(10, 5)|}; } }
+            """,
+            """
+            using Conjecture.Core;
+            class Test { void M() { var s = Generate.Integers(5, 10); } }
+            """);
     }
 
     [Fact]
     public async Task CodeFix_SwapsArguments_ForDoubles()
     {
-        string source = """
+        await VerifyCodeFixAsync(
+            """
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Doubles(1.0, 0.5); } }
-            """;
-
-        string? result = await ApplyCodeFixAsync(source);
-
-        Assert.NotNull(result);
-        Assert.Contains("Generate.Doubles(0.5, 1.0)", result);
+            class Test { void M() { var s = {|CON103:Generate.Doubles(1.0, 0.5)|}; } }
+            """,
+            """
+            using Conjecture.Core;
+            class Test { void M() { var s = Generate.Doubles(0.5, 1.0); } }
+            """);
     }
 
     [Fact]
     public async Task CodeFix_SwapsArguments_ForStringsWithNamedParams()
     {
-        string source = """
+        await VerifyCodeFixAsync(
+            """
             using Conjecture.Core;
-            class Test { void M() { var s = Generate.Strings(minLength: 10, maxLength: 5); } }
-            """;
-
-        string? result = await ApplyCodeFixAsync(source);
-
-        Assert.NotNull(result);
-        Assert.Contains("minLength: 5", result);
-        Assert.Contains("maxLength: 10", result);
+            class Test { void M() { var s = {|CON103:Generate.Strings(minLength: 10, maxLength: 5)|}; } }
+            """,
+            """
+            using Conjecture.Core;
+            class Test { void M() { var s = Generate.Strings(minLength: 5, maxLength: 10); } }
+            """);
     }
 
     // --- Helpers ---
 
-    private static ImmutableArray<MetadataReference> GetReferences()
+    private static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
     {
-        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        return
-        [
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
-            MetadataReference.CreateFromFile(typeof(Conjecture.Core.Generate).Assembly.Location),
-        ];
+        CSharpAnalyzerTest<CON103Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
     }
 
-    private static CSharpCompilation CreateCompilation(string source) =>
-        CSharpCompilation.Create(
-            assemblyName: "TestAssembly",
-            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
-            references: GetReferences(),
-            options: new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                nullableContextOptions: NullableContextOptions.Enable));
-
-    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
+    private static Task VerifyCodeFixAsync(string source, string fixedSource)
     {
-        CSharpCompilation compilation = CreateCompilation(source);
-        var analyzer = new CON103Analyzer();
-        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-    }
-
-    private static async Task<string?> ApplyCodeFixAsync(string source)
-    {
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? target = diagnostics.FirstOrDefault(d => d.Id == "CON103");
-        if (target is null)
+        CSharpCodeFixTest<CON103Analyzer, CON103CodeFix, DefaultVerifier> test = new()
         {
-            return null;
-        }
-
-        CSharpCompilation compilation = CreateCompilation(source);
-
-        using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
-        var projectId = ProjectId.CreateNewId();
-        var solution = workspace.CurrentSolution
-            .AddProject(ProjectInfo.Create(
-                projectId, VersionStamp.Create(), "Test", "Test", LanguageNames.CSharp,
-                compilationOptions: compilation.Options,
-                metadataReferences: GetReferences()));
-
-        var documentId = DocumentId.CreateNewId(projectId);
-        solution = solution.AddDocument(
-            DocumentInfo.Create(documentId, "Test.cs",
-                loader: TextLoader.From(TextAndVersion.Create(
-                    SourceText.From(source), VersionStamp.Create()))));
-
-        workspace.TryApplyChanges(solution);
-        Document document = workspace.CurrentSolution.GetDocument(documentId)!;
-
-        // Re-run the analyzer on the workspace compilation to get mapped diagnostics
-        Compilation workspaceCompilation = (await document.Project.GetCompilationAsync())!;
-        CompilationWithAnalyzers cwAnalyzers = workspaceCompilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(new CON103Analyzer()));
-        ImmutableArray<Diagnostic> mapped = await cwAnalyzers.GetAnalyzerDiagnosticsAsync();
-        Diagnostic? mappedDiagnostic = mapped.FirstOrDefault(d => d.Id == "CON103");
-        if (mappedDiagnostic is null)
-        {
-            return null;
-        }
-
-        var fix = new CON103CodeFix();
-        var actions = new List<CodeAction>();
-        var context = new CodeFixContext(
-            document, mappedDiagnostic,
-            (action, _) => actions.Add(action),
-            CancellationToken.None);
-        await fix.RegisterCodeFixesAsync(context);
-
-        if (!actions.Any())
-        {
-            return null;
-        }
-
-        ImmutableArray<CodeActionOperation> operations =
-            await actions[0].GetOperationsAsync(CancellationToken.None);
-        foreach (CodeActionOperation op in operations)
-        {
-            op.Apply(workspace, CancellationToken.None);
-        }
-
-        Document updated = workspace.CurrentSolution.GetDocument(documentId)!;
-        SourceText text = await updated.GetTextAsync();
-        return text.ToString();
+            TestCode = source,
+            FixedCode = fixedSource,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        TestHelpers.AddRuntimeReferences(test.FixedState.AdditionalReferences);
+        return test.RunAsync();
     }
 }

--- a/src/Conjecture.Analyzers.Tests/CON104Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON104Tests.cs
@@ -1,15 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-
-using Conjecture.Analyzers;
-
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Conjecture.Analyzers.Tests;
 
@@ -20,29 +14,21 @@ public sealed class CON104Tests
     [Fact]
     public async Task AssumeThat_FalseLiteral_EmitsCon104()
     {
-        string source = """
+        await VerifyAsync("""
             using Conjecture.Core;
-            class Tests { void M() { Assume.That(false); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON104");
+            class Tests { void M() { {|CON104:Assume.That(false)|}; } }
+            """);
     }
 
     [Fact]
     public async Task AssumeThat_FalseLiteral_Con104IsWarning()
     {
-        string source = """
+        await VerifyAsync(
+            """
             using Conjecture.Core;
-            class Tests { void M() { Assume.That(false); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? hyp104 = diagnostics.FirstOrDefault(d => d.Id == "CON104");
-
-        Assert.NotNull(hyp104);
-        Assert.Equal(DiagnosticSeverity.Warning, hyp104.Severity);
+            class Tests { void M() { {|#0:Assume.That(false)|}; } }
+            """,
+            new DiagnosticResult("CON104", DiagnosticSeverity.Warning).WithLocation(0));
     }
 
     // --- Assume.That(true) → no diagnostic ---
@@ -50,14 +36,10 @@ public sealed class CON104Tests
     [Fact]
     public async Task AssumeThat_TrueLiteral_NoCon104()
     {
-        string source = """
+        await VerifyAsync("""
             using Conjecture.Core;
             class Tests { void M() { Assume.That(true); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON104");
+            """);
     }
 
     // --- Assume.That(variable) → no diagnostic ---
@@ -65,45 +47,23 @@ public sealed class CON104Tests
     [Fact]
     public async Task AssumeThat_VariableArgument_NoCon104()
     {
-        string source = """
+        await VerifyAsync("""
             using Conjecture.Core;
             class Tests { void M(bool condition) { Assume.That(condition); } }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON104");
+            """);
     }
 
     // --- Helpers ---
 
-    private static ImmutableArray<MetadataReference> GetReferences()
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
     {
-        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        return
-        [
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
-            MetadataReference.CreateFromFile(typeof(Conjecture.Core.Assume).Assembly.Location),
-        ];
-    }
-
-    private static CSharpCompilation CreateCompilation(string source) =>
-        CSharpCompilation.Create(
-            assemblyName: "TestAssembly",
-            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
-            references: GetReferences(),
-            options: new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                nullableContextOptions: NullableContextOptions.Enable));
-
-    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
-    {
-        CSharpCompilation compilation = CreateCompilation(source);
-        var analyzer = new CON104Analyzer();
-        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        CSharpAnalyzerTest<CON104Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
     }
 }

--- a/src/Conjecture.Analyzers.Tests/CON105Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON105Tests.cs
@@ -1,15 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-
-using Conjecture.Analyzers;
-
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace Conjecture.Analyzers.Tests;
 
@@ -27,35 +21,27 @@ public sealed class CON105Tests
     [Fact]
     public async Task PropertyParam_TypeWithArbitrary_EmitsCon105()
     {
-        string source = Preamble + """
+        await VerifyAsync(Preamble + """
             [Arbitrary] class Person { }
             class Tests {
                 [Property]
-                public bool Foo(Person p) => true;
+                public bool Foo({|CON105:Person p|}) => true;
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.Contains(diagnostics, d => d.Id == "CON105");
+            """);
     }
 
     [Fact]
     public async Task PropertyParam_TypeWithArbitrary_Con105IsInfo()
     {
-        string source = Preamble + """
+        await VerifyAsync(
+            Preamble + """
             [Arbitrary] class Person { }
             class Tests {
                 [Property]
-                public bool Foo(Person p) => true;
+                public bool Foo({|#0:Person p|}) => true;
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-        Diagnostic? con105 = diagnostics.FirstOrDefault(d => d.Id == "CON105");
-
-        Assert.NotNull(con105);
-        Assert.Equal(DiagnosticSeverity.Info, con105.Severity);
+            """,
+            new DiagnosticResult("CON105", DiagnosticSeverity.Info).WithLocation(0));
     }
 
     // --- [Property] param with [From<PersonArbitrary>] -> no diagnostic ---
@@ -63,18 +49,14 @@ public sealed class CON105Tests
     [Fact]
     public async Task PropertyParam_WithFromAttribute_NoCon105()
     {
-        string source = Preamble + """
+        await VerifyAsync(Preamble + """
             [Arbitrary] class Person { }
             class PersonArbitrary : IStrategyProvider { }
             class Tests {
                 [Property]
                 public bool Foo([From<PersonArbitrary>] Person p) => true;
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON105");
+            """);
     }
 
     // --- Non-[Property] method -> no diagnostic ---
@@ -82,16 +64,12 @@ public sealed class CON105Tests
     [Fact]
     public async Task NonPropertyMethod_NoCon105()
     {
-        string source = Preamble + """
+        await VerifyAsync(Preamble + """
             [Arbitrary] class Person { }
             class Tests {
                 public bool Foo(Person p) => true;
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON105");
+            """);
     }
 
     // --- Type without [Arbitrary] -> no diagnostic ---
@@ -99,48 +77,26 @@ public sealed class CON105Tests
     [Fact]
     public async Task PropertyParam_TypeWithoutArbitrary_NoCon105()
     {
-        string source = Preamble + """
+        await VerifyAsync(Preamble + """
             class Person { }
             class Tests {
                 [Property]
                 public bool Foo(Person p) => true;
             }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(source);
-
-        Assert.DoesNotContain(diagnostics, d => d.Id == "CON105");
+            """);
     }
 
     // --- Helpers ---
 
-    private static ImmutableArray<MetadataReference> GetReferences()
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
     {
-        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
-        return
-        [
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
-            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
-            MetadataReference.CreateFromFile(typeof(Conjecture.Core.ArbitraryAttribute).Assembly.Location),
-        ];
-    }
-
-    private static CSharpCompilation CreateCompilation(string source) =>
-        CSharpCompilation.Create(
-            assemblyName: "TestAssembly",
-            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
-            references: GetReferences(),
-            options: new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                nullableContextOptions: NullableContextOptions.Enable));
-
-    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(string source)
-    {
-        CSharpCompilation compilation = CreateCompilation(source);
-        var analyzer = new CON105Analyzer();
-        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(analyzer));
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+        CSharpAnalyzerTest<CON105Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
     }
 }

--- a/src/Conjecture.Analyzers.Tests/Conjecture.Analyzers.Tests.csproj
+++ b/src/Conjecture.Analyzers.Tests/Conjecture.Analyzers.Tests.csproj
@@ -9,7 +9,8 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/Conjecture.Analyzers.Tests/EndToEnd/AnalyzerIntegrationE2ETests.cs
+++ b/src/Conjecture.Analyzers.Tests/EndToEnd/AnalyzerIntegrationE2ETests.cs
@@ -1,24 +1,22 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Conjecture.Analyzers;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Conjecture.Analyzers.Tests.EndToEnd;
 
+/// <summary>
+/// Integration tests that run multiple analyzers simultaneously.
+/// Single-analyzer and code-fix tests live in the per-analyzer test files.
+/// </summary>
 public sealed class AnalyzerIntegrationE2ETests
 {
     // Stub [Property] attribute works for CON100/CON102 (detected by name).
@@ -88,73 +86,6 @@ public sealed class AnalyzerIntegrationE2ETests
         Assert.Single(diagnostics, d => d.Id == "CON105");
     }
 
-    // --- Code-fix for CON103 produces compilable code ---
-
-    [Fact]
-    public async Task CON103CodeFix_ProducesCompilableOutput()
-    {
-        string source = Preamble + """
-            class Test { void M() { var s = Generate.Integers(10, 5); } }
-            """;
-
-        string? fixed_ = await ApplyCon103FixAsync(source);
-
-        Assert.NotNull(fixed_);
-        CSharpCompilation compilation = CreateCompilation(fixed_);
-        IEnumerable<Diagnostic> errors =
-            compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
-        Assert.Empty(errors);
-    }
-
-    [Fact]
-    public async Task CON103CodeFix_SwapsToCorrectBounds()
-    {
-        string source = Preamble + """
-            class Test { void M() { var s = Generate.Integers(10, 5); } }
-            """;
-
-        string? fixed_ = await ApplyCon103FixAsync(source);
-
-        Assert.NotNull(fixed_);
-        Assert.Contains("Generate.Integers(5, 10)", fixed_);
-    }
-
-    // --- Code-fix for CON102 produces compilable code ---
-
-    [Fact]
-    public async Task CON102CodeFix_ProducesCompilableOutput()
-    {
-        string source = Preamble + """
-            class Tests {
-                [Property] public void PropWithBlocking(int x) { Task.Delay(0).GetAwaiter().GetResult(); }
-            }
-            """;
-
-        string? fixed_ = await ApplyCon102FixAsync(source);
-
-        Assert.NotNull(fixed_);
-        CSharpCompilation compilation = CreateCompilation(fixed_);
-        IEnumerable<Diagnostic> errors =
-            compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
-        Assert.Empty(errors);
-    }
-
-    [Fact]
-    public async Task CON102CodeFix_ConvertsToAsyncAwait()
-    {
-        string source = Preamble + """
-            class Tests {
-                [Property] public void PropWithBlocking(int x) { Task.Delay(0).GetAwaiter().GetResult(); }
-            }
-            """;
-
-        string? fixed_ = await ApplyCon102FixAsync(source);
-
-        Assert.NotNull(fixed_);
-        Assert.Contains("async", fixed_);
-        Assert.Contains("await", fixed_);
-    }
-
     // --- No false positives on clean code ---
 
     [Fact]
@@ -207,20 +138,12 @@ public sealed class AnalyzerIntegrationE2ETests
         ImmutableArray<Diagnostic> combined =
             await GetDiagnosticsAsync(source, AllAnalyzers());
 
-        // Each individual analyzer should contribute its expected diagnostic
-        int con100 = combined.Count(d => d.Id == "CON100");
-        int con101 = combined.Count(d => d.Id == "CON101");
-        int con102 = combined.Count(d => d.Id == "CON102");
-        int con103 = combined.Count(d => d.Id == "CON103");
-        int con104 = combined.Count(d => d.Id == "CON104");
-        int con105 = combined.Count(d => d.Id == "CON105");
-
-        Assert.Equal(1, con100);
-        Assert.Equal(1, con101);
-        Assert.Equal(1, con102);
-        Assert.Equal(1, con103);
-        Assert.Equal(1, con104);
-        Assert.Equal(1, con105);
+        Assert.Equal(1, combined.Count(d => d.Id == "CON100"));
+        Assert.Equal(1, combined.Count(d => d.Id == "CON101"));
+        Assert.Equal(1, combined.Count(d => d.Id == "CON102"));
+        Assert.Equal(1, combined.Count(d => d.Id == "CON103"));
+        Assert.Equal(1, combined.Count(d => d.Id == "CON104"));
+        Assert.Equal(1, combined.Count(d => d.Id == "CON105"));
     }
 
     [Fact]
@@ -284,68 +207,5 @@ public sealed class AnalyzerIntegrationE2ETests
         CompilationWithAnalyzers compilationWithAnalyzers =
             compilation.WithAnalyzers(analyzers);
         return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-    }
-
-    private static async Task<string?> ApplyCon103FixAsync(string source) =>
-        await ApplyFixAsync(source, "CON103", new CON103Analyzer(), new CON103CodeFix());
-
-    private static async Task<string?> ApplyCon102FixAsync(string source) =>
-        await ApplyFixAsync(source, "CON102", new CON102Analyzer(), new CON102CodeFix());
-
-    private static async Task<string?> ApplyFixAsync(
-        string source, string diagnosticId,
-        DiagnosticAnalyzer analyzer, CodeFixProvider fix)
-    {
-        using var workspace = new Microsoft.CodeAnalysis.AdhocWorkspace();
-        ProjectId projectId = ProjectId.CreateNewId();
-        Solution solution = workspace.CurrentSolution
-            .AddProject(ProjectInfo.Create(
-                projectId, VersionStamp.Create(), "Test", "Test", LanguageNames.CSharp,
-                compilationOptions: new CSharpCompilationOptions(
-                    OutputKind.DynamicallyLinkedLibrary,
-                    nullableContextOptions: NullableContextOptions.Enable),
-                metadataReferences: GetReferences()));
-
-        DocumentId documentId = DocumentId.CreateNewId(projectId);
-        solution = solution.AddDocument(
-            DocumentInfo.Create(documentId, "Test.cs",
-                loader: TextLoader.From(
-                    TextAndVersion.Create(SourceText.From(source), VersionStamp.Create()))));
-
-        workspace.TryApplyChanges(solution);
-        Document document = workspace.CurrentSolution.GetDocument(documentId)!;
-
-        Compilation compilation = (await document.Project.GetCompilationAsync())!;
-        CompilationWithAnalyzers cwAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create(analyzer));
-        ImmutableArray<Diagnostic> mapped = await cwAnalyzers.GetAnalyzerDiagnosticsAsync();
-        Diagnostic? target = mapped.FirstOrDefault(d => d.Id == diagnosticId);
-        if (target is null)
-        {
-            return null;
-        }
-
-        var actions = new List<CodeAction>();
-        CodeFixContext context = new(
-            document, target,
-            (action, _) => actions.Add(action),
-            CancellationToken.None);
-        await fix.RegisterCodeFixesAsync(context);
-
-        if (!actions.Any())
-        {
-            return null;
-        }
-
-        ImmutableArray<CodeActionOperation> operations =
-            await actions[0].GetOperationsAsync(CancellationToken.None);
-        foreach (CodeActionOperation op in operations)
-        {
-            op.Apply(workspace, CancellationToken.None);
-        }
-
-        Document updated = workspace.CurrentSolution.GetDocument(documentId)!;
-        SourceText text = await updated.GetTextAsync();
-        return text.ToString();
     }
 }

--- a/src/Conjecture.Analyzers.Tests/TestHelpers.cs
+++ b/src/Conjecture.Analyzers.Tests/TestHelpers.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.IO;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Conjecture.Analyzers.Tests;
+
+/// <summary>
+/// Shared reference helpers for tests that add Conjecture.Core as an additional reference.
+/// Uses runtime assemblies instead of the framework's NuGet-sourced reference assemblies to
+/// avoid CS1705 version mismatches when Conjecture.Core targets a newer TFM.
+/// </summary>
+internal static class TestHelpers
+{
+    /// <summary>
+    /// A <see cref="ReferenceAssemblies" /> with no NuGet packages — callers must supply all
+    /// needed assemblies via <see cref="AddRuntimeReferences" />.
+    /// </summary>
+    internal static readonly ReferenceAssemblies EmptyNet10 = new("net10.0");
+
+    /// <summary>Adds BCL runtime assemblies and Conjecture.Core to the given reference list.</summary>
+    internal static void AddRuntimeReferences(IList<MetadataReference> refs)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        refs.Add(MetadataReference.CreateFromFile(typeof(object).Assembly.Location));
+        refs.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")));
+        refs.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")));
+        refs.Add(MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Numerics.dll")));
+        refs.Add(MetadataReference.CreateFromFile(
+            typeof(Conjecture.Core.Generate).Assembly.Location));
+    }
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -32,6 +32,8 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.3" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.3" />
 
     <!-- xUnit v3 -->
     <PackageVersion Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
## Description

Migrates `Conjecture.Analyzers.Tests` from the hand-rolled `CSharpCompilation` / `CompilationWithAnalyzers` helper pattern to the official `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` framework.

Key changes:
- Adds `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` and `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing` NuGet packages
- Rewrites all per-analyzer test files (CON100–CON105, CJ0050) using `CSharpAnalyzerTest<T>` with inline `{|ID:...|}`  diagnostic markup and `CSharpCodeFixTest<T,F>` with exact `FixedCode` assertions
- Adds `TestHelpers.EmptyNet10` to supply runtime BCL references for tests that reference `Conjecture.Core`, avoiding CS1705 TFM mismatch with the framework's default Net6 reference assemblies
- Consolidates E2E code-fix tests into per-analyzer files; retains multi-analyzer interaction tests in `AnalyzerIntegrationE2ETests` using the old helper approach (the new framework doesn't support multiple analyzers in one test)
- All 65 tests green

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [x] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #166
Part of #61