### PR TITLE
[61.2] CON107Analyzer: detect non-deterministic operations in [Property] methods

### DIFF
--- a/src/Conjecture.Analyzers.Tests/CON107Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON107Tests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Conjecture.Analyzers.Tests;
+
+public sealed class CON107Tests
+{
+    // Stub types so tests don't need external assembly references
+    private const string Preamble = """
+        using System;
+        [AttributeUsage(AttributeTargets.Method)] class PropertyAttribute : Attribute {}
+
+        """;
+
+    // --- Fires on Guid.NewGuid() inside [Property] ---
+
+    [Fact]
+    public async Task GuidNewGuid_InsidePropertyMethod_EmitsCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { Guid g = {|CON107:Guid.NewGuid()|}; }
+            }
+            """);
+    }
+
+    // --- Fires on DateTime.Now inside [Property] ---
+
+    [Fact]
+    public async Task DateTimeNow_InsidePropertyMethod_EmitsCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { DateTime d = {|CON107:DateTime.Now|}; }
+            }
+            """);
+    }
+
+    // --- Fires on DateTime.UtcNow inside [Property] ---
+
+    [Fact]
+    public async Task DateTimeUtcNow_InsidePropertyMethod_EmitsCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { DateTime d = {|CON107:DateTime.UtcNow|}; }
+            }
+            """);
+    }
+
+    // --- Fires on new Random() inside [Property] ---
+
+    [Fact]
+    public async Task NewRandom_InsidePropertyMethod_EmitsCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { Random r = {|CON107:new Random()|}; }
+            }
+            """);
+    }
+
+    // --- Fires on Random.Shared inside [Property] ---
+
+    [Fact]
+    public async Task RandomShared_InsidePropertyMethod_EmitsCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { Random r = {|CON107:Random.Shared|}; }
+            }
+            """);
+    }
+
+    // --- Fires on DateTimeOffset.Now inside [Property] ---
+
+    [Fact]
+    public async Task DateTimeOffsetNow_InsidePropertyMethod_EmitsCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { DateTimeOffset d = {|CON107:DateTimeOffset.Now|}; }
+            }
+            """);
+    }
+
+    // --- Fires on DateTimeOffset.UtcNow inside [Property] ---
+
+    [Fact]
+    public async Task DateTimeOffsetUtcNow_InsidePropertyMethod_EmitsCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { DateTimeOffset d = {|CON107:DateTimeOffset.UtcNow|}; }
+            }
+            """);
+    }
+
+    // --- Fires on Environment.TickCount inside [Property] ---
+
+    [Fact]
+    public async Task EnvironmentTickCount_InsidePropertyMethod_EmitsCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { int t = {|CON107:Environment.TickCount|}; }
+            }
+            """);
+    }
+
+    // --- Fires on Environment.TickCount64 inside [Property] ---
+
+    [Fact]
+    public async Task EnvironmentTickCount64_InsidePropertyMethod_EmitsCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { long t = {|CON107:Environment.TickCount64|}; }
+            }
+            """);
+    }
+
+    // --- Silent when same calls appear outside a [Property] method ---
+
+    [Fact]
+    public async Task NonDeterministicCalls_OutsidePropertyMethod_NoCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                public void Foo() {
+                    Guid g = Guid.NewGuid();
+                    DateTime d = DateTime.Now;
+                    DateTime u = DateTime.UtcNow;
+                    Random r = new Random();
+                    Random s = Random.Shared;
+                }
+            }
+            """);
+    }
+
+    // --- Silent when [Property] method has no non-deterministic calls ---
+
+    [Fact]
+    public async Task PropertyMethod_WithNonDeterministicCalls_NoCon107()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public void Foo(int x) { int y = x + 1; }
+            }
+            """);
+    }
+
+    // --- Diagnostic span points to the specific call site ---
+
+    [Fact]
+    public async Task GuidNewGuid_InsidePropertyMethod_Con107IsWarning()
+    {
+        await VerifyAsync(
+            Preamble + """
+            class Tests {
+                [Property]
+                public void Foo() { Guid g = {|#0:Guid.NewGuid()|}; }
+            }
+            """,
+            new DiagnosticResult("CON107", DiagnosticSeverity.Warning).WithLocation(0));
+    }
+
+    // --- Helpers ---
+
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+    {
+        CSharpAnalyzerTest<CON107Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+}

--- a/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
@@ -2,4 +2,5 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+CON107 | Conjecture | Warning | Non-deterministic operation inside a [Property] method
 | CJ0050 | Usage | Info | Suggest named extension property |

--- a/src/Conjecture.Analyzers/CON107Analyzer.cs
+++ b/src/Conjecture.Analyzers/CON107Analyzer.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Conjecture.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class CON107Analyzer : DiagnosticAnalyzer
+{
+    internal static readonly DiagnosticDescriptor Rule = new(
+        id: "CON107",
+        title: "Non-deterministic operation inside a [Property] method",
+        messageFormat: "'{0}' is non-deterministic and breaks reproducibility in [Property] methods; inject randomness via a strategy parameter instead",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Non-deterministic operations break reproducibility in property-based tests.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeMemberAccess, SyntaxKind.SimpleMemberAccessExpression);
+        context.RegisterSyntaxNodeAction(AnalyzeObjectCreation, SyntaxKind.ObjectCreationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return;
+        }
+
+        string type = memberAccess.Expression.ToString();
+        string member = memberAccess.Name.Identifier.Text;
+
+        if (type != "Guid" || member != "NewGuid")
+        {
+            return;
+        }
+
+        MethodDeclarationSyntax? method = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (method is null)
+        {
+            return;
+        }
+
+        if (!PropertyAttributeHelper.HasPropertyAttribute(method, context.SemanticModel))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), "Guid.NewGuid()"));
+    }
+
+    private static void AnalyzeObjectCreation(SyntaxNodeAnalysisContext context)
+    {
+        ObjectCreationExpressionSyntax creation = (ObjectCreationExpressionSyntax)context.Node;
+
+        if (creation.Type.ToString() != "Random")
+        {
+            return;
+        }
+
+        MethodDeclarationSyntax? method = creation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (method is null)
+        {
+            return;
+        }
+
+        if (!PropertyAttributeHelper.HasPropertyAttribute(method, context.SemanticModel))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, creation.GetLocation(), "new Random()"));
+    }
+
+    private static void AnalyzeMemberAccess(SyntaxNodeAnalysisContext context)
+    {
+        MemberAccessExpressionSyntax memberAccess = (MemberAccessExpressionSyntax)context.Node;
+
+        // Skip if this member access is the callee of an invocation — handled by AnalyzeInvocation
+        if (memberAccess.Parent is InvocationExpressionSyntax)
+        {
+            return;
+        }
+
+        string? display = TryGetNonDeterministicMemberDisplay(memberAccess);
+        if (display is null)
+        {
+            return;
+        }
+
+        MethodDeclarationSyntax? method = memberAccess.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (method is null)
+        {
+            return;
+        }
+
+        if (!PropertyAttributeHelper.HasPropertyAttribute(method, context.SemanticModel))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, memberAccess.GetLocation(), display));
+    }
+
+    private static string? TryGetNonDeterministicMemberDisplay(MemberAccessExpressionSyntax memberAccess)
+    {
+        string type = memberAccess.Expression.ToString();
+        string member = memberAccess.Name.Identifier.Text;
+
+        return (type, member) switch
+        {
+            ("Random", "Shared") => "Random.Shared",
+            ("DateTime", "Now") => "DateTime.Now",
+            ("DateTime", "UtcNow") => "DateTime.UtcNow",
+            ("DateTimeOffset", "Now") => "DateTimeOffset.Now",
+            ("DateTimeOffset", "UtcNow") => "DateTimeOffset.UtcNow",
+            ("Environment", "TickCount") => "Environment.TickCount",
+            ("Environment", "TickCount64") => "Environment.TickCount64",
+            _ => null,
+        };
+    }
+}


### PR DESCRIPTION
## Description

Adds `CON107Analyzer`, a Roslyn diagnostic analyzer that warns when non-deterministic operations are used inside `[Property]`-annotated test methods. Non-determinism breaks shrinking reproducibility — the same seed will not reproduce the failure if the method calls `DateTime.Now` or `Guid.NewGuid()` on its own.

Flagged operations:
- `new Random()` / `Random.Shared`
- `DateTime.Now` / `DateTime.UtcNow`
- `DateTimeOffset.Now` / `DateTimeOffset.UtcNow`
- `Guid.NewGuid()`
- `Environment.TickCount` / `Environment.TickCount64`

Uses name-based syntax matching (three node actions: `InvocationExpression`, `ObjectCreationExpression`, `SimpleMemberAccessExpression`) and delegates `[Property]` detection to the existing `PropertyAttributeHelper`.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #167
Part of #61