### PR TITLE
Release prep: documentation and changelog for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+### Added
+
+**Analyzers** (new package `Conjecture.Analyzers`, bundled into `Conjecture.Core.nupkg`)
+- CON107: Non-deterministic operation inside `[Property]` (`Guid.NewGuid()`, `DateTime.Now`, `Random`, etc.)
+- CON108: `Assume.That` condition always true given built-in strategy constraint (`PositiveInts`, `NegativeInts`, `NonNegativeInts`)
+- CON109: Missing strategy for `[Property]` parameter type
+- CON110: Async `[Property]` method contains no `await`
+- CON111: `Target.Maximize`/`Target.Minimize` outside `[Property]` method
+- CJ0050: Suggest named extension property (`.Positive`, `.NonEmpty`) instead of equivalent `.Where()` — with code fix
+
+**Time** (new package `Conjecture.Time`)
+- `TimeGenerate.TimeZones()` — strategy over system time zones, shrinks toward UTC
+- `TimeGenerate.ClockSet(nodeCount, maxSkew)` — generates an array of `FakeTimeProvider` instances with clock skew
+- `TimeProviderArbitrary` — `[Arbitrary]` auto-provider for `TimeProvider` parameters
+- `DateTimeOffsetExtensions`: `.NearMidnight()`, `.NearLeapYear()`, `.NearEpoch()`, `.NearDstTransition(zone?)`
+
+**Interactive** (new package `Conjecture.Interactive`)
+- `Strategy<T>.Preview(count, seed)` — quick-look HTML table of sample values
+- `Strategy<T>.SampleTable(count, seed)` — indexed HTML sample table
+- `Strategy<T>.Histogram(sampleSize, bucketCount, seed)` — SVG histogram of distribution
+- `Strategy<T>.ShrinkTrace(seed, failingProperty)` — step-by-step shrink trace
+- `ConjectureKernelExtension` — Polyglot Notebooks auto-load
+
+**Core**
+- `Generate.FromBytes<T>(ReadOnlySpan<byte>)` — deterministic replay from a fixed byte buffer
+- `Generate.DateTimeOffsets()` / `Generate.DateTimeOffsets(min, max)`
+- `Generate.TimeSpans()` / `Generate.TimeSpans(min, max)`
+- `Generate.DateOnlyValues()` / `Generate.DateOnlyValues(min, max)`
+- `Generate.TimeOnlyValues()` / `Generate.TimeOnlyValues(min, max)`
+
+**Tool**
+- `PlanRunner` resolves `IStrategyProvider<T>` via reflection for arbitrary types in plan steps
+
 ---
 
 ## [0.7.0] — 2026-04-11

--- a/docs/site/articles/changelog.md
+++ b/docs/site/articles/changelog.md
@@ -1,22 +1,3 @@
 # Changelog
 
