### PR TITLE
[66.6] Conjecture.Mcp: document MTP adapter

### DIFF
--- a/src/Conjecture.Mcp.Tests/ApiReferenceResourcesTests.cs
+++ b/src/Conjecture.Mcp.Tests/ApiReferenceResourcesTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using Conjecture.Mcp.Resources;
+
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Conjecture.Mcp.Tests;
+
+public class ApiReferenceResourcesTests
+{
+    private static RequestContext<T> MakeUninitializedContext<T>()
+        where T : class
+    {
+        Type contextType = typeof(RequestContext<T>);
+        object ctx = RuntimeHelpers.GetUninitializedObject(contextType);
+        return (RequestContext<T>)ctx;
+    }
+
+    private static RequestContext<ReadResourceRequestParams> MakeReadContext(string uri)
+    {
+        Type contextType = typeof(RequestContext<ReadResourceRequestParams>);
+        object ctx = RuntimeHelpers.GetUninitializedObject(contextType);
+        FieldInfo field = contextType.GetField(
+            "<Params>k__BackingField",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(ctx, new ReadResourceRequestParams { Uri = uri });
+        return (RequestContext<ReadResourceRequestParams>)ctx;
+    }
+
+    [Fact]
+    public async Task TestingPlatform_AppearsInListResources()
+    {
+        ListResourcesResult result = await ApiReferenceResources.HandleListResources(
+            MakeUninitializedContext<ListResourcesRequestParams>(), default);
+
+        Assert.Contains(result.Resources, r => r.Uri == "conjecture://api/testing-platform");
+    }
+
+    [Fact]
+    public async Task TestingPlatform_ReadReturnsNonEmptyMarkdown()
+    {
+        RequestContext<ReadResourceRequestParams> context =
+            MakeReadContext("conjecture://api/testing-platform");
+
+        ReadResourceResult result = await ApiReferenceResources.HandleReadResource(
+            context, default);
+
+        TextResourceContents contents = Assert.IsType<TextResourceContents>(result.Contents[0]);
+        Assert.DoesNotContain("not found", contents.Text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("Conjecture.TestingPlatform")]
+    [InlineData("--conjecture-seed")]
+    [InlineData("--conjecture-max-examples")]
+    public async Task TestingPlatform_ContentMentionsKeyTerms(string expectedTerm)
+    {
+        RequestContext<ReadResourceRequestParams> context =
+            MakeReadContext("conjecture://api/testing-platform");
+
+        ReadResourceResult result = await ApiReferenceResources.HandleReadResource(
+            context, default);
+
+        TextResourceContents contents = Assert.IsType<TextResourceContents>(result.Contents[0]);
+        Assert.Contains(expectedTerm, contents.Text);
+    }
+}

--- a/src/Conjecture.Mcp/Docs/attributes.md
+++ b/src/Conjecture.Mcp/Docs/attributes.md
@@ -2,7 +2,7 @@
 
 ## `[Property]`
 
-Marks a method as a Conjecture property test. Available on all adapters (xUnit, NUnit, MSTest).
+Marks a method as a Conjecture property test. Available on all adapters (xUnit, NUnit, MSTest, and Microsoft Testing Platform).
 
 ```csharp
 // xUnit
@@ -19,14 +19,35 @@ public void MyProperty(int x, string s) { ... }
 using Conjecture.MSTest;
 [Property]
 public void MyProperty(int x, string s) { ... }
+
+// Microsoft Testing Platform
+using Conjecture.TestingPlatform;
+[Property]
+public void MyProperty(int x, string s) { ... }
 ```
 
-**Parameters:**
+**Parameters (xUnit / NUnit / MSTest adapters):**
 
 | Parameter | Type | Default | Notes |
 |-----------|------|---------|-------|
 | `Seed` | `ulong` | random | Hex literal for deterministic replay, e.g. `0xDEAD` |
 | `MaxExamples` | `int` | 100 | Override the example count for this test |
+
+**Parameters (Microsoft Testing Platform adapter — `Conjecture.TestingPlatform`):**
+
+`PropertyAttribute` in the MTP adapter carries the **full settings surface directly** — no separate `[ConjectureSettings]` attribute exists in that namespace.
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|-------|
+| `Seed` | `ulong?` | `null` (random) | Fixed seed for deterministic replay |
+| `MaxExamples` | `int` | `100` | Number of examples to generate |
+| `UseDatabase` | `bool` | `true` | Whether to use the SQLite example cache |
+| `MaxStrategyRejections` | `int` | `5` | Max strategy rejections per value |
+| `DeadlineMs` | `int` | `0` | Per-example deadline in ms; `0` = no deadline |
+| `Targeting` | `bool` | `true` | Whether to run a targeting phase |
+| `TargetingProportion` | `double` | `0.5` | Fraction of budget for targeting |
+| `ExportReproOnFailure` | `bool` | `false` | Write reproduction file on failure |
+| `ReproOutputPath` | `string` | `".conjecture/repros/"` | Output path for reproduction files |
 
 ## `[ConjectureSettings]`
 

--- a/src/Conjecture.Mcp/Docs/settings.md
+++ b/src/Conjecture.Mcp/Docs/settings.md
@@ -84,3 +84,17 @@ public void MyTest(int x) { ... }
 ```
 
 On failure, a file is written to `ReproOutputPath` with the seed and minimal counterexample, ready to paste into a test class for deterministic replay.
+
+## CLI Overrides (MTP Adapter Only)
+
+When running under `Conjecture.TestingPlatform`, two CLI flags override settings globally for all properties in the run:
+
+- `--conjecture-seed <ulong>` — forces a fixed seed for all property runs
+- `--conjecture-max-examples <int>` — overrides `MaxExamples` for all properties
+
+```bash
+dotnet run -- --conjecture-seed 42
+dotnet test -- --conjecture-max-examples 1000
+```
+
+These flags are not available in the xUnit, NUnit, or MSTest adapters.

--- a/src/Conjecture.Mcp/Docs/testing-platform.md
+++ b/src/Conjecture.Mcp/Docs/testing-platform.md
@@ -1,0 +1,112 @@
+# Conjecture.TestingPlatform Adapter Reference
+
+## What is Conjecture.TestingPlatform
+
+`Conjecture.TestingPlatform` is a native `ITestFramework` for [Microsoft Testing Platform (MTP)](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro). It is **not** a VSTestBridge adapter — it runs as a self-contained test executable with `OutputType=Exe`.
+
+This means no xunit.runner, no MSTest runner, and no separate test host. The compiled test project is itself the test runner.
+
+## Project Setup
+
+Add a `PackageReference` to `Conjecture.TestingPlatform` and set `OutputType=Exe`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Conjecture.TestingPlatform" Version="*" />
+  </ItemGroup>
+</Project>
+```
+
+No additional runner package is needed.
+
+## `[Property]` Attribute
+
+Mark methods as property-based tests with `[Property]` from the `Conjecture.TestingPlatform` namespace:
+
+```csharp
+using Conjecture.TestingPlatform;
+
+[Property]
+public void MyProperty(int x, string s) { ... }
+```
+
+`PropertyAttribute` in the MTP adapter carries the **full settings surface directly** — no separate `[ConjectureSettings]` attribute exists in this namespace.
+
+### Parameters
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|-------|
+| `Seed` | `ulong?` | `null` (random) | Fixed seed for deterministic replay, e.g. `0xDEAD` |
+| `MaxExamples` | `int` | `100` | Number of examples to generate |
+| `UseDatabase` | `bool` | `true` | Whether to use the SQLite example cache |
+| `MaxStrategyRejections` | `int` | `5` | Max times a strategy may reject a generated value |
+| `DeadlineMs` | `int` | `0` | Per-example time limit in milliseconds; `0` means no deadline |
+| `Targeting` | `bool` | `true` | Whether to run a targeting phase after generation |
+| `TargetingProportion` | `double` | `0.5` | Fraction of `MaxExamples` budget allocated to targeting |
+| `ExportReproOnFailure` | `bool` | `false` | Write a reproduction file on test failure |
+| `ReproOutputPath` | `string` | `".conjecture/repros/"` | Output directory for reproduction files |
+
+### Example with settings
+
+```csharp
+using Conjecture.TestingPlatform;
+
+[Property(MaxExamples = 500, UseDatabase = false, DeadlineMs = 200)]
+public void ParseRoundtrip(string input) { ... }
+
+// Deterministic replay from a previous failure:
+[Property(Seed = 0xABCD1234)]
+public void ReproduceBug(int x) { ... }
+```
+
+## CLI Options
+
+When running under `Conjecture.TestingPlatform`, two CLI flags override settings globally for all properties in the run:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `--conjecture-seed <ulong>` | `ulong` | Force a fixed seed for all property runs |
+| `--conjecture-max-examples <int>` | `int` (positive) | Override `MaxExamples` for all properties |
+
+### Passing CLI options
+
+Via `dotnet run`:
+```bash
+dotnet run -- --conjecture-seed 42
+dotnet run -- --conjecture-max-examples 1000
+```
+
+Via `dotnet test` (MTP runner):
+```bash
+dotnet test -- --conjecture-seed 42
+dotnet test -- --conjecture-max-examples 1000
+```
+
+## TRX Reports
+
+`Conjecture.TestingPlatform` implements `ITrxReportCapability` automatically. No extra configuration is needed in the `.csproj`.
+
+Enable TRX output at the command line:
+```bash
+dotnet test --report-trx
+```
+
+Failed test nodes include the Conjecture counterexample message, so the TRX report captures the minimal failing input alongside the failure.
+
+## CrashDump Support
+
+Add `Microsoft.Testing.Extensions.CrashDump` to your test project — it is auto-wired by MSBuild:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Testing.Extensions.CrashDump" Version="*" />
+</ItemGroup>
+```
+
+No code changes are required. A `.dmp` file is written next to the test output on unhandled crash.

--- a/src/Conjecture.Mcp/Resources/ApiReferenceResources.cs
+++ b/src/Conjecture.Mcp/Resources/ApiReferenceResources.cs
@@ -21,6 +21,7 @@ internal static class ApiReferenceResources
         ("attributes",           "Test Attributes",            "[Property], [Example], [From<T>], [FromFactory], [ConjectureSettings]"),
         ("targeted-testing",     "Targeted Testing",           "Target.Maximize, Target.Minimize, IGeneratorContext.Target, and targeting settings"),
         ("recursive-strategies", "Recursive Strategies",       "Generate.Recursive<T> for tree-shaped and self-referential types"),
+        ("testing-platform",     "Microsoft Testing Platform Adapter", "Conjecture.TestingPlatform setup, [Property] attribute, CLI options, TRX reports, and CrashDump"),
     ];
 
     internal static ValueTask<ListResourcesResult> HandleListResources(


### PR DESCRIPTION
## Description

Adds `conjecture://api/testing-platform` as a new MCP resource documenting the `Conjecture.TestingPlatform` native MTP adapter — project setup, `[Property]` full settings surface, CLI options, TRX reports, and CrashDump.

Also updates `attributes.md` with MTP `[Property]` usage and its 9-property parameter table, and `settings.md` with a CLI overrides section (`--conjecture-seed`, `--conjecture-max-examples`).

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #216
Part of #66