### PR TITLE
[66.3] MtpLogger: wire ILogger to IMessageBus output

### DIFF
--- a/src/Conjecture.TestingPlatform.Tests/MtpLoggerTests.cs
+++ b/src/Conjecture.TestingPlatform.Tests/MtpLoggerTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Conjecture.TestingPlatform.Internal;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.TestHost;
+
+namespace Conjecture.TestingPlatform.Tests;
+
+public class MtpLoggerTests
+{
+    // ---- helpers -------------------------------------------------------------
+
+    private sealed class CapturingMessageBus : IMessageBus
+    {
+        private readonly List<TestNodeUpdateMessage> messages = [];
+
+        public IReadOnlyList<TestNodeUpdateMessage> Messages => messages;
+
+        public Task PublishAsync(IDataProducer dataProducer, IData data)
+        {
+            if (data is TestNodeUpdateMessage msg)
+            {
+                messages.Add(msg);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private static MtpLogger BuildLogger(CapturingMessageBus bus)
+    {
+        TestNodeUid nodeUid = new("test-node");
+        SessionUid session = new("test-session");
+        return new(bus, nodeUid, session);
+    }
+
+    // ---- IsEnabled -----------------------------------------------------------
+
+    [Fact]
+    public void IsEnabled_InformationLevel_ReturnsTrue()
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        bool result = logger.IsEnabled(LogLevel.Information);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsEnabled_WarningLevel_ReturnsTrue()
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        bool result = logger.IsEnabled(LogLevel.Warning);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsEnabled_ErrorLevel_ReturnsTrue()
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        bool result = logger.IsEnabled(LogLevel.Error);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsEnabled_DebugLevel_ReturnsFalse()
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        bool result = logger.IsEnabled(LogLevel.Debug);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsEnabled_TraceLevel_ReturnsFalse()
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        bool result = logger.IsEnabled(LogLevel.Trace);
+
+        Assert.False(result);
+    }
+
+    // ---- Log: messages published or suppressed --------------------------------
+
+    [Theory]
+    [InlineData(LogLevel.Information)]
+    [InlineData(LogLevel.Warning)]
+    [InlineData(LogLevel.Error)]
+    [InlineData(LogLevel.Critical)]
+    public void Log_AtOrAboveInformation_PublishesOneMessage(LogLevel level)
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        logger.Log(level, new EventId(0), "hello", null, static (s, _) => s);
+
+        Assert.Single(bus.Messages);
+    }
+
+    [Theory]
+    [InlineData(LogLevel.Debug)]
+    [InlineData(LogLevel.Trace)]
+    public void Log_BelowInformation_PublishesNothing(LogLevel level)
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        logger.Log(level, new EventId(0), "suppressed", null, static (s, _) => s);
+
+        Assert.Empty(bus.Messages);
+    }
+
+    // ---- Log: property key format --------------------------------------------
+
+    [Theory]
+    [InlineData(LogLevel.Information, "conjecture.log.Information")]
+    [InlineData(LogLevel.Warning, "conjecture.log.Warning")]
+    [InlineData(LogLevel.Error, "conjecture.log.Error")]
+    [InlineData(LogLevel.Critical, "conjecture.log.Critical")]
+    public void Log_AtOrAboveInformation_NodeHasKeyValuePropertyWithCorrectKey(
+        LogLevel level, string expectedKey)
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        logger.Log(level, new EventId(0), "msg", null, static (s, _) => s);
+
+        TestNodeUpdateMessage message = Assert.Single(bus.Messages);
+#pragma warning disable CS0618
+        KeyValuePairStringProperty? prop =
+            message.TestNode.Properties.SingleOrDefault<KeyValuePairStringProperty>();
+#pragma warning restore CS0618
+        Assert.NotNull(prop);
+        Assert.Equal(expectedKey, prop.Key);
+    }
+
+    // ---- Log: property value is formatted message ----------------------------
+
+    [Fact]
+    public void Log_InformationMessage_NodePropertyValueIsFormattedText()
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        logger.Log(
+            LogLevel.Information,
+            new EventId(0),
+            "hello world",
+            null,
+            static (s, _) => s);
+
+        TestNodeUpdateMessage message = Assert.Single(bus.Messages);
+#pragma warning disable CS0618
+        KeyValuePairStringProperty? prop =
+            message.TestNode.Properties.SingleOrDefault<KeyValuePairStringProperty>();
+#pragma warning restore CS0618
+        Assert.NotNull(prop);
+        Assert.Equal("hello world", prop.Value);
+    }
+
+    // ---- Log: message carries correct node uid and session uid ---------------
+
+    [Fact]
+    public void Log_Information_PublishedMessageCarriesNodeUid()
+    {
+        CapturingMessageBus bus = new();
+        TestNodeUid nodeUid = new("my-node");
+        SessionUid session = new("my-session");
+        MtpLogger logger = new(bus, nodeUid, session);
+
+        logger.Log(LogLevel.Information, new EventId(0), "test", null, static (s, _) => s);
+
+        TestNodeUpdateMessage message = Assert.Single(bus.Messages);
+        Assert.Equal("my-node", message.TestNode.Uid.Value);
+    }
+
+    [Fact]
+    public void Log_Information_PublishedMessageCarriesSessionUid()
+    {
+        CapturingMessageBus bus = new();
+        TestNodeUid nodeUid = new("my-node");
+        SessionUid session = new("my-session");
+        MtpLogger logger = new(bus, nodeUid, session);
+
+        logger.Log(LogLevel.Information, new EventId(0), "test", null, static (s, _) => s);
+
+        TestNodeUpdateMessage message = Assert.Single(bus.Messages);
+        Assert.Equal("my-session", message.SessionUid.Value);
+    }
+
+    // ---- BeginScope ----------------------------------------------------------
+
+    [Fact]
+    public void BeginScope_AnyState_ReturnsNull()
+    {
+        CapturingMessageBus bus = new();
+        MtpLogger logger = BuildLogger(bus);
+
+        IDisposable? scope = logger.BeginScope("some-scope");
+
+        Assert.Null(scope);
+    }
+}

