### PR TITLE
[66.2] PropertyTestFramework: implement ITestFramework with discovery and execution

### DIFF
--- a/src/Conjecture.TestingPlatform.Tests/PropertyTestFrameworkTests.cs
+++ b/src/Conjecture.TestingPlatform.Tests/PropertyTestFrameworkTests.cs
@@ -1,0 +1,343 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using Conjecture.Core;
+using Conjecture.TestingPlatform.Internal;
+
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.TestHost;
+
+namespace Conjecture.TestingPlatform.Tests;
+
+public class PropertyTestFrameworkTests
+{
+    // ---- test subjects -------------------------------------------------------
+
+    private static class AlwaysPassingSubject
+    {
+        [Property]
+        public static void AlwaysPasses(int x)
+        {
+        }
+    }
+
+    private static class AlwaysFailingSubject
+    {
+        [Property]
+        public static void AlwaysFails(int x) { throw new System.Exception("Always fails"); }
+    }
+
+    private static class WithExampleSubject
+    {
+        [Property]
+        [Example(42)]
+        public static void WithExample(int x)
+        {
+        }
+    }
+
+    private static class WithFailingExampleSubject
+    {
+        [Property]
+        [Example(99)]
+        public static void ExampleFails(int x) { throw new System.Exception("Example exploded"); }
+    }
+
+    private static class AsyncPassingSubject
+    {
+        [Property]
+        public static async Task AsyncPasses(int x)
+        {
+            await Task.Yield();
+        }
+    }
+
+    private static class TwoPropertiesSubject
+    {
+        [Property]
+        public static void FirstProperty(int x)
+        {
+        }
+
+        [Property]
+        public static void SecondProperty(string s)
+        {
+        }
+    }
+
+    // ---- helpers -------------------------------------------------------------
+
+    private sealed class CapturingMessageBus : IMessageBus
+    {
+        private readonly List<TestNodeUpdateMessage> messages = [];
+
+        public IReadOnlyList<TestNodeUpdateMessage> Messages => messages;
+
+        public Task PublishAsync(IDataProducer dataProducer, IData data)
+        {
+            if (data is TestNodeUpdateMessage msg)
+            {
+                messages.Add(msg);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private static PropertyTestFramework BuildFramework(System.Type subjectType)
+    {
+        Assembly assembly = subjectType.Assembly;
+        return new(serviceProvider: null!, assemblies: [assembly], typePredicate: t => t == subjectType);
+    }
+
+    private static async Task<IReadOnlyList<TestNodeUpdateMessage>> DiscoverAsync(
+        PropertyTestFramework framework,
+        System.Type subjectType)
+    {
+        CapturingMessageBus bus = new();
+        await framework.DiscoverAsync(bus, new SessionUid("test-session"));
+        return bus.Messages;
+    }
+
+    private static async Task<IReadOnlyList<TestNodeUpdateMessage>> RunAsync(
+        PropertyTestFramework framework,
+        System.Type subjectType)
+    {
+        CapturingMessageBus bus = new();
+        await framework.RunAsync(bus, new SessionUid("test-session"));
+        return bus.Messages;
+    }
+
+    // ---- discovery -----------------------------------------------------------
+
+    [Fact]
+    public async Task ExecuteRequestAsync_DiscoverRequest_EmitsOneNodePerPropertyMethod()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(TwoPropertiesSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await DiscoverAsync(framework, typeof(TwoPropertiesSubject));
+
+        Assert.Equal(2, messages.Count);
+    }
+
+    [Fact]
+    public async Task ExecuteRequestAsync_DiscoverRequest_NodeHasDiscoveredTestNodeStateProperty()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AlwaysPassingSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await DiscoverAsync(framework, typeof(AlwaysPassingSubject));
+
+        TestNodeUpdateMessage message = Assert.Single(messages);
+        DiscoveredTestNodeStateProperty? state = message.TestNode.Properties.SingleOrDefault<DiscoveredTestNodeStateProperty>();
+        Assert.NotNull(state);
+    }
+
+    [Fact]
+    public async Task ExecuteRequestAsync_DiscoverRequest_NodeDisplayNameMatchesMethodName()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AlwaysPassingSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await DiscoverAsync(framework, typeof(AlwaysPassingSubject));
+
+        TestNodeUpdateMessage message = Assert.Single(messages);
+        Assert.Contains("AlwaysPasses", message.TestNode.DisplayName);
+    }
+
+    // ---- run: passing property -----------------------------------------------
+
+    [Fact]
+    public async Task ExecuteRequestAsync_RunRequest_PassingProperty_EmitsPassedState()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AlwaysPassingSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await RunAsync(framework, typeof(AlwaysPassingSubject));
+
+        TestNodeUpdateMessage? final = null;
+        foreach (TestNodeUpdateMessage msg in messages)
+        {
+            if (msg.TestNode.Properties.Any<PassedTestNodeStateProperty>())
+            {
+                final = msg;
+            }
+        }
+
+        Assert.NotNull(final);
+    }
+
+    // ---- run: failing property -----------------------------------------------
+
+    [Fact]
+    public async Task ExecuteRequestAsync_RunRequest_FailingProperty_EmitsFailedState()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AlwaysFailingSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await RunAsync(framework, typeof(AlwaysFailingSubject));
+
+        TestNodeUpdateMessage? failed = null;
+        foreach (TestNodeUpdateMessage msg in messages)
+        {
+            if (msg.TestNode.Properties.Any<FailedTestNodeStateProperty>())
+            {
+                failed = msg;
+            }
+        }
+
+        Assert.NotNull(failed);
+    }
+
+    [Fact]
+    public async Task ExecuteRequestAsync_RunRequest_FailingProperty_FailureMessageContainsFalsifyingExample()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AlwaysFailingSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await RunAsync(framework, typeof(AlwaysFailingSubject));
+
+        FailedTestNodeStateProperty? failedProp = null;
+        foreach (TestNodeUpdateMessage msg in messages)
+        {
+            FailedTestNodeStateProperty? candidate = msg.TestNode.Properties.SingleOrDefault<FailedTestNodeStateProperty>();
+            if (candidate is not null)
+            {
+                failedProp = candidate;
+            }
+        }
+
+        Assert.NotNull(failedProp);
+        Assert.Contains("Falsifying example", failedProp.Explanation);
+    }
+
+    // ---- run: [Example] child nodes ------------------------------------------
+
+    [Fact]
+    public async Task ExecuteRequestAsync_RunRequest_PropertyWithExample_EmitsChildNodeBeforeRandomNode()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(WithExampleSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await RunAsync(framework, typeof(WithExampleSubject));
+
+        // At least one message must have a non-null ParentTestNodeUid (child node for [Example])
+        bool hasChildNode = false;
+        foreach (TestNodeUpdateMessage msg in messages)
+        {
+            if (msg.ParentTestNodeUid is not null)
+            {
+                hasChildNode = true;
+            }
+        }
+
+        Assert.True(hasChildNode);
+    }
+
+    [Fact]
+    public async Task ExecuteRequestAsync_RunRequest_PropertyWithPassingExample_ExampleChildNodeHasPassedState()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(WithExampleSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await RunAsync(framework, typeof(WithExampleSubject));
+
+        TestNodeUpdateMessage? exampleNode = null;
+        foreach (TestNodeUpdateMessage msg in messages)
+        {
+            if (msg.ParentTestNodeUid is not null && msg.TestNode.Properties.Any<PassedTestNodeStateProperty>())
+            {
+                exampleNode = msg;
+            }
+        }
+
+        Assert.NotNull(exampleNode);
+    }
+
+    // ---- run: failing [Example] stops random generation ---------------------
+
+    [Fact]
+    public async Task ExecuteRequestAsync_RunRequest_FailingExample_EmitsFailedChildNode()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(WithFailingExampleSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await RunAsync(framework, typeof(WithFailingExampleSubject));
+
+        TestNodeUpdateMessage? failedChild = null;
+        foreach (TestNodeUpdateMessage msg in messages)
+        {
+            if (msg.ParentTestNodeUid is not null && msg.TestNode.Properties.Any<FailedTestNodeStateProperty>())
+            {
+                failedChild = msg;
+            }
+        }
+
+        Assert.NotNull(failedChild);
+    }
+
+    [Fact]
+    public async Task ExecuteRequestAsync_RunRequest_FailingExample_PropertyNodeAlsoFailsAndNoPassedNodeEmitted()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(WithFailingExampleSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await RunAsync(framework, typeof(WithFailingExampleSubject));
+
+        bool hasTopLevelPassed = false;
+        foreach (TestNodeUpdateMessage msg in messages)
+        {
+            if (msg.ParentTestNodeUid is null && msg.TestNode.Properties.Any<PassedTestNodeStateProperty>())
+            {
+                hasTopLevelPassed = true;
+            }
+        }
+
+        Assert.False(hasTopLevelPassed);
+    }
+
+    // ---- run: async Task-returning property ----------------------------------
+
+    [Fact]
+    public async Task ExecuteRequestAsync_RunRequest_AsyncPassingProperty_EmitsPassedState()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AsyncPassingSubject));
+
+        IReadOnlyList<TestNodeUpdateMessage> messages = await RunAsync(framework, typeof(AsyncPassingSubject));
+
+        TestNodeUpdateMessage? passed = null;
+        foreach (TestNodeUpdateMessage msg in messages)
+        {
+            if (msg.TestNode.Properties.Any<PassedTestNodeStateProperty>())
+            {
+                passed = msg;
+            }
+        }
+
+        Assert.NotNull(passed);
+    }
+
+    // ---- metadata ------------------------------------------------------------
+
+    [Fact]
+    public void PropertyTestFramework_Uid_IsStableWellKnownString()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AlwaysPassingSubject));
+
+        Assert.Equal("Conjecture.TestingPlatform", framework.Uid);
+    }
+
+    [Fact]
+    public void PropertyTestFramework_DisplayName_IsNonEmpty()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AlwaysPassingSubject));
+
+        Assert.False(string.IsNullOrWhiteSpace(framework.DisplayName));
+    }
+
+    [Fact]
+    public async Task PropertyTestFramework_IsEnabledAsync_ReturnsTrue()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AlwaysPassingSubject));
+
+        bool enabled = await framework.IsEnabledAsync();
+
+        Assert.True(enabled);
+    }
+}

