### PR TITLE
[61.5] CON108Analyzer: detect unreachable Assume.That() with known built-in providers

### DIFF
--- a/src/Conjecture.Analyzers.Tests/CON108Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON108Tests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Conjecture.Analyzers.Tests;
+
+public sealed class CON108Tests
+{
+    // Preamble stubs PropertyAttribute and the named strategy classes.
+    // Assume and From<T> come from Conjecture.Core via AddRuntimeReferences.
+    private const string Preamble = """
+        using System;
+        using Conjecture.Core;
+        [AttributeUsage(AttributeTargets.Method)] class PropertyAttribute : Attribute {}
+        class PositiveInts : IStrategyProvider {}
+        class NegativeInts : IStrategyProvider {}
+        class NonNegativeInts : IStrategyProvider {}
+
+        """;
+
+    // --- Fires: [From<PositiveInts>] int x with Assume.That(x > 0) ---
+
+    [Fact]
+    public async Task PositiveInts_AssumeGreaterThanZero_EmitsCon108()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo([From<PositiveInts>] int x)
+                {
+                    {|CON108:Assume.That(x > 0)|};
+                    return x > 0;
+                }
+            }
+            """);
+    }
+
+    // --- Fires: [From<NegativeInts>] int x with Assume.That(x < 0) ---
+
+    [Fact]
+    public async Task NegativeInts_AssumeLessThanZero_EmitsCon108()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo([From<NegativeInts>] int x)
+                {
+                    {|CON108:Assume.That(x < 0)|};
+                    return x < 0;
+                }
+            }
+            """);
+    }
+
+    // --- Diagnostic severity and message ---
+
+    [Fact]
+    public async Task PositiveInts_AssumeGreaterThanZero_Con108IsWarning()
+    {
+        await VerifyAsync(
+            Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo([From<PositiveInts>] int x)
+                {
+                    {|#0:Assume.That(x > 0)|};
+                    return x > 0;
+                }
+            }
+            """,
+            new DiagnosticResult("CON108", DiagnosticSeverity.Warning).WithLocation(0));
+    }
+
+    [Fact]
+    public async Task PositiveInts_AssumeGreaterThanZero_Con108MessageContainsParamAndStrategy()
+    {
+        await VerifyAsync(
+            Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo([From<PositiveInts>] int x)
+                {
+                    {|#0:Assume.That(x > 0)|};
+                    return x > 0;
+                }
+            }
+            """,
+            new DiagnosticResult("CON108", DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("x", "PositiveInts"));
+    }
+
+    // --- Silent: [From<PositiveInts>] int x with Assume.That(x > 5) (more restrictive) ---
+
+    [Fact]
+    public async Task PositiveInts_AssumeGreaterThanFive_NoCon108()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo([From<PositiveInts>] int x)
+                {
+                    Assume.That(x > 5);
+                    return x > 5;
+                }
+            }
+            """);
+    }
+
+    // --- Fires: [From<PositiveInts>] int x with Assume.That(x >= 1) (x > 0 implies x >= 1) ---
+
+    [Fact]
+    public async Task PositiveInts_AssumeGreaterThanOrEqualOne_EmitsCon108()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo([From<PositiveInts>] int x)
+                {
+                    {|CON108:Assume.That(x >= 1)|};
+                    return x >= 1;
+                }
+            }
+            """);
+    }
+
+    // --- Silent: custom provider type — unknown strategy ---
+
+    [Fact]
+    public async Task CustomProvider_NoCon108()
+    {
+        await VerifyAsync(Preamble + """
+            class MyProvider : IStrategyProvider {}
+            class Tests {
+                [Property]
+                public bool Foo([From<MyProvider>] int x)
+                {
+                    Assume.That(x > 0);
+                    return x > 0;
+                }
+            }
+            """);
+    }
+
+    // --- Silent: Assume.That(x > 0) without [From<T>] ---
+
+    [Fact]
+    public async Task NoFromAttribute_NoCon108()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo(int x)
+                {
+                    Assume.That(x > 0);
+                    return x > 0;
+                }
+            }
+            """);
+    }
+
+    // --- Silent: outside a [Property] method ---
+
+    [Fact]
+    public async Task OutsidePropertyMethod_NoCon108()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                public bool Foo([From<PositiveInts>] int x)
+                {
+                    Assume.That(x > 0);
+                    return x > 0;
+                }
+            }
+            """);
+    }
+
+    // --- Helpers ---
+
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+    {
+        CSharpAnalyzerTest<CON108Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+}

--- a/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
@@ -3,6 +3,7 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 CON107 | Conjecture | Warning | Non-deterministic operation inside a [Property] method
+CON108 | Conjecture | Warning | Assume.That condition always true given strategy constraint
 CON109 | Conjecture | Warning | CON109Analyzer
 CON110 | Conjecture | Info | CON110Analyzer
 | CJ0050 | Usage | Info | Suggest named extension property |

