### PR TITLE
[61.3] CON109Analyzer: detect missing strategy for [Property] parameter type

### DIFF
--- a/src/Conjecture.Analyzers.Tests/CON109Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON109Tests.cs
@@ -1,0 +1,203 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Conjecture.Analyzers.Tests;
+
+public sealed class CON109Tests
+{
+    // Stub types so tests don't need external assembly references.
+    // IStrategyProvider and From<T> are stubbed; [Arbitrary] is imported from Conjecture.Core.
+    private const string Preamble = """
+        using System;
+        using Conjecture.Core;
+        [AttributeUsage(AttributeTargets.Method)] class PropertyAttribute : Attribute {}
+
+        """;
+
+    // --- Fires on [Property] parameter of custom struct with no [Arbitrary] and no [From<T>] ---
+
+    [Fact]
+    public async Task PropertyParam_CustomStructNoArbitraryNoFrom_EmitsCon109()
+    {
+        await VerifyAsync(Preamble + """
+            struct MyPoint { public int X; public int Y; }
+            class Tests {
+                [Property]
+                public bool Foo(MyPoint {|CON109:p|}) => true;
+            }
+            """);
+    }
+
+    // --- Fires on [Property] parameter of custom class with no [Arbitrary] and no [From<T>] ---
+
+    [Fact]
+    public async Task PropertyParam_CustomClassNoArbitraryNoFrom_EmitsCon109()
+    {
+        await VerifyAsync(Preamble + """
+            class Widget { }
+            class Tests {
+                [Property]
+                public bool Foo(Widget {|CON109:w|}) => true;
+            }
+            """);
+    }
+
+    // --- Silent when parameter has [From<TStrategy>] ---
+
+    [Fact]
+    public async Task PropertyParam_WithFromAttribute_NoCon109()
+    {
+        await VerifyAsync(Preamble + """
+            struct MyPoint { public int X; public int Y; }
+            class MyPointStrategy : IStrategyProvider { }
+            class Tests {
+                [Property]
+                public bool Foo([From<MyPointStrategy>] MyPoint p) => true;
+            }
+            """);
+    }
+
+    // --- Silent when parameter type is decorated with [Arbitrary] ---
+
+    [Fact]
+    public async Task PropertyParam_TypeWithArbitraryAttribute_NoCon109()
+    {
+        await VerifyAsync(Preamble + """
+            [Arbitrary] class Person { }
+            class Tests {
+                [Property]
+                public bool Foo(Person p) => true;
+            }
+            """);
+    }
+
+    // --- Silent for built-in int parameter ---
+
+    [Fact]
+    public async Task PropertyParam_BuiltInInt_NoCon109()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo(int x) => x >= 0;
+            }
+            """);
+    }
+
+    // --- Silent for built-in bool parameter ---
+
+    [Fact]
+    public async Task PropertyParam_BuiltInBool_NoCon109()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo(bool b) => b || !b;
+            }
+            """);
+    }
+
+    // --- Silent for built-in string parameter ---
+
+    [Fact]
+    public async Task PropertyParam_BuiltInString_NoCon109()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo(string s) => s is not null;
+            }
+            """);
+    }
+
+    // --- Silent for built-in double parameter ---
+
+    [Fact]
+    public async Task PropertyParam_BuiltInDouble_NoCon109()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo(double d) => double.IsFinite(d) || !double.IsFinite(d);
+            }
+            """);
+    }
+
+    // --- Silent for fully-qualified primitive (System.Int32) ---
+
+    [Fact]
+    public async Task PropertyParam_FullyQualifiedInt_NoCon109()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo(System.Int32 x) => x >= 0;
+            }
+            """);
+    }
+
+    // --- Silent for methods without [Property] ---
+
+    [Fact]
+    public async Task NonPropertyMethod_CustomStructParam_NoCon109()
+    {
+        await VerifyAsync(Preamble + """
+            struct MyPoint { public int X; public int Y; }
+            class Tests {
+                public bool Foo(MyPoint p) => true;
+            }
+            """);
+    }
+
+    // --- Diagnostic span points to the parameter name ---
+
+    [Fact]
+    public async Task PropertyParam_CustomStruct_Con109IsWarning()
+    {
+        await VerifyAsync(
+            Preamble + """
+            struct MyPoint { public int X; public int Y; }
+            class Tests {
+                [Property]
+                public bool Foo(MyPoint {|#0:p|}) => true;
+            }
+            """,
+            new DiagnosticResult("CON109", DiagnosticSeverity.Warning).WithLocation(0));
+    }
+
+    // --- Diagnostic message contains parameter name and type name ---
+
+    [Fact]
+    public async Task PropertyParam_CustomStruct_Con109MessageContainsParamAndType()
+    {
+        await VerifyAsync(
+            Preamble + """
+            struct MyPoint { public int X; public int Y; }
+            class Tests {
+                [Property]
+                public bool Foo(MyPoint {|#0:p|}) => true;
+            }
+            """,
+            new DiagnosticResult("CON109", DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("p", "MyPoint"));
+    }
+
+    // --- Helpers ---
+
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+    {
+        CSharpAnalyzerTest<CON109Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+}

--- a/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
@@ -3,4 +3,5 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 CON107 | Conjecture | Warning | Non-deterministic operation inside a [Property] method
+CON109 | Conjecture | Warning | CON109Analyzer
 | CJ0050 | Usage | Info | Suggest named extension property |

--- a/src/Conjecture.Analyzers/CON109Analyzer.cs
+++ b/src/Conjecture.Analyzers/CON109Analyzer.cs
@@ -11,16 +11,16 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Conjecture.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-internal sealed class CON105Analyzer : DiagnosticAnalyzer
+internal sealed class CON109Analyzer : DiagnosticAnalyzer
 {
     internal static readonly DiagnosticDescriptor Rule = new(
-        id: "CON105",
-        title: "[Arbitrary] provider exists but [From<T>] not used",
-        messageFormat: "Parameter '{0}' of type '{1}' has an [Arbitrary] provider; use [From<{1}Arbitrary>] to opt in",
+        id: "CON109",
+        title: "No strategy found for [Property] parameter",
+        messageFormat: "No strategy found for parameter '{0}' of type '{1}'; add [Arbitrary] to the type or use [From<TStrategy>]",
         category: "Conjecture",
-        defaultSeverity: DiagnosticSeverity.Info,
+        defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "When a type is decorated with [Arbitrary], its generated provider should be referenced explicitly via [From<T>] on the parameter.");
+        description: "All [Property] parameters must have a resolvable strategy.");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);
@@ -34,40 +34,47 @@ internal sealed class CON105Analyzer : DiagnosticAnalyzer
 
     private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
     {
-        var method = (MethodDeclarationSyntax)context.Node;
+        MethodDeclarationSyntax method = (MethodDeclarationSyntax)context.Node;
 
         if (!PropertyAttributeHelper.HasPropertyAttribute(method, context.SemanticModel))
         {
             return;
         }
 
-        foreach (ParameterSyntax param in method.ParameterList.Parameters)
+        foreach (ParameterSyntax parameter in method.ParameterList.Parameters)
         {
-            if (param.Type is null)
+            if (PropertyAttributeHelper.HasFromAttribute(parameter, context.SemanticModel))
             {
                 continue;
             }
 
-            if (context.SemanticModel.GetSymbolInfo(param.Type).Symbol is not INamedTypeSymbol typeSymbol)
+            TypeSyntax? typeSyntax = parameter.Type;
+            if (typeSyntax is null)
             {
                 continue;
             }
 
-            if (!PropertyAttributeHelper.HasArbitraryAttribute(typeSymbol))
+            ITypeSymbol? typeSymbol = context.SemanticModel.GetTypeInfo(typeSyntax).Type;
+
+            if (typeSymbol is null)
             {
                 continue;
             }
 
-            if (PropertyAttributeHelper.HasFromAttribute(param, context.SemanticModel))
+            if (typeSymbol.SpecialType != SpecialType.None)
             {
                 continue;
             }
 
-            context.ReportDiagnostic(Diagnostic.Create(
-                Rule,
-                param.GetLocation(),
-                param.Identifier.Text,
-                typeSymbol.Name));
+            if (PropertyAttributeHelper.HasArbitraryAttribute(typeSymbol))
+            {
+                continue;
+            }
+
+            string paramName = parameter.Identifier.Text;
+            string typeName = typeSyntax.ToString();
+            context.ReportDiagnostic(
+                Diagnostic.Create(Rule, parameter.Identifier.GetLocation(), paramName, typeName));
         }
     }
 }

--- a/src/Conjecture.Analyzers/PropertyAttributeHelper.cs
+++ b/src/Conjecture.Analyzers/PropertyAttributeHelper.cs
@@ -49,4 +49,44 @@ internal static class PropertyAttributeHelper
 
         return false;
     }
+
+    internal static bool HasFromAttribute(ParameterSyntax parameter, SemanticModel model)
+    {
+        foreach (AttributeListSyntax attrList in parameter.AttributeLists)
+        {
+            foreach (AttributeSyntax attr in attrList.Attributes)
+            {
+                SymbolInfo info = model.GetSymbolInfo(attr);
+                ISymbol? symbol = info.Symbol ?? info.CandidateSymbols.FirstOrDefault();
+                if (symbol?.ContainingType?.MetadataName == "FromAttribute`1")
+                {
+                    return true;
+                }
+
+                // Fallback: name-based when attribute is unresolvable
+                string name = attr.Name.ToString();
+                if (name.StartsWith("From<", System.StringComparison.Ordinal) || name == "From")
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool HasArbitraryAttribute(ITypeSymbol typeSymbol)
+    {
+        foreach (AttributeData attr in typeSymbol.GetAttributes())
+        {
+            INamedTypeSymbol? attrClass = attr.AttributeClass;
+            if (attrClass?.Name is "ArbitraryAttribute" or "Arbitrary" &&
+                attrClass.ContainingNamespace?.ToDisplayString() == "Conjecture.Core")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
## Description

Adds `CON109Analyzer`, which emits a `Warning` when a `[Property]` method parameter has no resolvable strategy — i.e. the type is not a built-in primitive, not decorated with `[Arbitrary]`, and has no `[From<T>]` attribute.

Also extracts `HasFromAttribute` and `HasArbitraryAttribute` from `CON105Analyzer` into `PropertyAttributeHelper` so both analyzers share the same (correct, namespace-guarded) implementations.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #168
Part of #61