### PR TITLE
[61.4] CON110Analyzer: detect async [Property] method without await

### DIFF
--- a/src/Conjecture.Analyzers.Tests/CON110Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON110Tests.cs
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Conjecture.Analyzers.Tests;
+
+public sealed class CON110Tests
+{
+    // Stub types so tests don't need external assembly references.
+    private const string Preamble = """
+        using System;
+        using System.Threading.Tasks;
+        [AttributeUsage(AttributeTargets.Method)] class PropertyAttribute : Attribute {}
+
+        """;
+
+    // --- Fires on async Task<bool> [Property] method with no await ---
+
+    [Fact]
+    public async Task AsyncTaskBool_PropertyMethodNoAwait_EmitsCon110()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public {|CON110:async|} Task<bool> Foo(int x) { return x > 0; }
+            }
+            """);
+    }
+
+    // --- Fires on async Task [Property] method with no await ---
+
+    [Fact]
+    public async Task AsyncTask_PropertyMethodNoAwait_EmitsCon110()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public {|CON110:async|} Task Bar(int x) { }
+            }
+            """);
+    }
+
+    // --- Diagnostic is Info severity ---
+
+    [Fact]
+    public async Task AsyncTaskBool_PropertyMethodNoAwait_Con110IsInfo()
+    {
+        await VerifyAsync(
+            Preamble + """
+            class Tests {
+                [Property]
+                public {|#0:async|} Task<bool> Foo(int x) { return x > 0; }
+            }
+            """,
+            new DiagnosticResult("CON110", DiagnosticSeverity.Info).WithLocation(0));
+    }
+
+    // --- Diagnostic message contains the method name ---
+
+    [Fact]
+    public async Task AsyncTaskBool_PropertyMethodNoAwait_Con110MessageContainsMethodName()
+    {
+        await VerifyAsync(
+            Preamble + """
+            class Tests {
+                [Property]
+                public {|#0:async|} Task<bool> Foo(int x) { return x > 0; }
+            }
+            """,
+            new DiagnosticResult("CON110", DiagnosticSeverity.Info)
+                .WithLocation(0)
+                .WithArguments("Foo"));
+    }
+
+    // --- Diagnostic span is on the async keyword token ---
+
+    [Fact]
+    public async Task AsyncTask_PropertyMethodNoAwait_Con110SpanOnAsyncKeyword()
+    {
+        await VerifyAsync(
+            Preamble + """
+            class Tests {
+                [Property]
+                public {|#0:async|} Task Bar(int x) { }
+            }
+            """,
+            new DiagnosticResult("CON110", DiagnosticSeverity.Info).WithLocation(0));
+    }
+
+    // --- Silent when async [Property] method contains at least one await ---
+
+    [Fact]
+    public async Task AsyncTask_PropertyMethodWithAwait_NoCon110()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public async Task<bool> Foo(int x) { await Task.Yield(); return x > 0; }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task AsyncTaskBool_PropertyMethodWithAwait_NoCon110()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public async Task<bool> Foo(int x) { bool result = await Task.FromResult(x > 0); return result; }
+            }
+            """);
+    }
+
+    // --- Silent for non-async [Property] methods ---
+
+    [Fact]
+    public async Task NonAsync_PropertyMethod_NoCon110()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo(int x) => x > 0;
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task NonAsyncTask_PropertyMethod_NoCon110()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public Task<bool> Foo(int x) => Task.FromResult(x > 0);
+            }
+            """);
+    }
+
+    // --- Silent for async methods without [Property] ---
+
+    [Fact]
+    public async Task AsyncTaskNoAwait_NonPropertyMethod_NoCon110()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                public async Task<bool> Foo(int x) { return Task.FromResult(x > 0).Result; }
+            }
+            """);
+    }
+
+    [Fact]
+    public async Task AsyncTaskNoAwait_NonPropertyMethodVoid_NoCon110()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                public async Task Bar() { return; }
+            }
+            """);
+    }
+
+    // --- Helpers ---
+
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+    {
+        CSharpAnalyzerTest<CON110Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+}

--- a/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
@@ -4,4 +4,5 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 CON107 | Conjecture | Warning | Non-deterministic operation inside a [Property] method
 CON109 | Conjecture | Warning | CON109Analyzer
+CON110 | Conjecture | Info | CON110Analyzer
 | CJ0050 | Usage | Info | Suggest named extension property |

--- a/src/Conjecture.Analyzers/CON110Analyzer.cs
+++ b/src/Conjecture.Analyzers/CON110Analyzer.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Conjecture.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class CON110Analyzer : DiagnosticAnalyzer
+{
+    internal static readonly DiagnosticDescriptor Rule = new(
+        id: "CON110",
+        title: "Async [Property] method contains no await",
+        messageFormat: "[Property] method '{0}' is declared async but contains no await; remove 'async' or add an awaited call",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "An async [Property] method with no await expression adds unnecessary overhead and may indicate a missing await.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+    }
+
+    private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+    {
+        MethodDeclarationSyntax method = (MethodDeclarationSyntax)context.Node;
+
+        if (!PropertyAttributeHelper.HasPropertyAttribute(method, context.SemanticModel))
+        {
+            return;
+        }
+
+        SyntaxToken asyncKeyword = method.Modifiers.FirstOrDefault(
+            static m => m.IsKind(SyntaxKind.AsyncKeyword));
+
+        if (asyncKeyword.IsKind(SyntaxKind.None))
+        {
+            return;
+        }
+
+        bool hasAwait = method.DescendantNodes().OfType<AwaitExpressionSyntax>().Any();
+        if (hasAwait)
+        {
+            return;
+        }
+
+        string methodName = method.Identifier.Text;
+        context.ReportDiagnostic(Diagnostic.Create(Rule, asyncKeyword.GetLocation(), methodName));
+    }
+}


### PR DESCRIPTION
## Description

Adds `CON110Analyzer`, which emits an `Info` diagnostic when a `[Property]` method is declared `async` but contains no `await` expression. The diagnostic is placed on the `async` keyword token.

This mirrors the intent of compiler warning CS1998 but scoped to property-based test methods, where an accidentally async method may indicate a missing awaited call.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #169
Part of #61