--- a/src/Conjecture.TestingPlatform/Conjecture.TestingPlatform.csproj
+++ b/src/Conjecture.TestingPlatform/Conjecture.TestingPlatform.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Description>Microsoft Testing Platform adapter for Conjecture.NET property-based testing</Description>
   </PropertyGroup>

--- a/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
+++ b/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
@@ -1,0 +1,230 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.Requests;
+using Microsoft.Testing.Platform.TestHost;
+
+namespace Conjecture.TestingPlatform.Internal;
+
+internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
+{
+    private readonly IEnumerable<Assembly> assemblies;
+    private readonly Func<Type, bool>? typePredicate;
+
+    internal PropertyTestFramework(IServiceProvider serviceProvider)
+        : this(serviceProvider, AppDomain.CurrentDomain.GetAssemblies(), null)
+    {
+    }
+
+    internal PropertyTestFramework(
+        IServiceProvider serviceProvider,
+        IEnumerable<Assembly> assemblies,
+        Func<Type, bool>? typePredicate = null)
+    {
+        _ = serviceProvider;
+        this.assemblies = assemblies;
+        this.typePredicate = typePredicate;
+    }
+
+    public string Uid => "Conjecture.TestingPlatform";
+    public string Version => typeof(PropertyTestFramework).Assembly
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "1.0.0";
+    public string DisplayName => "Conjecture Property Testing";
+    public string Description => "Property-based testing for .NET via Microsoft.Testing.Platform";
+
+    public Type[] DataTypesProduced => [typeof(TestNodeUpdateMessage)];
+
+    public Task<bool> IsEnabledAsync()
+    {
+        return Task.FromResult(true);
+    }
+
+    public Task<CreateTestSessionResult> CreateTestSessionAsync(CreateTestSessionContext context)
+    {
+        return Task.FromResult(new CreateTestSessionResult { IsSuccess = true });
+    }
+
+    public Task<CloseTestSessionResult> CloseTestSessionAsync(CloseTestSessionContext context)
+    {
+        return Task.FromResult(new CloseTestSessionResult { IsSuccess = true });
+    }
+
+    [RequiresUnreferencedCode("Discovers property methods via reflection; not trim-safe.")]
+    [RequiresDynamicCode("Resolves parameter strategies via MakeGenericMethod; not NativeAOT-safe.")]
+    public async Task ExecuteRequestAsync(ExecuteRequestContext context)
+    {
+        try
+        {
+            if (context.Request is DiscoverTestExecutionRequest discoverRequest)
+            {
+                await DiscoverAsync(context.MessageBus, discoverRequest.Session.SessionUid);
+            }
+            else if (context.Request is RunTestExecutionRequest runRequest)
+            {
+                await RunAsync(context.MessageBus, runRequest.Session.SessionUid);
+            }
+        }
+        finally
+        {
+            context.Complete();
+        }
+    }
+
+    [RequiresUnreferencedCode("Discovers property methods via reflection; not trim-safe.")]
+    internal async Task DiscoverAsync(IMessageBus bus, SessionUid sessionUid)
+    {
+        foreach (MethodInfo method in EnumeratePropertyMethods())
+        {
+            string uid = TestCaseHelper.ComputeTestId(method);
+            string displayName = $"{method.DeclaringType!.Name}.{method.Name}";
+            TestNode node = new()
+            {
+                Uid = new(uid),
+                DisplayName = displayName,
+            };
+            node.Properties.Add(DiscoveredTestNodeStateProperty.CachedInstance);
+            await bus.PublishAsync(this, new TestNodeUpdateMessage(sessionUid, node));
+        }
+    }
+
+    [RequiresUnreferencedCode("Discovers and runs property methods via reflection; not trim-safe.")]
+    [RequiresDynamicCode("Resolves parameter strategies via MakeGenericMethod; not NativeAOT-safe.")]
+    internal async Task RunAsync(IMessageBus bus, SessionUid sessionUid)
+    {
+        foreach (MethodInfo method in EnumeratePropertyMethods())
+        {
+            await RunMethodAsync(bus, sessionUid, method);
+        }
+    }
+
+    [RequiresUnreferencedCode("Runs property method via reflection; not trim-safe.")]
+    [RequiresDynamicCode("Resolves parameter strategies via MakeGenericMethod; not NativeAOT-safe.")]
+    private async Task RunMethodAsync(IMessageBus bus, SessionUid sessionUid, MethodInfo method)
+    {
+        PropertyAttribute attr = method.GetCustomAttribute<PropertyAttribute>()!;
+        string uid = TestCaseHelper.ComputeTestId(method);
+        string displayName = $"{method.DeclaringType!.Name}.{method.Name}";
+        TestNodeUid parentNodeUid = new(uid);
+        ParameterInfo[] parameters = method.GetParameters();
+        bool exampleFailed = false;
+
+        ExampleAttribute[] examples = method.GetCustomAttributes<ExampleAttribute>().ToArray();
+        for (int i = 0; i < examples.Length; i++)
+        {
+            ExampleAttribute example = examples[i];
+            string childUid = uid + ":example:" + i;
+            string childDisplayName = $"{displayName}[Example {i}]";
+            TestNode childNode = new()
+            {
+                Uid = new(childUid),
+                DisplayName = childDisplayName,
+            };
+
+            try
+            {
+                TestCaseHelper.ValidateExampleArgs(example, parameters);
+                if (TestCaseHelper.IsAsyncReturnType(method.ReturnType))
+                {
+                    await TestCaseHelper.InvokeAsync(method, null, example.Arguments!);
+                }
+                else
+                {
+                    TestCaseHelper.InvokeSync(method, null, example.Arguments!);
+                }
+
+                childNode.Properties.Add(PassedTestNodeStateProperty.CachedInstance);
+                await bus.PublishAsync(this, new TestNodeUpdateMessage(sessionUid, childNode, parentNodeUid));
+            }
+            catch (Exception ex)
+            {
+                string msg = TestCaseHelper.BuildExampleFailureMessage(example, parameters, ex);
+                childNode.Properties.Add(new FailedTestNodeStateProperty(ex, msg));
+                await bus.PublishAsync(this, new TestNodeUpdateMessage(sessionUid, childNode, parentNodeUid));
+
+                TestNode parentNode = new()
+                {
+                    Uid = parentNodeUid,
+                    DisplayName = displayName,
+                };
+                parentNode.Properties.Add(new FailedTestNodeStateProperty(ex, msg));
+                await bus.PublishAsync(this, new TestNodeUpdateMessage(sessionUid, parentNode));
+                exampleFailed = true;
+                break;
+            }
+        }
+
+        if (exampleFailed)
+        {
+            return;
+        }
+
+        ConjectureSettings settings = ConjectureSettings.From(attr);
+        using ExampleDatabase db = new(Path.Combine(settings.DatabasePath, "conjecture.db"), settings.Logger);
+
+        Task Test(ConjectureData data)
+        {
+            object[] args = SharedParameterStrategyResolver.Resolve(parameters, data);
+            if (TestCaseHelper.IsAsyncReturnType(method.ReturnType))
+            {
+                return TestCaseHelper.InvokeAsync(method, null, args);
+            }
+
+            TestCaseHelper.InvokeSync(method, null, args);
+            return Task.CompletedTask;
+        }
+
+        TestRunResult result = await TestRunner.RunAsync(settings, Test, db, uid);
+
+        TestNode resultNode = new()
+        {
+            Uid = parentNodeUid,
+            DisplayName = displayName,
+        };
+
+        if (result.Passed)
+        {
+            resultNode.Properties.Add(PassedTestNodeStateProperty.CachedInstance);
+        }
+        else
+        {
+            string failureMessage = TestCaseHelper.BuildFailureMessage(result, parameters);
+            resultNode.Properties.Add(new FailedTestNodeStateProperty(failureMessage));
+        }
+
+        await bus.PublishAsync(this, new TestNodeUpdateMessage(sessionUid, resultNode));
+    }
+
+    [RequiresUnreferencedCode("Iterates assembly types via reflection; not trim-safe.")]
+    private IEnumerable<MethodInfo> EnumeratePropertyMethods()
+    {
+        foreach (Assembly assembly in assemblies)
+        {
+            foreach (Type type in assembly.GetTypes())
+            {
+                if (typePredicate is not null && !typePredicate(type))
+                {
+                    continue;
+                }
+
+                foreach (MethodInfo method in type.GetMethods(
+                    BindingFlags.Public | BindingFlags.NonPublic |
+                    BindingFlags.Static | BindingFlags.Instance))
+                {
+                    if (method.GetCustomAttribute<PropertyAttribute>() is not null)
+                    {
+                        yield return method;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Conjecture.TestingPlatform/Internal/PropertyTestFrameworkCapabilities.cs
+++ b/src/Conjecture.TestingPlatform/Internal/PropertyTestFrameworkCapabilities.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+
+namespace Conjecture.TestingPlatform.Internal;
+
+internal sealed class PropertyTestFrameworkCapabilities : ITestFrameworkCapabilities
+{
+    public IReadOnlyCollection<ITestFrameworkCapability> Capabilities => [];
+}

--- a/src/Conjecture.TestingPlatform/Program.cs
+++ b/src/Conjecture.TestingPlatform/Program.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.TestingPlatform.Internal;
+
+using Microsoft.Testing.Platform.Builder;
+
+ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+builder.RegisterTestFramework(
+    _ => new PropertyTestFrameworkCapabilities(),
+    (_, services) => new PropertyTestFramework(services));
+using ITestApplication app = await builder.BuildAsync();
+return await app.RunAsync();


### PR DESCRIPTION
## Description

Implements `PropertyTestFramework` — an `ITestFramework` for Microsoft.Testing.Platform that discovers and executes `[Property]`-annotated methods.

**Discovery** (`DiscoverTestExecutionRequest`): reflects over loaded assemblies, finds `[Property]` methods, and emits one `TestNodeUpdateMessage` per method with `DiscoveredTestNodeStateProperty` and a stable `TestNodeUid` from `TestCaseHelper.ComputeTestId`.

**Execution** (`RunTestExecutionRequest`):
- Runs `[Example]` cases first as child `TestNode`s with `PassedTestNodeStateProperty` / `FailedTestNodeStateProperty`; a failing example emits a failed parent node and stops before random generation
- Builds `ConjectureSettings` from `PropertyAttribute`, delegates to `TestRunner.RunAsync`, and maps `TestRunResult` to the appropriate node state property

Also adds `PropertyTestFrameworkCapabilities` (empty, extended in later cycles) and the `Program.cs` MTP entry point.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #175
Part of #66