### PR TITLE
Adds gh-stack support to implement-cycle skill

### DIFF
--- a/.claude/skills/implement-cycle/SKILL.md
+++ b/.claude/skills/implement-cycle/SKILL.md
@@ -43,11 +43,44 @@ Cycle <cycle-number>: <title>  (#<sub-issue-number>)
 
 ### 2. Create a branch
 
-Branch name format: `feat/#<parent>-#<sub>-<slug>`
+Branch name format: `feat/<parent>-<sub>-<slug>` (no `#` in the git branch name).
 
+First, update main:
 ```bash
-git checkout main && git pull && git checkout -b feat/<parent>-<sub>-<slug>
+git checkout main && git pull
 ```
+
+Then check whether gh-stack is available and whether a stack already exists for this parent:
+```bash
+gh stack view --json 2>/dev/null
+```
+
+- Command fails entirely → `STACK_MODE=unavailable`
+- Output contains a branch matching `feat/<parent>-` → `STACK_MODE=add`
+- Otherwise → `STACK_MODE=init`
+
+**`STACK_MODE=unavailable`** — announce fallback, create branch manually:
+```bash
+git checkout -b feat/<parent>-<sub>-<slug>
+```
+
+**`STACK_MODE=init`** — initialize a new stack:
+```bash
+gh stack init feat/<parent>-<sub>-<slug>
+```
+(creates and checks out the branch — do NOT also run `git checkout -b`)
+
+**`STACK_MODE=add`** — navigate to top of the existing stack, then add a new layer:
+```bash
+gh stack top
+gh stack add feat/<parent>-<sub>-<slug>
+```
+
+In both stack modes (`init` and `add`), sync to pick up any merges from previous cycles:
+```bash
+gh stack sync
+```
+If `gh stack sync` reports conflicts, stop and ask the user to resolve them before continuing.
 
 ### 3–5. TDD loop (max 3 iterations)
 
@@ -130,6 +163,8 @@ Stage all new and modified files from this cycle and commit with the suggested m
 
 ### 8. Push branch and create PR
 
+**`STACK_MODE=unavailable`** — push and create a PR against `main` (same as before):
+
 ```bash
 git push -u origin feat/<parent>-<sub>-<slug>
 ```
@@ -150,7 +185,28 @@ EOF
 )"
 ```
 
-Print the PR URL.
+**`STACK_MODE=init` or `STACK_MODE=add`** — submit the stack:
+
+Fill in `.github/pull_request_template.md` with this cycle's description plus:
+```
+Closes #<sub-issue-number>
+Part of #<parent-issue-number>
+```
+
+Then run:
+```bash
+gh stack submit
+```
+
+When prompted for the PR title for this cycle's branch, enter: `[<cycle>] <title>`
+When prompted for the PR body, paste the filled-in template. Do NOT use `--auto` — the title and `Closes #N` body are load-bearing for GitHub's sub-issue tracking.
+
+For any previously-submitted PRs in the stack that are already open, accept the existing title as-is.
+
+Print the PR URL for this cycle's branch:
+```bash
+gh pr view feat/<parent>-<sub>-<slug> --json url --jq '.url'
+```
 
 ## Guidelines
 
@@ -158,4 +214,7 @@ Print the PR URL.
 - If the issue references a `/decision` step, invoke the `decision` skill before the loop.
 - Never create the PR if the build or tests are red.
 - Scope all changes to what the cycle issue demands.
-- Branch off `main` — never off another feature branch.
+- When gh-stack is available: branch off the previous cycle via `gh stack add`, not off `main` directly. When unavailable: branch off `main`.
+- Always call `gh stack top` before `gh stack add` — `add` must be run from the topmost branch.
+- `gh stack sync` at Step 2 handles merges of previous cycles; do not manually rebase onto main.
+- `STACK_MODE` is a local variable for this invocation — re-detect it fresh each run.


### PR DESCRIPTION
## Description

Updates the `implement-cycle` skill to use [gh-stack](https://github.com/github/gh-stack) for stacked PR workflows. Each cycle's PR now chains onto the previous cycle's branch (rather than always targeting `main`), so reviewers can begin reviewing early cycles while later ones are still being implemented.

Key changes:
- **Branch creation** detects `STACK_MODE` via `gh stack view --json`: uses `gh stack init` for the first cycle of a parent issue, `gh stack top && gh stack add` for subsequent cycles
- **`gh stack sync`** runs at the start of each cycle to rebase cleanly onto any previously merged cycles
- **PR submission** uses `gh stack submit` so each cycle's PR is automatically based on the previous cycle's branch
- **Fallback** to existing `git checkout -b` + `gh pr create --base main` behaviour when gh-stack is not installed (private preview)

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [ ] `dotnet test src/` passes
- [ ] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [ ] Follows `.editorconfig` code style