--- a/src/Conjecture.Analyzers/CON108Analyzer.cs
+++ b/src/Conjecture.Analyzers/CON108Analyzer.cs
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Conjecture.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class CON108Analyzer : DiagnosticAnalyzer
+{
+    internal static readonly DiagnosticDescriptor Rule = new(
+        id: "CON108",
+        title: "Assume.That condition is always true given strategy constraint",
+        messageFormat: "Assume.That condition is always true for parameter '{0}' given strategy '{1}'; remove the redundant assumption",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The strategy guarantees the parameter already satisfies this condition; the Assume.That call is redundant.");
+
+    // Maps strategy class name → (operator kind, threshold) that the strategy guarantees.
+    private static readonly Dictionary<string, (SyntaxKind Op, int Threshold)> KnownStrategies = new()
+    {
+        ["PositiveInts"] = (SyntaxKind.GreaterThanExpression, 0),
+        ["NegativeInts"] = (SyntaxKind.LessThanExpression, 0),
+        ["NonNegativeInts"] = (SyntaxKind.GreaterThanOrEqualExpression, 0),
+    };
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsAssumeThat(invocation, context.SemanticModel))
+        {
+            return;
+        }
+
+        if (invocation.ArgumentList.Arguments.Count != 1)
+        {
+            return;
+        }
+
+        MethodDeclarationSyntax? method = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (method is null)
+        {
+            return;
+        }
+
+        if (!PropertyAttributeHelper.HasPropertyAttribute(method, context.SemanticModel))
+        {
+            return;
+        }
+
+        ExpressionSyntax condition = invocation.ArgumentList.Arguments[0].Expression;
+        if (condition is not BinaryExpressionSyntax binary)
+        {
+            return;
+        }
+
+        if (binary.Left is not IdentifierNameSyntax paramRef)
+        {
+            return;
+        }
+
+        if (binary.Right is not LiteralExpressionSyntax literal ||
+            !literal.Token.IsKind(SyntaxKind.NumericLiteralToken))
+        {
+            return;
+        }
+
+        string referencedParam = paramRef.Identifier.Text;
+        SyntaxKind conditionOp = binary.Kind();
+        int conditionThreshold = (int)literal.Token.Value!;
+
+        foreach (ParameterSyntax parameter in method.ParameterList.Parameters)
+        {
+            if (parameter.Identifier.Text != referencedParam)
+            {
+                continue;
+            }
+
+            string? strategyName = PropertyAttributeHelper.TryGetFromStrategyTypeName(parameter);
+            if (strategyName is null)
+            {
+                break;
+            }
+
+            if (!KnownStrategies.TryGetValue(strategyName, out (SyntaxKind Op, int Threshold) constraint))
+            {
+                break;
+            }
+
+            if (IsImplied(constraint.Op, constraint.Threshold, conditionOp, conditionThreshold))
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(Rule, invocation.GetLocation(), referencedParam, strategyName));
+            }
+
+            break;
+        }
+    }
+
+    private static bool IsAssumeThat(InvocationExpressionSyntax invocation, SemanticModel model)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+
+        if (memberAccess.Name.Identifier.Text != "That")
+        {
+            return false;
+        }
+
+        SymbolInfo info = model.GetSymbolInfo(invocation);
+        if (info.Symbol is IMethodSymbol method)
+        {
+            return method.ContainingType.ToDisplayString() == "Conjecture.Core.Assume";
+        }
+
+        // Fallback when semantic resolution is unavailable
+        return memberAccess.Expression.ToString() == "Assume";
+    }
+
+    // Returns true when the constraint (constraintOp, constraintThreshold) guarantees
+    // that the condition (conditionOp, conditionThreshold) is always satisfied.
+    private static bool IsImplied(
+        SyntaxKind constraintOp,
+        int constraintThreshold,
+        SyntaxKind conditionOp,
+        int conditionThreshold)
+    {
+        return (constraintOp, conditionOp) switch
+        {
+            // x > k implies x > n  iff  k >= n
+            (SyntaxKind.GreaterThanExpression, SyntaxKind.GreaterThanExpression)
+                => constraintThreshold >= conditionThreshold,
+
+            // x < k implies x < n  iff  k <= n
+            (SyntaxKind.LessThanExpression, SyntaxKind.LessThanExpression)
+                => constraintThreshold <= conditionThreshold,
+
+            // x >= k implies x >= n  iff  k >= n
+            (SyntaxKind.GreaterThanOrEqualExpression, SyntaxKind.GreaterThanOrEqualExpression)
+                => constraintThreshold >= conditionThreshold,
+
+            // x > k implies x >= n  iff  k+1 >= n  (i.e. k >= n-1)
+            (SyntaxKind.GreaterThanExpression, SyntaxKind.GreaterThanOrEqualExpression)
+                => constraintThreshold + 1 >= conditionThreshold,
+
+            _ => false,
+        };
+    }
+}

--- a/src/Conjecture.Analyzers/PropertyAttributeHelper.cs
+++ b/src/Conjecture.Analyzers/PropertyAttributeHelper.cs
@@ -89,4 +89,25 @@ internal static class PropertyAttributeHelper
 
         return false;
     }
+
+    /// <summary>
+    /// Returns the unqualified type name of <c>T</c> in a <c>[From&lt;T&gt;]</c> attribute,
+    /// or <see langword="null"/> if no such attribute is present.
+    /// </summary>
+    internal static string? TryGetFromStrategyTypeName(ParameterSyntax parameter)
+    {
+        foreach (AttributeListSyntax attrList in parameter.AttributeLists)
+        {
+            foreach (AttributeSyntax attr in attrList.Attributes)
+            {
+                string name = attr.Name.ToString();
+                if (name.StartsWith("From<", System.StringComparison.Ordinal) && name.EndsWith(">"))
+                {
+                    return name.Substring(5, name.Length - 6);
+                }
+            }
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
## Description

Adds `CON108Analyzer`, which warns when an `Assume.That(condition)` call inside a `[Property]` method is provably redundant because the parameter's strategy already guarantees the condition.

Built-in strategy constraints recognised:
- `PositiveInts` → `x > 0`
- `NegativeInts` → `x < 0`
- `NonNegativeInts` → `x >= 0`

The implication check handles same-operator comparisons and the cross-operator case `x > k` → `x >= k+1`. Unknown strategies and non-trivial conditions (e.g. `x > 5` with `PositiveInts`) are silently ignored.

Also extracts `TryGetFromStrategyTypeName` into `PropertyAttributeHelper` to centralise `From<T>` generic-attribute text parsing.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #170
Part of #61