--- a/src/Conjecture.TestingPlatform/Internal/MtpLogger.cs
+++ b/src/Conjecture.TestingPlatform/Internal/MtpLogger.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.TestHost;
+
+namespace Conjecture.TestingPlatform.Internal;
+
+internal sealed class MtpLogger : ILogger
+{
+    private readonly IDataProducer? producer;
+    private readonly IMessageBus bus;
+    private readonly TestNodeUid nodeUid;
+    private readonly SessionUid session;
+
+    internal MtpLogger(IMessageBus bus, TestNodeUid nodeUid, SessionUid session)
+        : this(null, bus, nodeUid, session)
+    {
+    }
+
+    internal MtpLogger(IDataProducer? producer, IMessageBus bus, TestNodeUid nodeUid, SessionUid session)
+    {
+        this.producer = producer;
+        this.bus = bus;
+        this.nodeUid = nodeUid;
+        this.session = session;
+    }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        return null;
+    }
+
+    public bool IsEnabled(LogLevel level)
+    {
+        return level >= LogLevel.Information;
+    }
+
+    public void Log<TState>(
+        LogLevel level,
+        EventId id,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(level))
+        {
+            return;
+        }
+
+        string message = formatter(state, exception);
+        _ = bus.PublishAsync(producer!, new TestNodeUpdateMessage(
+            session,
+            new TestNode
+            {
+                Uid = nodeUid,
+                DisplayName = string.Empty,
+                Properties = new PropertyBag(
+#pragma warning disable CS0618 // KeyValuePairStringProperty is obsolete
+                    new KeyValuePairStringProperty($"conjecture.log.{level}", message))
+#pragma warning restore CS0618
+            }));
+    }
+}

--- a/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
+++ b/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
@@ -167,7 +167,8 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
             return;
         }
 
-        ConjectureSettings settings = ConjectureSettings.From(attr);
+        MtpLogger mtpLogger = new(this, bus, parentNodeUid, sessionUid);
+        ConjectureSettings settings = ConjectureSettings.From(attr, mtpLogger);
         using ExampleDatabase db = new(Path.Combine(settings.DatabasePath, "conjecture.db"), settings.Logger);
 
         Task Test(ConjectureData data)


### PR DESCRIPTION
## Description

Implements `MtpLogger`, an `ILogger` that publishes log entries from property test execution as `TestNodeUpdateMessage`s on the MTP message bus. `PropertyTestFramework` constructs one instance per test node execution and injects it into `ConjectureSettings.Logger`. Log messages at `Information` and above appear as `KeyValuePairStringProperty` entries keyed `conjecture.log.{Level}`; messages below `Information` are silently dropped.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #176
Part of #66