### PR TITLE
[204.1] Scaffold: create Conjecture.LinqPad and Conjecture.LinqPad.Tests projects

### DIFF
--- a/src/Conjecture.LinqPad.Tests/Conjecture.LinqPad.Tests.csproj
+++ b/src/Conjecture.LinqPad.Tests/Conjecture.LinqPad.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.LinqPad\Conjecture.LinqPad.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/Conjecture.LinqPad/Conjecture.LinqPad.csproj
+++ b/src/Conjecture.LinqPad/Conjecture.LinqPad.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>LINQPad integration for Conjecture.NET — rich output formatters and visualizers</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LINQPad.Reference" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Conjecture.LinqPad/PublicAPI.Shipped.txt
+++ b/src/Conjecture.LinqPad/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.LinqPad/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.LinqPad/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.LinqPad/README.md
+++ b/src/Conjecture.LinqPad/README.md
@@ -1,0 +1,3 @@
+# Conjecture.LinqPad
+
+LINQPad integration for [Conjecture.NET](https://github.com/kommundsen/Conjecture) — rich output formatters and visualizers for property-based testing in LINQPad scripts.

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -28,4 +28,6 @@
   <Project Path="Conjecture.Interactive.Tests/Conjecture.Interactive.Tests.csproj" />
   <Project Path="Conjecture.TestingPlatform/Conjecture.TestingPlatform.csproj" />
   <Project Path="Conjecture.TestingPlatform.Tests/Conjecture.TestingPlatform.Tests.csproj" />
+  <Project Path="Conjecture.LinqPad/Conjecture.LinqPad.csproj" />
+  <Project Path="Conjecture.LinqPad.Tests/Conjecture.LinqPad.Tests.csproj" />
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -60,6 +60,9 @@
     <!-- CLI tool -->
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta5.25277.114" />
 
+    <!-- LINQPad -->
+    <PackageVersion Include="LINQPad.Reference" Version="1.3.1" />
+
     <!-- Microsoft Testing Platform -->
     <PackageVersion Include="Microsoft.Testing.Platform" Version="1.9.1" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="1.9.1" />


### PR DESCRIPTION
## Description

Scaffolds the `Conjecture.LinqPad` and `Conjecture.LinqPad.Tests` projects as the foundation for LINQPad integration. Adds `LINQPad.Reference` to central package management and wires both projects into the solution.

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [x] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #220
Part of #204