### PR TITLE
[66.5] TrxReport and CrashDump: implement MTP extension capabilities

### DIFF
--- a/src/Conjecture.TestingPlatform.Tests/Conjecture.TestingPlatform.Tests.csproj
+++ b/src/Conjecture.TestingPlatform.Tests/Conjecture.TestingPlatform.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/src/Conjecture.TestingPlatform.Tests/ExtensionCapabilityTests.cs
+++ b/src/Conjecture.TestingPlatform.Tests/ExtensionCapabilityTests.cs
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+
+using Conjecture.Core;
+using Conjecture.TestingPlatform.Internal;
+
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.TestHost;
+
+namespace Conjecture.TestingPlatform.Tests;
+
+public class ExtensionCapabilityTests
+{
+    // ---- test subjects -------------------------------------------------------
+
+    private static class AlwaysFailingSubject
+    {
+        [Property(MaxExamples = 1)]
+        public static void AlwaysFails(int x) { throw new System.Exception("Always fails"); }
+    }
+
+    private static class AlwaysPassingSubject
+    {
+        [Property(MaxExamples = 1)]
+        public static void AlwaysPasses(int x) { }
+    }
+
+    private static class ExampleFailingSubject
+    {
+        [Property]
+        [Example(0)]
+        public static void FailsOnExample(int x) { throw new System.Exception("Example failed"); }
+    }
+
+    // ---- helpers -------------------------------------------------------------
+
+    private sealed class CapturingMessageBus : IMessageBus
+    {
+        private readonly List<TestNodeUpdateMessage> messages = [];
+
+        public IReadOnlyList<TestNodeUpdateMessage> Messages => messages;
+
+        public Task PublishAsync(IDataProducer dataProducer, IData data)
+        {
+            if (data is TestNodeUpdateMessage msg)
+            {
+                messages.Add(msg);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private static PropertyTestFramework BuildFramework(System.Type subjectType)
+    {
+        Assembly assembly = subjectType.Assembly;
+        return new(serviceProvider: null!, assemblies: [assembly], typePredicate: t => t == subjectType);
+    }
+
+    // ---- ITrxReportCapability membership ------------------------------------
+
+    [Fact]
+    public void PropertyTestFrameworkCapabilities_ImplementsITrxReportCapability()
+    {
+        PropertyTestFrameworkCapabilities capabilities = new();
+
+        Assert.True(capabilities is ITrxReportCapability);
+    }
+
+    [Fact]
+    public void PropertyTestFrameworkCapabilities_CapabilitiesCollection_ContainsTrxReportCapability()
+    {
+        PropertyTestFrameworkCapabilities capabilities = new();
+
+        bool found = false;
+        foreach (ITestFrameworkCapability cap in capabilities.Capabilities)
+        {
+            if (cap is ITrxReportCapability)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+    }
+
+    // ---- IsSupported ---------------------------------------------------------
+
+    [Fact]
+    public void ITrxReportCapability_IsSupported_ReturnsTrue()
+    {
+        PropertyTestFrameworkCapabilities capabilities = new();
+        ITrxReportCapability trx = (ITrxReportCapability)capabilities;
+
+        Assert.True(trx.IsSupported);
+    }
+
+    // ---- TrxExceptionProperty only emitted after Enable() -------------------
+
+    [Fact]
+    public async Task RunAsync_WithoutEnablingTrx_FailedNode_DoesNotHaveTrxExceptionProperty()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(AlwaysFailingSubject));
+        CapturingMessageBus bus = new();
+
+        await framework.RunAsync(bus, new SessionUid("test-session"));
+
+        bool hasTrxException = false;
+        foreach (TestNodeUpdateMessage msg in bus.Messages)
+        {
+            if (msg.TestNode.Properties.SingleOrDefault<TrxExceptionProperty>() is not null)
+            {
+                hasTrxException = true;
+            }
+        }
+
+        Assert.False(hasTrxException);
+    }
+
+    [Fact]
+    public async Task RunAsync_AfterEnablingTrx_FailedNode_HasTrxExceptionPropertyWithCounterexampleMessage()
+    {
+        PropertyTestFrameworkCapabilities capabilities = new();
+        ITrxReportCapability trx = (ITrxReportCapability)capabilities;
+        trx.Enable();
+
+        PropertyTestFramework framework = new(
+            serviceProvider: null!,
+            assemblies: [typeof(AlwaysFailingSubject).Assembly],
+            typePredicate: t => t == typeof(AlwaysFailingSubject),
+            capabilities: capabilities);
+        CapturingMessageBus bus = new();
+
+        await framework.RunAsync(bus, new SessionUid("test-session"));
+
+        TrxExceptionProperty? trxException = null;
+        foreach (TestNodeUpdateMessage msg in bus.Messages)
+        {
+            TrxExceptionProperty? candidate = msg.TestNode.Properties.SingleOrDefault<TrxExceptionProperty>();
+            if (candidate is not null && msg.TestNode.Properties.SingleOrDefault<FailedTestNodeStateProperty>() is not null)
+            {
+                trxException = candidate;
+            }
+        }
+
+        Assert.NotNull(trxException);
+        Assert.False(string.IsNullOrWhiteSpace(trxException.Message));
+    }
+
+    [Fact]
+    public async Task RunAsync_AfterEnablingTrx_ExampleFailure_HasTrxExceptionProperty()
+    {
+        PropertyTestFrameworkCapabilities capabilities = new();
+        ITrxReportCapability trx = (ITrxReportCapability)capabilities;
+        trx.Enable();
+
+        PropertyTestFramework framework = new(
+            serviceProvider: null!,
+            assemblies: [typeof(ExampleFailingSubject).Assembly],
+            typePredicate: t => t == typeof(ExampleFailingSubject),
+            capabilities: capabilities);
+        CapturingMessageBus bus = new();
+
+        await framework.RunAsync(bus, new SessionUid("test-session"));
+
+        TrxExceptionProperty? trxException = null;
+        foreach (TestNodeUpdateMessage msg in bus.Messages)
+        {
+            TrxExceptionProperty? candidate = msg.TestNode.Properties.SingleOrDefault<TrxExceptionProperty>();
+            if (candidate is not null && msg.TestNode.Properties.SingleOrDefault<FailedTestNodeStateProperty>() is not null)
+            {
+                trxException = candidate;
+            }
+        }
+
+        Assert.NotNull(trxException);
+        Assert.False(string.IsNullOrWhiteSpace(trxException.Message));
+    }
+
+    [Fact]
+    public async Task RunAsync_WithoutEnablingTrx_ExampleFailure_DoesNotHaveTrxExceptionProperty()
+    {
+        PropertyTestFramework framework = BuildFramework(typeof(ExampleFailingSubject));
+        CapturingMessageBus bus = new();
+
+        await framework.RunAsync(bus, new SessionUid("test-session"));
+
+        bool hasTrxException = false;
+        foreach (TestNodeUpdateMessage msg in bus.Messages)
+        {
+            if (msg.TestNode.Properties.SingleOrDefault<TrxExceptionProperty>() is not null)
+            {
+                hasTrxException = true;
+            }
+        }
+
+        Assert.False(hasTrxException);
+    }
+
+    [Fact]
+    public async Task RunAsync_AfterEnablingTrx_PassedNode_DoesNotHaveTrxExceptionProperty()
+    {
+        PropertyTestFrameworkCapabilities capabilities = new();
+        ITrxReportCapability trx = (ITrxReportCapability)capabilities;
+        trx.Enable();
+
+        PropertyTestFramework framework = new(
+            serviceProvider: null!,
+            assemblies: [typeof(AlwaysPassingSubject).Assembly],
+            typePredicate: t => t == typeof(AlwaysPassingSubject),
+            capabilities: capabilities);
+        CapturingMessageBus bus = new();
+
+        await framework.RunAsync(bus, new SessionUid("test-session"));
+
+        bool hasTrxException = false;
+        foreach (TestNodeUpdateMessage msg in bus.Messages)
+        {
+            if (msg.TestNode.Properties.SingleOrDefault<TrxExceptionProperty>() is not null)
+            {
+                hasTrxException = true;
+            }
+        }
+
+        Assert.False(hasTrxException);
+    }
+}

--- a/src/Conjecture.TestingPlatform/Conjecture.TestingPlatform.csproj
+++ b/src/Conjecture.TestingPlatform/Conjecture.TestingPlatform.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" />
     <PackageReference Include="Microsoft.Testing.Platform" />
   </ItemGroup>
 

--- a/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
+++ b/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Conjecture.Core;
 using Conjecture.Core.Internal;
 
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 using Microsoft.Testing.Platform.CommandLine;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
@@ -22,6 +23,7 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
     private readonly IEnumerable<Assembly> assemblies;
     private readonly Func<Type, bool>? typePredicate;
     private readonly ICommandLineOptions? commandLineOptions;
+    private readonly PropertyTestFrameworkCapabilities? capabilities;
 
     internal PropertyTestFramework(IServiceProvider serviceProvider)
         : this(serviceProvider, AppDomain.CurrentDomain.GetAssemblies(), null,
@@ -33,12 +35,14 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
         IServiceProvider serviceProvider,
         IEnumerable<Assembly> assemblies,
         Func<Type, bool>? typePredicate = null,
-        ICommandLineOptions? commandLineOptions = null)
+        ICommandLineOptions? commandLineOptions = null,
+        PropertyTestFrameworkCapabilities? capabilities = null)
     {
         _ = serviceProvider;
         this.assemblies = assemblies;
         this.typePredicate = typePredicate;
         this.commandLineOptions = commandLineOptions;
+        this.capabilities = capabilities;
     }
 
     public string Uid => "Conjecture.TestingPlatform";
@@ -154,6 +158,11 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
             {
                 string msg = TestCaseHelper.BuildExampleFailureMessage(example, parameters, ex);
                 childNode.Properties.Add(new FailedTestNodeStateProperty(ex, msg));
+                if (capabilities?.TrxEnabled == true)
+                {
+                    childNode.Properties.Add(new TrxExceptionProperty(msg, ex.StackTrace));
+                }
+
                 await bus.PublishAsync(this, new TestNodeUpdateMessage(sessionUid, childNode, parentNodeUid));
 
                 TestNode parentNode = new()
@@ -162,6 +171,11 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
                     DisplayName = displayName,
                 };
                 parentNode.Properties.Add(new FailedTestNodeStateProperty(ex, msg));
+                if (capabilities?.TrxEnabled == true)
+                {
+                    parentNode.Properties.Add(new TrxExceptionProperty(msg, ex.StackTrace));
+                }
+
                 await bus.PublishAsync(this, new TestNodeUpdateMessage(sessionUid, parentNode));
                 exampleFailed = true;
                 break;
@@ -223,6 +237,10 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
         {
             string failureMessage = TestCaseHelper.BuildFailureMessage(result, parameters);
             resultNode.Properties.Add(new FailedTestNodeStateProperty(failureMessage));
+            if (capabilities?.TrxEnabled == true)
+            {
+                resultNode.Properties.Add(new TrxExceptionProperty(failureMessage, null));
+            }
         }
 
         await bus.PublishAsync(this, new TestNodeUpdateMessage(sessionUid, resultNode));

--- a/src/Conjecture.TestingPlatform/Internal/PropertyTestFrameworkCapabilities.cs
+++ b/src/Conjecture.TestingPlatform/Internal/PropertyTestFrameworkCapabilities.cs
@@ -1,11 +1,21 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 
 namespace Conjecture.TestingPlatform.Internal;
 
-internal sealed class PropertyTestFrameworkCapabilities : ITestFrameworkCapabilities
+internal sealed class PropertyTestFrameworkCapabilities : ITestFrameworkCapabilities, ITrxReportCapability
 {
-    public IReadOnlyCollection<ITestFrameworkCapability> Capabilities => [];
+    public bool IsSupported => true;
+
+    public bool TrxEnabled { get; private set; }
+
+    public void Enable()
+    {
+        TrxEnabled = true;
+    }
+
+    public IReadOnlyCollection<ITestFrameworkCapability> Capabilities => [this];
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -61,7 +61,8 @@
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25277.114" />
 
     <!-- Microsoft Testing Platform -->
-    <PackageVersion Include="Microsoft.Testing.Platform" Version="1.9.0" />
-    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="1.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="1.9.1" />
+    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="1.9.1" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="1.9.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Implements `ITrxReportCapability` on `PropertyTestFrameworkCapabilities` so TRX reports include counterexample detail and stack traces on test failures. When the TRX extension calls `Enable()`, failed test nodes receive a `TrxExceptionProperty` covering both property-based and `[Example]`-attributed failure paths. Without calling `Enable()`, no `TrxExceptionProperty` is emitted.

Also adds `Microsoft.Testing.Extensions.TrxReport.Abstractions` as a package dependency and bumps `Microsoft.Testing.Platform` packages from 1.9.0 to 1.9.1 to keep versions in sync.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #178
Part of #66