### PR TITLE
[66.0] ADR: MTP adapter architecture

### DIFF
--- a/.claude/skills/implement-cycle-stacked/SKILL.md
+++ b/.claude/skills/implement-cycle-stacked/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: implement-cycle
-description: >
-  Execute the next incomplete TDD cycle from a GitHub tracking issue: Red → Green → Refactor → Verify → PR.
-  Use this skill whenever the user wants to work through the next planned cycle, progress the implementation plan, run the next TDD iteration, or says "next cycle" — even if they don't specify which one.
-  Triggers on phrases like "do the next cycle", "implement cycle X.Y", "implement the next cycle of #76", "work through phase 2", "continue the implementation plan", or "what's the next step in the plan".
+name: implement-cycle-stacked
 ---
 
-Execute the next incomplete TDD cycle from a GitHub tracking issue: Red → Green → Refactor → Verify → PR.
+Execute the next incomplete TDD cycle from a GitHub tracking issue using gh-stack stacked PRs: Red → Green → Refactor → Verify → PR.
+
+> **Requires gh-stack** (`gh extension install github/gh-stack`). This extension is currently in private preview — sign up at https://gh.io/stacksbeta. Use `/implement-cycle` if gh-stack is not available.
+
+Each cycle's PR is stacked on top of the previous cycle's branch, so reviewers can begin reviewing completed cycles while later ones are still being implemented.
 
 ## Input
 