-All notable changes are documented here. See also [`CHANGELOG.md`](https://github.com/kommundsen/Conjecture/blob/main/CHANGELOG.md) in the repository root.
-
-## [0.6.0-alpha.1] — 2026-04-05
-
-First public alpha. All seven implementation phases complete.
-
-### Added
-
-- **Core engine** — byte-stream-backed generation, `SplittableRandom` PRNG, `[Property]` attribute
-- **Strategy library** — integers, floats, strings, booleans, bytes, enums, collections, tuples, nullable, `SampledFrom`, `Just`, `OneOf`, `Recursive`, `StateMachine`
-- **LINQ combinators** — `Select`, `Where`, `SelectMany`, `Zip`, `OrNull`, `WithLabel`, `Generate.Compose`
-- **10-pass shrinking** — universal byte-stream minimization; no custom shrinkers required
-- **Targeted testing** — `Target.Maximize` / `Target.Minimize` with hill-climbing phase
-- **Stateful testing** — `IStateMachine<TState, TCommand>`, command sequence shrinking
-- **Framework adapters** — xUnit v2, xUnit v3, NUnit 4, MSTest
-- **Parameter resolution** — `[From<T>]`, `[FromFactory]`, `[Example]`, `[Arbitrary]`
-- **Roslyn tooling** — source generator + 6 analyzers bundled in `Conjecture.Core`
-- **Example database** — SQLite persistence of failing inputs for regression prevention
-- **Structured logging** — `ILogger` integration, auto-wired in all adapters
-- **Release infrastructure** — MinVer, SourceLink, GitHub Actions publish workflow
+The full changelog is maintained in [`CHANGELOG.md`](https://github.com/kommundsen/Conjecture/blob/main/CHANGELOG.md) at the repository root.

--- a/docs/site/articles/contributing.md
+++ b/docs/site/articles/contributing.md
@@ -21,8 +21,9 @@ src/
 ├── Conjecture.Core.Tests       # Core unit tests
 ├── Conjecture.Generators       # Source generator ([Arbitrary]) — bundled into Conjecture.Core.nupkg
 ├── Conjecture.Generators.Tests # Source generator tests
-├── Conjecture.Analyzers        # Roslyn analyzer (CON100-105) — bundled into Conjecture.Core.nupkg
-├── Conjecture.Analyzers.Tests  # Roslyn analyser tests
+├── Conjecture.Analyzers        # Roslyn analyzers (CON100–CON111, CJ0050) — bundled into Conjecture.Core.nupkg
+├── Conjecture.Analyzers.CodeFixes # Code fixes for analyzer diagnostics — bundled into Conjecture.Core.nupkg
+├── Conjecture.Analyzers.Tests  # Roslyn analyzer tests
 ├── Conjecture.Xunit            # xUnit v2 adapter
 ├── Conjecture.Xunit.Tests      # xUnit v2 adapter tests
 ├── Conjecture.Xunit.V3         # xUnit v3 adapter
@@ -31,6 +32,16 @@ src/
 ├── Conjecture.NUnit.Tests      # NUnit adapter tests
 ├── Conjecture.MSTest           # MSTest adapter
 ├── Conjecture.MSTest.Tests     # MSTest adapter tests
+├── Conjecture.Formatters       # Output formatters (JSON, JSONL)
+├── Conjecture.Formatters.Tests # Formatter tests
+├── Conjecture.Time             # TimeProvider strategies (Conjecture.Time package)
+├── Conjecture.Time.Tests       # Time strategy tests
+├── Conjecture.Interactive      # Polyglot Notebooks extension (Conjecture.Interactive package)
+├── Conjecture.Interactive.Tests # Interactive extension tests
+├── Conjecture.Tool             # CLI tool (conjecture generate / conjecture plan)
+├── Conjecture.Tool.Tests       # CLI tool tests
+├── Conjecture.Mcp              # MCP server
+├── Conjecture.Mcp.Tests        # MCP server tests
 ├── Conjecture.SelfTests        # Dogfooding (tests Conjecture with Conjecture)
 └── Conjecture.Benchmarks       # BenchmarkDotNet performance tests
 ```

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -21,6 +21,10 @@ items:
     href: use-data-gen.md
   - name: Use the CLI tool
     href: use-cli-tool.md
+  - name: Use time strategies
+    href: use-time-strategies.md
+  - name: Explore strategies in notebooks
+    href: use-notebooks.md
   - name: Use the MCP server
     href: use-mcp-server.md
   - name: Troubleshoot

--- a/docs/site/articles/how-to/use-notebooks.md
+++ b/docs/site/articles/how-to/use-notebooks.md
@@ -1,0 +1,71 @@
+# How to explore strategies in notebooks
+
+Visualise strategy output interactively with `Conjecture.Interactive` in Polyglot Notebooks.
+
+## Install
+
+In a `.dib` notebook cell:
+
+```csharp
+#r "nuget: Conjecture.Core"
+#r "nuget: Conjecture.Interactive"
+using Conjecture.Core;
+using Conjecture.Interactive;
+```
+
+The kernel extension loads automatically.
+
+## Preview sample values
+
+Call `.Preview()` on any strategy to see a quick HTML table:
+
+```csharp
+Generate.Integers<int>(0, 100).Preview()
+```
+
+Pass `count` (default 20, max 100) and `seed` for reproducibility:
+
+```csharp
+Generate.Strings(5, 20).Preview(count: 10, seed: 42)
+```
+
+## Show an indexed sample table
+
+`.SampleTable()` renders a two-column index/value table:
+
+```csharp
+Generate.Doubles(-1, 1).SampleTable(count: 5)
+```
+
+## Plot a distribution histogram
+
+`.Histogram()` returns an SVG histogram. Works on any `IConvertible` strategy:
+
+```csharp
+Generate.Integers<int>(0, 1000).Histogram()
+```
+
+Use the `selector` overload for non-numeric strategies:
+
+```csharp
+Generate.Strings(0, 50).Histogram(s => s.Length)
+```
+
+Tweak `sampleSize` (default 1000) and `bucketCount` (default 20) for resolution.
+
+## Trace a shrink sequence
+
+`.ShrinkTrace()` shows step-by-step minimisation toward a counterexample:
+
+```csharp
+Generate.Integers<int>().ShrinkTrace(seed: 42, x => x < 1000)
+```
+
+The result is a `ShrinkTraceResult<T>` with `.Steps` (list of `ShrinkStep<T>`) and `.Html` (rendered table).
+
+> [!NOTE]
+> The property must fail on the value generated from the given seed, otherwise `ArgumentException` is thrown.
+
+## See also
+
+- [Quick Start notebook](https://github.com/kommundsen/Conjecture/blob/main/docs/notebooks/Conjecture-QuickStart.dib)

--- a/docs/site/articles/how-to/use-source-generators.md
+++ b/docs/site/articles/how-to/use-source-generators.md
@@ -97,5 +97,5 @@ public partial struct Point
 
 ## See also
 
-- [Reference: Analyzers](../reference/analyzers.md) — runtime analyzer rules (CON100–CON105)
+- [Reference: Analyzers](../reference/analyzers.md) — runtime analyzer rules (CON100–CON111, CJ0050)
 - [Reference: Attributes](../reference/attributes.md) — `[Arbitrary]`, `[From<T>]` full reference

--- a/docs/site/articles/how-to/use-time-strategies.md
+++ b/docs/site/articles/how-to/use-time-strategies.md
@@ -1,0 +1,71 @@
+# How to test time-dependent code
+
+Generate deterministic, boundary-focused time values with `Conjecture.Time`.
+
+## Install
+
+```bash
+dotnet add package Conjecture.Time
+```
+
+## Generate boundary dates
+
+Chain extension methods on `Generate.DateTimeOffsets()` to target problematic time regions:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Time;
+
+[Property]
+public bool MidnightRollover_HandledCorrectly(int x)
+{
+    DateTimeOffset dt = DataGen.SampleOne(Generate.DateTimeOffsets().NearMidnight());
+    return FormatDate(dt).Contains(dt.Year.ToString());
+}
+```
+
+Available boundary extensions:
+
+| Method | Targets |
+|---|---|
+| `.NearMidnight()` | +/-30 min of midnight UTC |
+| `.NearLeapYear()` | +/-1 day of Feb 29 |
+| `.NearEpoch()` | Unix epoch, Y2K38, min/max date |
+| `.NearDstTransition(zone?)` | +/-1 hour of a DST transition |
+
+## Test with clock skew
+
+Generate a cluster of `FakeTimeProvider` instances with bounded skew for distributed system tests:
+
+```csharp
+[Property]
+public bool LeaderElection_ConvergesUnderSkew(int x)
+{
+    FakeTimeProvider[] clocks = DataGen.SampleOne(
+        TimeGenerate.ClockSet(nodeCount: 3, maxSkew: TimeSpan.FromSeconds(5)));
+
+    Cluster cluster = new(clocks);
+    cluster.RunElection();
+    return cluster.HasSingleLeader;
+}
+```
+
+## Use TimeProvider as a property parameter
+
+`TimeProviderArbitrary` is an `[Arbitrary]`-decorated provider. Use it with `[From<T>]`:
+
+```csharp
+[Property]
+public bool Scheduler_FiresOnTime([From<TimeProviderArbitrary>] TimeProvider clock)
+{
+    Scheduler scheduler = new(clock);
+    scheduler.ScheduleAt(((FakeTimeProvider)clock).GetUtcNow() + TimeSpan.FromMinutes(5));
+    ((FakeTimeProvider)clock).Advance(TimeSpan.FromMinutes(5));
+    return scheduler.HasFired;
+}
+```
+
+## See also
+
+- [Reference: Time strategies](../reference/time-strategies.md) — full API surface
+- [Reference: Strategies](../reference/strategies.md) — core `Generate.DateTimeOffsets()`, `Generate.TimeSpans()`, etc.

--- a/docs/site/articles/reference/analyzers.md
+++ b/docs/site/articles/reference/analyzers.md
@@ -107,6 +107,112 @@ public bool Test(Money money) => ...;
 public bool Test([From<MoneyArbitrary>] Money money) => ...;
 ```
 
+### CON107: Non-deterministic operation in `[Property]`
+
+**Severity:** Warning  
+**Target:** Calls to `Guid.NewGuid()`, `DateTime.Now`, `DateTime.UtcNow`, `DateTimeOffset.Now`, `DateTimeOffset.UtcNow`, `Random.Shared`, `new Random()`, `Environment.TickCount`, or `Environment.TickCount64` inside a `[Property]` method.
+
+Non-deterministic operations break shrink reproducibility.
+
+```csharp
+// Triggers CON107:
+[Property]
+public bool Bad(int x)
+{
+    Guid id = Guid.NewGuid();  // CON107
+    return id != Guid.Empty;
+}
+
+// Better: inject randomness via a strategy parameter
+[Property]
+public bool Good([From<GuidStrategy>] Guid id) => id != Guid.Empty;
+```
+
+### CON108: Redundant `Assume.That` given strategy constraint
+
+**Severity:** Warning  
+**Target:** `Assume.That(condition)` where the condition is always satisfied by a known built-in strategy (`PositiveInts`, `NegativeInts`, `NonNegativeInts`).
+
+```csharp
+// Triggers CON108:
+[Property]
+public bool Bad([From<PositiveInts>] int x)
+{
+    Assume.That(x > 0);  // CON108: always true for PositiveInts
+    return x * 2 > x;
+}
+
+// Fix: remove the redundant assumption
+[Property]
+public bool Good([From<PositiveInts>] int x) => x * 2 > x;
+```
+
+### CON109: No strategy found for `[Property]` parameter
+
+**Severity:** Warning  
+**Target:** `[Property]` method parameters whose type has no resolvable strategy — no built-in support, no `[From<T>]`, and no `[Arbitrary]` on the type.
+
+```csharp
+// Triggers CON109:
+[Property]
+public bool Bad(MyCustomType x) => x is not null;  // CON109
+
+// Fix: add [Arbitrary] to the type or use [From<T>]
+[Property]
+public bool Good([From<MyCustomTypeStrategy>] MyCustomType x) => x is not null;
+```
+
+### CON110: Async `[Property]` without `await`
+
+**Severity:** Info  
+**Target:** `[Property]` methods declared `async` that contain no `await` expression.
+
+```csharp
+// Triggers CON110:
+[Property]
+public async Task<bool> Bad(int x) { return x > 0; }  // CON110
+
+// Fix: remove async or add an awaited call
+[Property]
+public bool Good(int x) => x > 0;
+```
+
+### CON111: `Target.Maximize`/`Minimize` outside `[Property]`
+
+**Severity:** Warning  
+**Target:** Calls to `Target.Maximize(…)` or `Target.Minimize(…)` in a method not decorated with `[Property]`. These calls are no-ops outside a property test body.
+
+```csharp
+// Triggers CON111:
+public void Helper(double x)
+{
+    Target.Maximize(x);  // CON111: no effect here
+}
+
+// Fix: move the call into a [Property] method
+[Property]
+public bool Good(double x)
+{
+    Target.Maximize(x);
+    return x < 1000;
+}
+```
+
+### CJ0050: Suggest named extension property
+
+**Severity:** Info  
+**Target:** `.Where()` predicates that match a named extension property: `.Positive`, `.Negative`, `.NonZero`, `.NonEmpty`.
+
+A code fix is available.
+
+```csharp
+// Triggers CJ0050:
+var pos = Generate.Integers<int>().Where(x => x > 0);  // CJ0050
+
+// Fix: use the extension property
+var pos = Generate.Integers<int>().Positive;
+```
+
 ## Source generator diagnostics
 
 The `[Arbitrary]` source generator reports its own set of diagnostics:

--- a/docs/site/articles/reference/strategies.md
+++ b/docs/site/articles/reference/strategies.md
@@ -74,6 +74,84 @@ Generates a `byte[]` of exactly `size` bytes. `size` must be ≥ 0.
 
 See [String strategies reference](string-strategies.md) for `Strings`, `Text`, `Identifiers`, `NumericStrings`, and `VersionStrings`.
 
+## Date and time strategies
+
+### `Generate.DateTimeOffsets()`
+
+```csharp
+Strategy<DateTimeOffset> Generate.DateTimeOffsets()
+```
+
+Generates `DateTimeOffset` values across the full range.
+
+### `Generate.DateTimeOffsets(DateTimeOffset min, DateTimeOffset max)`
+
+```csharp
+Strategy<DateTimeOffset> Generate.DateTimeOffsets(DateTimeOffset min, DateTimeOffset max)
+```
+
+Generates `DateTimeOffset` values in `[min, max]`.
+
+### `Generate.TimeSpans()`
+
+```csharp
+Strategy<TimeSpan> Generate.TimeSpans()
+```
+
+Generates `TimeSpan` values across the full range.
+
+### `Generate.TimeSpans(TimeSpan min, TimeSpan max)`
+
+```csharp
+Strategy<TimeSpan> Generate.TimeSpans(TimeSpan min, TimeSpan max)
+```
+
+Generates `TimeSpan` values in `[min, max]`.
+
+### `Generate.DateOnlyValues()`
+
+```csharp
+Strategy<DateOnly> Generate.DateOnlyValues()
+```
+
+Generates `DateOnly` values across the full range.
+
+### `Generate.DateOnlyValues(DateOnly min, DateOnly max)`
+
+```csharp
+Strategy<DateOnly> Generate.DateOnlyValues(DateOnly min, DateOnly max)
+```
+
+Generates `DateOnly` values in `[min, max]`.
+
+### `Generate.TimeOnlyValues()`
+
+```csharp
+Strategy<TimeOnly> Generate.TimeOnlyValues()
+```
+
+Generates `TimeOnly` values across the full range.
+
+### `Generate.TimeOnlyValues(TimeOnly min, TimeOnly max)`
+
+```csharp
+Strategy<TimeOnly> Generate.TimeOnlyValues(TimeOnly min, TimeOnly max)
+```
+
+Generates `TimeOnly` values in `[min, max]`.
+
+For boundary-focused extensions (`.NearMidnight()`, `.NearDstTransition()`, etc.) and `TimeGenerate` factory methods, see [Time strategies reference](time-strategies.md).
+
+## Byte buffer strategies
+
+### `Generate.FromBytes<T>(ReadOnlySpan<byte> buffer)`
+
+```csharp
+Strategy<T> Generate.FromBytes<T>(ReadOnlySpan<byte> buffer)
+```
+
+Replays a value of type `T` from a fixed byte buffer using the default strategy for `T`. The buffer is the same format stored by the example database. Useful for deterministic replay and round-trip testing.
+
 ## Collection strategies
 
 ### `Generate.Lists<T>(Strategy<T> inner, int minSize = 0, int maxSize = 100)`

--- a/docs/site/articles/reference/time-strategies.md
+++ b/docs/site/articles/reference/time-strategies.md
@@ -1,0 +1,69 @@
+# Time strategies reference
+
+Strategies in the `Conjecture.Time` package for generating time-related values with boundary awareness.
+
+> [!NOTE]
+> Requires the `Conjecture.Time` NuGet package. The core `Generate.DateTimeOffsets()`, `Generate.TimeSpans()`, `Generate.DateOnlyValues()`, and `Generate.TimeOnlyValues()` methods are in `Conjecture.Core` and do not require this package.
+
+## `TimeGenerate.TimeZones()`
+
+```csharp
+Strategy<TimeZoneInfo> TimeGenerate.TimeZones()
+```
+
+Picks uniformly from system time zones. Shrinks toward `TimeZoneInfo.Utc`.
+
+## `TimeGenerate.ClockSet(int nodeCount, TimeSpan maxSkew)`
+
+```csharp
+Strategy<FakeTimeProvider[]> TimeGenerate.ClockSet(int nodeCount, TimeSpan maxSkew)
+```
+
+Generates an array of `nodeCount` `FakeTimeProvider` instances, each with a clock offset in `[-maxSkew/2, +maxSkew/2]` relative to `DateTimeOffset.UtcNow`. `nodeCount` must be >= 2.
+
+## `TimeProviderArbitrary`
+
+```csharp
+[Arbitrary]
+public sealed class TimeProviderArbitrary : IStrategyProvider<TimeProvider>
+```
+
+Auto-provider for `TimeProvider` parameters. Each generated value is a `FakeTimeProvider` with a deterministic epoch start.
+
+Use with `[From<TimeProviderArbitrary>]` or let `[Arbitrary]` resolution pick it up automatically.
+
+## DateTimeOffset extension methods
+
+Extension properties on `Strategy<DateTimeOffset>` that narrow the output to values near interesting temporal boundaries. Chain after `Generate.DateTimeOffsets()`.
+
+### `.NearMidnight()`
+
+```csharp
+Strategy<DateTimeOffset> NearMidnight()
+```
+
+Values within +/-30 minutes of midnight UTC.
+
+### `.NearLeapYear()`
+
+```csharp
+Strategy<DateTimeOffset> NearLeapYear()
+```
+
+Values within +/-1 day of February 29 in a leap year (years 1970-2400).
+
+### `.NearEpoch()`
+
+```csharp
+Strategy<DateTimeOffset> NearEpoch()
+```
+
+Values within +/-1 hour of well-known epoch anchors: Unix epoch (1970-01-01), near-min (0001-01-02), near-max (9999-12-30), Y2K38 (2038-01-19).
+
+### `.NearDstTransition(TimeZoneInfo? zone = null)`
+
+```csharp
+Strategy<DateTimeOffset> NearDstTransition(TimeZoneInfo? zone = null)
+```
+
+Values within +/-1 hour of a DST transition. Picks a random DST-having zone if `zone` is null. Falls back to `.NearEpoch()` if no transitions are found.

--- a/docs/site/articles/reference/toc.yml
+++ b/docs/site/articles/reference/toc.yml
@@ -11,5 +11,7 @@ items:
     href: attributes.md
   - name: Analyzers
     href: analyzers.md
+  - name: Time strategies
+    href: time-strategies.md
   - name: Formatters
     href: formatters.md

--- a/docs/site/articles/tutorials/06-advanced-patterns.md
+++ b/docs/site/articles/tutorials/06-advanced-patterns.md
@@ -44,6 +44,12 @@ Roslyn analyzers are bundled in `Conjecture.Core` and active automatically. Diag
 | CON103 | Strategy bounds are inverted (`min > max`) |
 | CON104 | `Assume.That(false)` always skips |
 | CON105 | `[Arbitrary]` provider exists but `[From<T>]` not used |
+| CON107 | Non-deterministic operation in `[Property]` (e.g. `Guid.NewGuid()`, `DateTime.Now`) |
+| CON108 | `Assume.That` condition always true given strategy constraint |
+| CON109 | No strategy found for `[Property]` parameter type |
+| CON110 | Async `[Property]` method contains no `await` |
+| CON111 | `Target.Maximize`/`Minimize` outside `[Property]` method |
+| CJ0050 | Suggest named extension property (`.Positive`, `.NonEmpty`) instead of `.Where()` |
 
 ## The Example Database
 

--- a/src/Conjecture.Interactive/Conjecture.Interactive.csproj
+++ b/src/Conjecture.Interactive/Conjecture.Interactive.csproj
@@ -10,6 +10,9 @@
     <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
     <!-- Packed into interactive-extensions/dotnet so Polyglot auto-loads on #r nuget: -->
     <None Include="extension.dib" Pack="true" PackagePath="interactive-extensions/dotnet" />
     <!-- Also copy to output so the test can find it -->

--- a/src/Conjecture.Interactive/README.md
+++ b/src/Conjecture.Interactive/README.md
@@ -1,0 +1,44 @@
+# Conjecture.Interactive
+
+[Polyglot Notebooks](https://github.com/dotnet/interactive) extension for [Conjecture.NET](https://github.com/kommundsen/Conjecture). Explore strategy output interactively with sample tables, histograms, and shrink traces.
+
+## Install
+
+In a `.dib` notebook cell:
+
+```
+#r "nuget: Conjecture.Interactive"
+```
+
+The kernel extension loads automatically and registers HTML formatters for `Strategy<T>`.
+
+## Usage
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Interactive;
+
+// Quick-look at sample values
+Generate.Integers<int>(0, 100).Preview()
+
+// Distribution histogram (SVG)
+Generate.Doubles(0, 1).Histogram()
+
+// Step-by-step shrink trace
+Generate.Integers<int>().ShrinkTrace(seed: 42, x => x < 1000)
+```
+
+## API
+
+| Method | Returns | Description |
+|---|---|---|
+| `.Preview(count, seed)` | `string` (HTML) | Sample values in a single-row table |
+| `.SampleTable(count, seed)` | `string` (HTML) | Indexed two-column sample table |
+| `.Histogram(sampleSize, bucketCount, seed)` | `string` (SVG) | Distribution histogram |
+| `.Histogram(selector, sampleSize, bucketCount, seed)` | `string` (SVG) | Histogram with projection function |
+| `.ShrinkTrace(seed, failingProperty)` | `ShrinkTraceResult<T>` | Step-by-step shrink trace with HTML |
+
+## Links
+
+- [GitHub](https://github.com/kommundsen/Conjecture)
+- [License](https://github.com/kommundsen/Conjecture/blob/main/LICENSE-MIT.txt)

--- a/src/Conjecture.Time/Conjecture.Time.csproj
+++ b/src/Conjecture.Time/Conjecture.Time.csproj
@@ -9,4 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 </Project>

--- a/src/Conjecture.Time/README.md
+++ b/src/Conjecture.Time/README.md
@@ -1,0 +1,49 @@
+# Conjecture.Time
+
+Time-focused strategies for [Conjecture.NET](https://github.com/kommundsen/Conjecture) property-based testing. Provides boundary-aware `DateTimeOffset` extensions and `FakeTimeProvider` generation for deterministic time-dependent tests.
+
+## Install
+
+```
+dotnet add package Conjecture.Time
+```
+
+## Usage
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Time;
+
+// Generate values near DST transitions
+[Property]
+public bool DstSafe([From<DateTimeOffsetArbitrary>] DateTimeOffset dt)
+{
+    DateTimeOffset nearDst = Generate.DateTimeOffsets().NearDstTransition();
+    // ...
+}
+
+// Generate a cluster of clocks with bounded skew
+[Property]
+public bool ClockSkewTolerant(int x)
+{
+    FakeTimeProvider[] clocks = DataGen.SampleOne(
+        TimeGenerate.ClockSet(nodeCount: 3, maxSkew: TimeSpan.FromSeconds(5)));
+    // ...
+}
+```
+
+## API
+
+| Method | Returns | Description |
+|---|---|---|
+| `TimeGenerate.TimeZones()` | `Strategy<TimeZoneInfo>` | System time zones, shrinks toward UTC |
+| `TimeGenerate.ClockSet(nodeCount, maxSkew)` | `Strategy<FakeTimeProvider[]>` | Array of clocks with bounded skew |
+| `.NearMidnight()` | `Strategy<DateTimeOffset>` | Values within ~30 min of midnight |
+| `.NearLeapYear()` | `Strategy<DateTimeOffset>` | Values within ~1 day of Feb 29 |
+| `.NearEpoch()` | `Strategy<DateTimeOffset>` | Values near Unix epoch, Y2K38, min/max |
+| `.NearDstTransition(zone?)` | `Strategy<DateTimeOffset>` | Values within ~1 hour of a DST transition |
+
+## Links
+
+- [GitHub](https://github.com/kommundsen/Conjecture)
+- [License](https://github.com/kommundsen/Conjecture/blob/main/LICENSE-MIT.txt)


### PR DESCRIPTION
## Description

Brings all documentation up to date for the v0.8.0 release. The docs changelog was stale (only v0.6.0-alpha.1) and several v0.7.0/v0.8.0 feature areas had no documentation at all.

### Changelog
- Adds v0.8.0 `[Unreleased]` section to root `CHANGELOG.md` covering Analyzers, Time, Interactive, Core, and Tool changes
- Replaces duplicate docs-site changelog with a redirect to the root file

### Analyzer reference
- Adds CON107–CON111 and CJ0050 with severity, target description, and code examples
- Fixes stale "CON100–105" cross-references in `contributing.md`, `tutorials/06-advanced-patterns.md`, and `use-source-generators.md`

### Strategies reference
- Adds 8 date/time generator methods (`DateTimeOffsets`, `TimeSpans`, `DateOnlyValues`, `TimeOnlyValues` + ranged overloads)
- Adds `Generate.FromBytes<T>` byte buffer section
- New `reference/time-strategies.md` page for `Conjecture.Time` API (`TimeGenerate`, `DateTimeOffsetExtensions`, `TimeProviderArbitrary`)

### New how-to pages (diataxis structure)
- `how-to/use-time-strategies.md` — boundary dates, clock skew, `TimeProviderArbitrary`
- `how-to/use-notebooks.md` — `.Preview()`, `.SampleTable()`, `.Histogram()`, `.ShrinkTrace()` in Polyglot Notebooks

### Package READMEs
- `src/Conjecture.Time/README.md`
- `src/Conjecture.Interactive/README.md`

### Project structure
- `contributing.md` updated with all new projects (Formatters, Time, Interactive, Tool, Mcp, CodeFixes)

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #200