### PR TITLE
[66.7] Docs: add MTP adapter coverage

### DIFF
--- a/docs/site/articles/how-to/install.md
+++ b/docs/site/articles/how-to/install.md
@@ -12,6 +12,7 @@ Install the package for your test framework. Each adapter transitively reference
 | xUnit v3 | `Conjecture.Xunit.V3` |
 | NUnit 4 | `Conjecture.NUnit` |
 | MSTest | `Conjecture.MSTest` |
+| MTP (no framework) | `Conjecture.TestingPlatform` |
 
 # [xUnit v2](#tab/xunit-v2)
 
@@ -36,6 +37,14 @@ dotnet add package Conjecture.NUnit
 ```bash
 dotnet add package Conjecture.MSTest
 ```
+
+# [MTP](#tab/mtp)
+
+```bash
+dotnet add package Conjecture.TestingPlatform
+```
+
+Also set `OutputType=Exe` in the `.csproj`. See [How to use the MTP adapter](use-mtp-adapter.md) for full setup.
 
 ***
 
@@ -69,6 +78,13 @@ using Conjecture.NUnit;  // [Property], [Example], [From<T>], [FromFactory], ...
 ```csharp
 using Conjecture.Core;    // Generate, Strategy<T>, Assume, ConjectureSettings, ...
 using Conjecture.MSTest;  // [Property], [Example], [From<T>], [FromFactory], ...
+```
+
+# [MTP](#tab/mtp)
+
+```csharp
+using Conjecture.Core;              // Generate, Strategy<T>, Assume, ...
+using Conjecture.TestingPlatform;   // [Property], [Example], [From<T>], [FromFactory], ...
 ```
 
 ***

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -1,6 +1,8 @@
 items:
   - name: Install
     href: install.md
+  - name: Use the MTP adapter
+    href: use-mtp-adapter.md
   - name: Reproduce a failure
     href: reproduce-a-failure.md
   - name: Export counterexamples to files

--- a/docs/site/articles/how-to/use-mtp-adapter.md
+++ b/docs/site/articles/how-to/use-mtp-adapter.md
@@ -1,0 +1,100 @@
+# How to use the MTP adapter
+
+`Conjecture.TestingPlatform` is a native [Microsoft Testing Platform (MTP)](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro) adapter. The test project compiles to a self-contained executable — no xUnit, NUnit, or MSTest runner needed.
+
+## When to choose MTP
+
+- **.NET 10+ greenfield projects** — MTP is the default going forward and requires no framework dependency.
+- **Minimal dependencies** — just `Conjecture.TestingPlatform`; no third-party test framework.
+- **Framework-agnostic pipelines** — no runner packages, no `.runsettings`, no adapter DLLs.
+
+If you have an existing test suite in xUnit, NUnit, or MSTest, stay with the corresponding adapter. Conjecture's `[Property]` API is identical across all adapters.
+
+## Project setup
+
+Create a new class library, then add `Conjecture.TestingPlatform`:
+
+```bash
+dotnet new classlib -n MyProject.Tests
+cd MyProject.Tests
+dotnet add package Conjecture.TestingPlatform
+```
+
+Edit the generated `.csproj` to set `OutputType=Exe`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Conjecture.TestingPlatform" Version="*" />
+  </ItemGroup>
+</Project>
+```
+
+The package supplies the entry point — no `Program.cs` needed in your project.
+
+## Minimal working example
+
+```csharp
+using Conjecture.Core;
+using Conjecture.TestingPlatform;
+
+public class MathTests
+{
+    [Property]
+    public bool Addition_is_commutative(int a, int b) => a + b == b + a;
+
+    [Property(MaxExamples = 500)]
+    public void Abs_is_non_negative(int value)
+    {
+        Assume.That(value != int.MinValue);
+        if (Math.Abs(value) < 0)
+        {
+            throw new Exception("Negative abs value");
+        }
+    }
+}
+```
+
+Run with:
+
+```bash
+dotnet test
+```
+
+Each `[Property]` method runs against 100 randomly generated inputs by default. A failure shows the shrunk counterexample.
+
+## CLI options
+
+Two CLI flags override settings globally for all properties in the run:
+
+| Option | Description |
+|--------|-------------|
+| `--conjecture-seed <ulong>` | Fix a seed for deterministic replay across all properties |
+| `--conjecture-max-examples <int>` | Override `MaxExamples` for all properties |
+
+Pass them after `--` so `dotnet test` forwards them to the executable:
+
+```bash
+dotnet test -- --conjecture-seed 42
+dotnet test -- --conjecture-max-examples 1000
+```
+
+## TRX reports
+
+TRX output is supported out of the box — no extra configuration:
+
+```bash
+dotnet test --report-trx
+```
+
+Failed test nodes include the Conjecture counterexample, so the TRX captures the minimal failing input alongside the failure message.
+
+## Next
+
+- [Tutorial 5: Framework Adapters](../tutorials/05-framework-adapters.md) — side-by-side comparison of all adapters
+- [How to reproduce a failure](reproduce-a-failure.md) — replay a specific counterexample with a fixed seed

--- a/docs/site/articles/quick-start.md
+++ b/docs/site/articles/quick-start.md
@@ -36,6 +36,16 @@ cd MyProject.Tests
 dotnet add package Conjecture.MSTest
 ```
 