@@ -43,11 +43,39 @@ Cycle <cycle-number>: <title>  (#<sub-issue-number>)
 
 ### 2. Create a branch
 
-Branch name format: `feat/#<parent>-#<sub>-<slug>`
+Branch name format: `feat/<parent>-<sub>-<slug>` (no `#` in the git branch name).
 
+First, update main:
 ```bash
-git checkout main && git pull && git checkout -b feat/<parent>-<sub>-<slug>
+git checkout main && git pull
 ```
+
+Then check whether a stack already exists for this parent:
+```bash
+gh stack view --json 2>/dev/null
+```
+
+- Command fails entirely → stop and tell the user gh-stack is not installed
+- Output contains a branch matching `feat/<parent>-` → `STACK_MODE=add`
+- Otherwise → `STACK_MODE=init`
+
+**`STACK_MODE=init`** — initialize a new stack:
+```bash
+gh stack init feat/<parent>-<sub>-<slug>
+```
+(creates and checks out the branch — do NOT also run `git checkout -b`)
+
+**`STACK_MODE=add`** — navigate to top of the existing stack, then add a new layer:
+```bash
+gh stack top
+gh stack add feat/<parent>-<sub>-<slug>
+```
+
+In both stack modes, sync to pick up any merges from previous cycles:
+```bash
+gh stack sync
+```
+If `gh stack sync` reports conflicts, stop and ask the user to resolve them before continuing.
 
 ### 3–5. TDD loop (max 3 iterations)
 
@@ -130,27 +158,26 @@ Stage all new and modified files from this cycle and commit with the suggested m
 
 ### 8. Push branch and create PR
 
-```bash
-git push -u origin feat/<parent>-<sub>-<slug>
+Fill in `.github/pull_request_template.md` with this cycle's description plus:
 ```
-
-Read `.github/pull_request_template.md` and fill it in:
-
-```bash
-gh pr create \
-  --repo kommundsen/Conjecture \
-  --title "[<cycle>] <title>" \
-  --base main \
-  --body "$(cat <<'EOF'
-<filled-in pull_request_template.md content>
-
 Closes #<sub-issue-number>
 Part of #<parent-issue-number>
-EOF
-)"
 ```
 
-Print the PR URL.
+Then submit the stack:
+```bash
+gh stack submit
+```
+
+When prompted for the PR title for this cycle's branch, enter: `[<cycle>] <title>`
+When prompted for the PR body, paste the filled-in template. Do NOT use `--auto` — the title and `Closes #N` body are load-bearing for GitHub's sub-issue tracking.
+
+For any previously-submitted PRs in the stack that are already open, accept the existing title as-is.
+
+Print the PR URL for this cycle's branch:
+```bash
+gh pr view feat/<parent>-<sub>-<slug> --json url --jq '.url'
+```
 
 ## Guidelines
 
@@ -158,4 +185,7 @@ Print the PR URL.
 - If the issue references a `/decision` step, invoke the `decision` skill before the loop.
 - Never create the PR if the build or tests are red.
 - Scope all changes to what the cycle issue demands.
-- Branch off `main` — never off another feature branch.
+- Branch off the previous cycle via `gh stack add`, not off `main` directly.
+- Always call `gh stack top` before `gh stack add` — `add` must be run from the topmost branch.
+- `gh stack sync` at Step 2 handles merges of previous cycles; do not manually rebase onto main.
+- `STACK_MODE` is a local variable for this invocation — re-detect it fresh each run.

--- a/docs/decisions/0048-mtp-adapter-architecture.md
+++ b/docs/decisions/0048-mtp-adapter-architecture.md
@@ -1,0 +1,84 @@
+# 0048. MTP Adapter Architecture
+
+**Date:** 2026-04-14
+**Status:** Accepted
+
+## Context
+
+Microsoft Testing Platform (MTP) is a modern, self-contained test execution platform that embeds the runner directly in the test project executable. Unlike VSTest — which launches a separate `testhost` process — an MTP test project sets `OutputType=Exe` and references the platform directly. MTP 1.x is the engine behind `dotnet test` in .NET 9+ and is the target platform for TRX reporting, crash dump collection, and IDE integrations going forward.
+
+Conjecture already supports xUnit v2/v3, NUnit, and MSTest via dedicated adapter packages (ADR-0030). Each of those packages targets a framework-specific extensibility model and ships as a library (`OutputType=Library`). MTP's executable output requirement makes it incompatible with those packages: a library cannot set `OutputType=Exe`, and Core cannot carry this constraint without forcing it on every consumer.
+
+MTP provides two integration paths:
+
+1. **VSTestBridge** — a compatibility shim that translates VSTest discovery/execution calls into MTP's protocol. Low effort to adopt; carries the full weight of the VSTest adapter model with its known limitations (no fine-grained `TestNode` control, no native capability support).
+2. **Native `ITestFramework`** — direct implementation of MTP's extension point. Full control over `TestNode` shape, lifecycle events, and platform capabilities. More code, but unlocks TRX reporting, crash dump integration, and precise test node composition.
+
+The question is which path to take, how to package it, and how to wire Conjecture's existing infrastructure (logging, `[Example]` parity, seed/settings) into MTP's protocol.
+
+## Decision
+
+### Standalone package: `Conjecture.TestingPlatform`
+
+Ship MTP support as a separate `Conjecture.TestingPlatform` NuGet package. Users reference it alongside their chosen Conjecture adapter (or instead of it, if they run MTP-first). This package sets no `OutputType` itself — test projects that reference it set `OutputType=Exe` in their own `.csproj`, which is standard MTP usage.
+
+This keeps `Conjecture.Core` a plain library and preserves the opt-in model established for all other adapters.
+
+### Native `ITestFramework` — no VSTestBridge
+
+Implement `ITestFramework` directly. VSTestBridge is a stepping stone for frameworks that already have a VSTest adapter and want MTP reach without rewriting; Conjecture has no VSTest adapter to bridge from. A native implementation gives full control over:
+
+- `TestNode` composition (one node per `[Property]`, child nodes per `[Example]`)
+- `ITestSessionContext` and lifetime hooks
+- Platform capabilities (TRX, crash dump) declared at startup
+
+### MTP minimum version: 1.9
+
+MTP 1.9 is the first release with stable `ITrxReportCapability` and the `KeyValuePairStringProperty` API used for structured log output. Targeting 1.9 avoids conditional compilation around capability availability.
+
+### Logging: `IMessageBus` + `KeyValuePairStringProperty`
+
+MTP has no direct equivalent of xUnit's `ITestOutputHelper` or NUnit's `TestContext.Out`. The idiomatic pattern is to attach structured properties to `TestNode` updates via `IMessageBus`. A `MtpLogger` wraps `IMessageBus` and posts `KeyValuePairStringProperty("output", message)` on each log line, mirroring what `TestOutputHelperLogger` does in the xUnit adapter.
+
+### `TestNode` structure
+
+Each `[Property]` method produces one `TestNode`. `[Example]` cases that run before random generation produce child `TestNode` entries under the property node. This structure maps naturally to IDE Test Explorer hierarchies and TRX output sections.
+
+### `[Example]` parity via `TestCaseHelper.ValidateExampleArgs()`
+
+`TestCaseHelper.ValidateExampleArgs()` in Core validates and unpacks `[Example]` attribute arguments into typed parameter arrays. The MTP adapter calls this method directly (via `InternalsVisibleTo`), giving identical `[Example]` semantics to every other adapter without duplicating validation logic.
+
+### Discovery: method names only
+
+`DiscoverTestExecutionRequest` returns one entry per `[Property]` method. Discovered tests list only the method name — not generated inputs or `[Example]` argument permutations. This matches how other adapters surface discovery and avoids flooding the test list with unbounded generated cases.
+
+### Out-of-box extensions: TrxReport and CrashDump
+
+`Conjecture.TestingPlatform` registers `ITrxReportCapability` and the crash dump extension at startup. Both are available without any user configuration. TRX output goes to the standard `TestResults/` directory; crash dumps are captured on unhandled exceptions during test execution.
+
+### Mixed-solution support
+
+A solution may contain test projects targeting different frameworks (xUnit, NUnit, MSTest) alongside MTP test projects. Each test project selects its own adapter via its project references. No global configuration is required; MTP test projects simply reference `Conjecture.TestingPlatform` while other projects reference their respective adapter packages.
+
+## Consequences
+
+**Easier:**
+- Core remains a library with no `OutputType` constraint; all existing consumers are unaffected.
+- Full `TestNode` control enables precise TRX and IDE integration without workarounds.
+- Logging, `[Example]` parity, and seed/settings infrastructure reuse Core without duplication.
+- Mixed adapter solutions work without any glue configuration.
+
+**Harder:**
+- `Conjecture.TestingPlatform` is a net-new project with its own `PublicAPI.Unshipped.txt`, test project, and CI steps.
+- MTP's native API surface is less documented than the framework-specific models; implementation requires consulting the MTP source and samples directly.
+- `InternalsVisibleTo` must be extended to include `Conjecture.TestingPlatform` for `TestCaseHelper` and `SharedParameterStrategyResolver` access.
+
+## Alternatives Considered
+
+**VSTestBridge** — rejected. Conjecture has no existing VSTest adapter, so VSTestBridge offers no migration advantage. It also prevents native `ITrxReportCapability` registration and limits `TestNode` shape control.
+
+**Integrate MTP support into `Conjecture.Core`** — rejected. MTP's executable output requirement would force all Core consumers to set `OutputType=Exe`, breaking library consumers and every existing adapter.
+
+**Target MTP 1.5 (earlier stable release)** — rejected. `KeyValuePairStringProperty` and `ITrxReportCapability` stabilised in 1.9; targeting an earlier version would require runtime capability probing or conditional compilation.
+
+**Per-framework MTP shims (e.g., `Conjecture.Xunit.Mtp`)** — rejected. MTP is framework-agnostic at the execution layer; a single `Conjecture.TestingPlatform` package is the correct boundary. Framework-specific shims would duplicate test runner logic and fragment the package surface.


### PR DESCRIPTION
## Description

Records ADR-0048: architecture decisions for the Microsoft Testing Platform (MTP) adapter (`Conjecture.TestingPlatform`). Documents the key choices that constrain subsequent implementation cycles (66.1–66.5).

Key decisions:
- Standalone `Conjecture.TestingPlatform` package — MTP requires `OutputType=Exe`, incompatible with Core as a library
- Native `ITestFramework` implementation — no VSTestBridge
- MTP minimum version 1.9 (stable `ITrxReportCapability` + `KeyValuePairStringProperty`)
- `MtpLogger` via `IMessageBus` + `KeyValuePairStringProperty`
- One `TestNode` per `[Property]`; `[Example]` cases as child nodes
- Discovery lists method names only
- TrxReport and CrashDump registered out-of-box

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #173
Part of #66