### PR TITLE
[61.6] CON111Analyzer: detect Target.Maximize/Minimize outside [Property] context

### DIFF
--- a/src/Conjecture.Analyzers.Tests/CON111Tests.cs
+++ b/src/Conjecture.Analyzers.Tests/CON111Tests.cs
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Conjecture.Analyzers.Tests;
+
+public sealed class CON111Tests
+{
+    private const string Preamble = """
+        using System;
+        using Conjecture.Core;
+        [AttributeUsage(AttributeTargets.Method)] class PropertyAttribute : Attribute {}
+
+        """;
+
+    // --- Fires: Target.Maximize inside a non-[Property] method ---
+
+    [Fact]
+    public async Task Target_Maximize_NonPropertyMethod_EmitsCon111()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                public void Foo(double x) { {|CON111:Target.Maximize(x)|}; }
+            }
+            """);
+    }
+
+    // --- Fires: Target.Minimize inside a non-[Property] method ---
+
+    [Fact]
+    public async Task Target_Minimize_NonPropertyMethod_EmitsCon111()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                public void Foo(double x) { {|CON111:Target.Minimize(x)|}; }
+            }
+            """);
+    }
+
+    // --- Fires: Target.Maximize with no enclosing MethodDeclarationSyntax (static constructor) ---
+
+    [Fact]
+    public async Task Target_Maximize_NoEnclosingMethod_EmitsCon111()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                static Tests() { {|CON111:Target.Maximize(1.0)|}; }
+            }
+            """);
+    }
+
+    // --- Silent: Target.Maximize inside a [Property] method ---
+
+    [Fact]
+    public async Task Target_Maximize_PropertyMethod_NoCon111()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo(double x) { Target.Maximize(x); return x > 0; }
+            }
+            """);
+    }
+
+    // --- Silent: Target.Minimize inside a [Property] method ---
+
+    [Fact]
+    public async Task Target_Minimize_PropertyMethod_NoCon111()
+    {
+        await VerifyAsync(Preamble + """
+            class Tests {
+                [Property]
+                public bool Foo(double x) { Target.Minimize(x); return x < 0; }
+            }
+            """);
+    }
+
+    // --- Diagnostic severity is Warning ---
+
+    [Fact]
+    public async Task Target_Maximize_NonPropertyMethod_Con111IsWarning()
+    {
+        await VerifyAsync(
+            Preamble + """
+            class Tests {
+                public void Foo(double x) { {|#0:Target.Maximize(x)|}; }
+            }
+            """,
+            new DiagnosticResult("CON111", DiagnosticSeverity.Warning).WithLocation(0));
+    }
+
+    // --- Diagnostic message contains the method name ---
+
+    [Fact]
+    public async Task Target_Maximize_NonPropertyMethod_Con111MessageContainsMethodName()
+    {
+        await VerifyAsync(
+            Preamble + """
+            class Tests {
+                public void Foo(double x) { {|#0:Target.Maximize(x)|}; }
+            }
+            """,
+            new DiagnosticResult("CON111", DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("Maximize"));
+    }
+
+    [Fact]
+    public async Task Target_Minimize_NonPropertyMethod_Con111MessageContainsMethodName()
+    {
+        await VerifyAsync(
+            Preamble + """
+            class Tests {
+                public void Foo(double x) { {|#0:Target.Minimize(x)|}; }
+            }
+            """,
+            new DiagnosticResult("CON111", DiagnosticSeverity.Warning)
+                .WithLocation(0)
+                .WithArguments("Minimize"));
+    }
+
+    // --- Silent: user-defined Target type (not Conjecture.Core.Target) ---
+
+    [Fact]
+    public async Task UserDefinedTarget_Maximize_NonPropertyMethod_NoCon111()
+    {
+        await VerifyAsync("""
+            using System;
+            [AttributeUsage(AttributeTargets.Method)] class PropertyAttribute : Attribute {}
+            static class Target { public static void Maximize(double x) { } }
+
+            class Tests {
+                public void Foo(double x) { Target.Maximize(x); }
+            }
+            """);
+    }
+
+    // --- Helpers ---
+
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+    {
+        CSharpAnalyzerTest<CON111Analyzer, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestHelpers.EmptyNet10,
+        };
+        TestHelpers.AddRuntimeReferences(test.TestState.AdditionalReferences);
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+}

--- a/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Analyzers/AnalyzerReleases.Unshipped.md
@@ -6,4 +6,5 @@ CON107 | Conjecture | Warning | Non-deterministic operation inside a [Property] 
 CON108 | Conjecture | Warning | Assume.That condition always true given strategy constraint
 CON109 | Conjecture | Warning | CON109Analyzer
 CON110 | Conjecture | Info | CON110Analyzer
+CON111 | Conjecture | Warning | CON111Analyzer
 | CJ0050 | Usage | Info | Suggest named extension property |

--- a/src/Conjecture.Analyzers/CON111Analyzer.cs
+++ b/src/Conjecture.Analyzers/CON111Analyzer.cs
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Conjecture.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class CON111Analyzer : DiagnosticAnalyzer
+{
+    internal static readonly DiagnosticDescriptor Rule = new(
+        id: "CON111",
+        title: "Target.Maximize/Minimize has no effect outside a [Property] method",
+        messageFormat: "'{0}' has no effect outside a [Property] method; move this call inside a [Property] method",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Target.Maximize and Target.Minimize only affect generation when called inside a [Property] method body.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
+    {
+        InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
+
+        if (!IsTargetCall(invocation, context.SemanticModel, out string? methodName))
+        {
+            return;
+        }
+
+        MethodDeclarationSyntax? method = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+
+        if (method is not null && PropertyAttributeHelper.HasPropertyAttribute(method, context.SemanticModel))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), methodName));
+    }
+
+    private static bool IsTargetCall(
+        InvocationExpressionSyntax invocation,
+        SemanticModel model,
+        out string? methodName)
+    {
+        methodName = null;
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+
+        string name = memberAccess.Name.Identifier.Text;
+        if (name != "Maximize" && name != "Minimize")
+        {
+            return false;
+        }
+
+        SymbolInfo info = model.GetSymbolInfo(invocation);
+        ISymbol? symbol = info.Symbol ?? info.CandidateSymbols.FirstOrDefault();
+        if (symbol is IMethodSymbol methodSymbol)
+        {
+            if (methodSymbol.ContainingType.ToDisplayString() == "Conjecture.Core.Target")
+            {
+                methodName = name;
+                return true;
+            }
+
+            return false;
+        }
+
+        // Fallback when semantic resolution is unavailable.
+        // Check the receiver type: if it resolves to a type other than Conjecture.Core.Target, reject.
+        if (memberAccess.Expression.ToString() == "Target")
+        {
+            TypeInfo receiverType = model.GetTypeInfo(memberAccess.Expression);
+            if (receiverType.Type is INamedTypeSymbol receiverSymbol &&
+                receiverSymbol.ToDisplayString() != "Conjecture.Core.Target")
+            {
+                return false;
+            }
+
+            methodName = name;
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Description

Adds `CON111Analyzer`, which fires a Warning when `Target.Maximize` or `Target.Minimize` is called outside a `[Property]` method. These calls have no effect on generation outside the property test body, so the diagnostic guides users to move them to the right place.

Detection uses the semantic model (with `CandidateSymbols` fallback). The string-based fallback also checks the receiver's type info to avoid false positives on user-defined types named `Target`.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #171
Part of #61