+# [MTP](#tab/mtp)
+
+```bash
+dotnet new classlib -n MyProject.Tests
+cd MyProject.Tests
+dotnet add package Conjecture.TestingPlatform
+```
+
+Then edit `MyProject.Tests.csproj` and add `<OutputType>Exe</OutputType>` inside `<PropertyGroup>`.
+
 ***
 
 ## 2. Write a Property Test
@@ -148,6 +158,32 @@ public class MathTests
 }
 ```
 
+# [MTP](#tab/mtp)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.TestingPlatform;
+
+namespace MyProject.Tests;
+
+public class MathTests
+{
+    [Property]
+    public bool Addition_is_commutative(int a, int b)
+    {
+        return a + b == b + a;
+    }
+
+    [Property]
+    public bool Abs_is_non_negative(int value)
+    {
+        // Skip int.MinValue — Math.Abs throws for it
+        Assume.That(value != int.MinValue);
+        return Math.Abs(value) >= 0;
+    }
+}
+```
+
 ***
 
 ## 3. Run
@@ -217,6 +253,20 @@ public void Sorting_preserves_length(List<int> items)
 {
     var sorted = items.OrderBy(x => x).ToList();
     Assert.AreEqual(items.Count, sorted.Count);
+}
+```
+
+# [MTP](#tab/mtp)
+
+```csharp
+[Property]
+public void Sorting_preserves_length(List<int> items)
+{
+    List<int> sorted = items.OrderBy(x => x).ToList();
+    if (sorted.Count != items.Count)
+    {
+        throw new Exception($"Expected {items.Count} items, got {sorted.Count}");
+    }
 }
 ```
 

--- a/docs/site/articles/tutorials/05-framework-adapters.md
+++ b/docs/site/articles/tutorials/05-framework-adapters.md
@@ -92,6 +92,30 @@ Package: `Conjecture.MSTest`
 
 > **Note:** MSTest requires `[TestClass]` on the class. The other frameworks don't.
 
+# [MTP](#tab/mtp)
+
+```csharp
+using Conjecture.TestingPlatform;
+
+public class MathTests
+{
+    [Property]
+    public bool Addition_is_commutative(int a, int b) => a + b == b + a;
+
+    [Property(MaxExamples = 500)]
+    public void Abs_is_non_negative(int value)
+    {
+        Assume.That(value != int.MinValue);
+        if (Math.Abs(value) < 0)
+        {
+            throw new Exception("Negative abs value");
+        }
+    }
+}
+```
+
+Package: `Conjecture.TestingPlatform` — requires `OutputType=Exe` in the `.csproj`. See [How to use the MTP adapter](../how-to/use-mtp-adapter.md).
+
 ***
 
 ## Shared Features
@@ -105,6 +129,10 @@ All adapters support the same `[Property]` properties:
 | `UseDatabase` | `bool` | `true` | Persist failing examples |
 | `MaxStrategyRejections` | `int` | 5 | Max filter rejections per strategy |
 | `DeadlineMs` | `int` | 0 (none) | Per-example timeout in ms |
+| `Targeting` | `bool` | `true` | Run a targeting phase after generation |
+| `TargetingProportion` | `double` | 0.5 | Fraction of `MaxExamples` budget for targeting |
+| `ExportReproOnFailure` | `bool` | `false` | Write a reproduction file on failure |
+| `ReproOutputPath` | `string` | `.conjecture/repros/` | Output directory for reproduction files |
 
 All adapters also support:
 - `[Example(...)]` — explicit test cases
@@ -117,6 +145,8 @@ All adapters also support:
 ## Choosing a Framework
 
 The choice is usually dictated by your existing test suite. Conjecture's `[Property]` tests coexist with your regular `[Fact]`/`[Test]`/`[TestMethod]` tests in the same project.
+
+For **new .NET 10+ projects with no existing framework preference**, consider `Conjecture.TestingPlatform`. It has the fewest dependencies and runs as a native MTP executable without a separate runner. See [How to use the MTP adapter](../how-to/use-mtp-adapter.md).
 
 ## Next
 


### PR DESCRIPTION
## Description

Documents `Conjecture.TestingPlatform` across the doc site. No prior user-facing documentation existed for the MTP adapter despite five TDD cycles having shipped it.

- Adds `use-mtp-adapter.md` how-to guide (project setup, minimal example, CLI options, TRX reports)
- Adds MTP tab to `quick-start.md` (steps 1, 2, Return Types)
- Adds MTP tab to tutorial `05-framework-adapters.md` side-by-side comparison
- Extends Shared Features table with `Targeting`, `TargetingProportion`, `ExportReproOnFailure`, `ReproOutputPath`
- Adds MTP row and tabs to `install.md`; adds `toc.yml` entry

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [ ] `dotnet test src/` passes
- [ ] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #217
Part of #66