### PR TITLE
[204.2] HtmlRenderer: HTML sample table, inline preview, and SVG histogram

### DIFF
--- a/src/Conjecture.LinqPad.Tests/HtmlRendererTests.cs
+++ b/src/Conjecture.LinqPad.Tests/HtmlRendererTests.cs
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Text.RegularExpressions;
+
+using Conjecture.Core;
+
+namespace Conjecture.LinqPad.Tests;
+
+public class HtmlRendererTests
+{
+    // --- HtmlSampleTable ---
+
+    [Fact]
+    public void HtmlSampleTable_Render_OutputContainsTableElement()
+    {
+        Strategy<int> strategy = Generate.Just(1);
+
+        string html = HtmlSampleTable.Render(strategy, count: 5, seed: 0);
+
+        Assert.Contains("<table", html);
+    }
+
+    [Fact]
+    public void HtmlSampleTable_Render_OutputContainsThElement()
+    {
+        Strategy<int> strategy = Generate.Just(1);
+
+        string html = HtmlSampleTable.Render(strategy, count: 5, seed: 0);
+
+        Assert.Contains("<th", html);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public void HtmlSampleTable_Render_ContainsExactlyCountDataRows(int count)
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = HtmlSampleTable.Render(strategy, count: count, seed: 0);
+
+        int trCount = Regex.Matches(html, "<tr", RegexOptions.IgnoreCase).Count;
+        // One <tr> per data row; header row uses <th>, not an extra <tr> with data.
+        Assert.Equal(count, trCount);
+    }
+
+    [Fact]
+    public void HtmlSampleTable_Render_CountAbove50_CapsAt50Rows()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = HtmlSampleTable.Render(strategy, count: 75, seed: 0);
+
+        int trCount = Regex.Matches(html, "<tr", RegexOptions.IgnoreCase).Count;
+        Assert.Equal(50, trCount);
+    }
+
+    [Fact]
+    public void HtmlSampleTable_Render_CountAbove50_ContainsTruncationNotice()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = HtmlSampleTable.Render(strategy, count: 75, seed: 0);
+
+        Assert.Contains("truncat", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlSampleTable_Render_SameSeedTwice_ProducesIdenticalOutput()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string first = HtmlSampleTable.Render(strategy, count: 10, seed: 99);
+        string second = HtmlSampleTable.Render(strategy, count: 10, seed: 99);
+
+        Assert.Equal(first, second);
+    }
+
+    // --- HtmlPreview ---
+
+    [Fact]
+    public void HtmlPreview_Render_OutputIsSpanElement()
+    {
+        Strategy<int> strategy = Generate.Just(7);
+
+        string html = HtmlPreview.Render(strategy, count: 5, seed: 0);
+
+        Assert.StartsWith("<span", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlPreview_Render_OutputContainsCommaSeparatedValues()
+    {
+        Strategy<int> strategy = Generate.Just(42);
+
+        string html = HtmlPreview.Render(strategy, count: 5, seed: 0);
+
+        Assert.Contains(",", html);
+        Assert.Contains("42", html);
+    }
+
+    [Fact]
+    public void HtmlPreview_Render_DefaultCount_Contains20Values()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = HtmlPreview.Render(strategy, seed: 0);
+
+        // 20 values produce 19 commas inside the span content.
+        int commaCount = html.Split(',').Length - 1;
+        Assert.Equal(19, commaCount);
+    }
+
+    [Fact]
+    public void HtmlPreview_Render_CountAbove100_CapsAt100Values()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = HtmlPreview.Render(strategy, count: 150, seed: 0);
+
+        // The truncation notice may contain commas too; strip it first.
+        // We verify the values portion has exactly 99 commas (100 items).
+        int commaCount = html.Split(',').Length - 1;
+        Assert.True(commaCount >= 99, $"Expected at least 99 commas (100 values), got {commaCount}");
+    }
+
+    [Fact]
+    public void HtmlPreview_Render_CountAbove100_ContainsTruncationNotice()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = HtmlPreview.Render(strategy, count: 150, seed: 0);
+
+        Assert.Contains("truncat", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlPreview_Render_SameSeedTwice_ProducesIdenticalOutput()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string first = HtmlPreview.Render(strategy, count: 20, seed: 7);
+        string second = HtmlPreview.Render(strategy, count: 20, seed: 7);
+
+        Assert.Equal(first, second);
+    }
+
+    // --- SvgHistogram ---
+
+    [Fact]
+    public void SvgHistogram_Render_OutputContainsSvgElement()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+
+        string svg = SvgHistogram.Render(strategy, sampleSize: 100, bucketCount: 10, seed: 0);
+
+        Assert.Contains("<svg", svg);
+    }
+
+    [Theory]
+    [InlineData(5)]
+    [InlineData(10)]
+    [InlineData(20)]
+    public void SvgHistogram_Render_ContainsExactlyBucketCountRectElements(int bucketCount)
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string svg = SvgHistogram.Render(strategy, sampleSize: 200, bucketCount: bucketCount, seed: 0);
+
+        int rectCount = Regex.Matches(svg, "<rect", RegexOptions.IgnoreCase).Count;
+        Assert.Equal(bucketCount, rectCount);
+    }
+
+    [Fact]
+    public void SvgHistogram_Render_SameSeedTwice_ProducesIdenticalOutput()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string first = SvgHistogram.Render(strategy, sampleSize: 100, bucketCount: 20, seed: 5);
+        string second = SvgHistogram.Render(strategy, sampleSize: 100, bucketCount: 20, seed: 5);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void SvgHistogram_Render_OutputContainsBucketRangeLabels()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+
+        string svg = SvgHistogram.Render(strategy, sampleSize: 100, bucketCount: 10, seed: 0);
+
+        // Range labels appear as text elements in the SVG.
+        Assert.Contains("<text", svg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // --- Zero-sample edge cases ---
+
+    [Fact]
+    public void HtmlSampleTable_Render_ZeroCount_ReturnsTableWithNoDataRows()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = HtmlSampleTable.Render(strategy, count: 0, seed: 0);
+
+        Assert.Contains("<table", html);
+        Assert.DoesNotContain("<tr>", html);
+    }
+
+    [Fact]
+    public void HtmlPreview_Render_ZeroCount_ReturnsEmptySpan()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string html = HtmlPreview.Render(strategy, count: 0, seed: 0);
+
+        Assert.StartsWith("<span", html, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(",", html);
+    }
+
+    [Fact]
+    public void SvgHistogram_Render_ZeroSampleSize_ReturnsSvgElement()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 1000);
+
+        string svg = SvgHistogram.Render(strategy, sampleSize: 0, seed: 0);
+
+        Assert.Contains("<svg", svg);
+    }
+}

--- a/src/Conjecture.LinqPad/BucketHelpers.cs
+++ b/src/Conjecture.LinqPad/BucketHelpers.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+
+namespace Conjecture.LinqPad;
+
+internal static class BucketHelpers
+{
+    internal static int[] Compute(IReadOnlyList<double> values, int bucketCount)
+    {
+        int[] counts = new int[bucketCount];
+        if (values.Count == 0)
+        {
+            return counts;
+        }
+
+        double min = values[0];
+        double max = values[0];
+        foreach (double v in values)
+        {
+            if (v < min)
+            {
+                min = v;
+            }
+
+            if (v > max)
+            {
+                max = v;
+            }
+        }
+
+        double effectiveMax = min == max ? min + 1.0 : max;
+        double range = effectiveMax - min;
+
+        foreach (double v in values)
+        {
+            int bucket = (int)((v - min) / range * bucketCount);
+            if (bucket >= bucketCount)
+            {
+                bucket = bucketCount - 1;
+            }
+
+            counts[bucket]++;
+        }
+
+        return counts;
+    }
+}

--- a/src/Conjecture.LinqPad/Conjecture.LinqPad.csproj
+++ b/src/Conjecture.LinqPad/Conjecture.LinqPad.csproj
@@ -18,4 +18,10 @@
     <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Conjecture.LinqPad.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/Conjecture.LinqPad/HtmlPreview.cs
+++ b/src/Conjecture.LinqPad/HtmlPreview.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Text;
+
+using Conjecture.Core;
+
+namespace Conjecture.LinqPad;
+
+internal static class HtmlPreview
+{
+    private const int MaxCount = 100;
+
+    internal static string Render<T>(Strategy<T> strategy, int count = 20, int? seed = null)
+    {
+        bool capped = count > MaxCount;
+        int effective = capped ? MaxCount : count;
+        ulong? ulongSeed = SeedHelpers.ToUlong(seed);
+        IReadOnlyList<T> samples = DataGen.Sample(strategy, effective, ulongSeed);
+
+        StringBuilder sb = new();
+        sb.Append("<span>");
+        for (int i = 0; i < samples.Count; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            sb.Append(samples[i]?.ToString() ?? "");
+        }
+
+        if (capped)
+        {
+            sb.Append(", ... (truncated)");
+        }
+
+        sb.Append("</span>");
+        return sb.ToString();
+    }
+}

--- a/src/Conjecture.LinqPad/HtmlSampleTable.cs
+++ b/src/Conjecture.LinqPad/HtmlSampleTable.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Text;
+
+using Conjecture.Core;
+
+namespace Conjecture.LinqPad;
+
+internal static class HtmlSampleTable
+{
+    private const int MaxRows = 50;
+
+    internal static string Render<T>(Strategy<T> strategy, int count = 10, int? seed = null)
+    {
+        bool capped = count > MaxRows;
+        int effective = capped ? MaxRows : count;
+        ulong? ulongSeed = SeedHelpers.ToUlong(seed);
+        IReadOnlyList<T> samples = DataGen.Sample(strategy, effective, ulongSeed);
+
+        StringBuilder sb = new();
+        sb.Append("<table><thead><th>#</th><th>Value</th></thead>");
+        for (int i = 0; i < samples.Count; i++)
+        {
+            sb.Append("<tr><td>");
+            sb.Append(i + 1);
+            sb.Append("</td><td>");
+            sb.Append(samples[i]?.ToString() ?? "");
+            sb.Append("</td></tr>");
+        }
+
+        sb.Append("</table>");
+        if (capped)
+        {
+            sb.Append("<p>truncated (showing ");
+            sb.Append(MaxRows);
+            sb.Append(" of ");
+            sb.Append(count);
+            sb.Append(")</p>");
+        }
+        return sb.ToString();
+    }
+}

--- a/src/Conjecture.LinqPad/SeedHelpers.cs
+++ b/src/Conjecture.LinqPad/SeedHelpers.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.LinqPad;
+
+internal static class SeedHelpers
+{
+    internal static ulong? ToUlong(int? seed) => seed.HasValue ? (ulong)seed.Value : null;
+}

--- a/src/Conjecture.LinqPad/SvgHistogram.cs
+++ b/src/Conjecture.LinqPad/SvgHistogram.cs
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+using Conjecture.Core;
+
+namespace Conjecture.LinqPad;
+
+internal static class SvgHistogram
+{
+    private const int SvgWidth = 600;
+    private const int SvgHeight = 200;
+    private const int PaddingLeft = 10;
+    private const int PaddingRight = 10;
+    private const int PaddingTop = 10;
+    private const int PaddingBottom = 30;
+
+    internal static string Render<T>(Strategy<T> strategy, int sampleSize = 1000, int bucketCount = 20, int? seed = null)
+        where T : IConvertible
+    {
+        ulong? ulongSeed = SeedHelpers.ToUlong(seed);
+        IReadOnlyList<T> samples = DataGen.Sample(strategy, sampleSize, ulongSeed);
+
+        List<double> doubles = new(samples.Count);
+        foreach (T value in samples)
+        {
+            doubles.Add(Convert.ToDouble(value, CultureInfo.InvariantCulture));
+        }
+
+        if (doubles.Count == 0)
+        {
+            return "<svg></svg>";
+        }
+
+        double min = doubles[0];
+        double max = doubles[0];
+        foreach (double v in doubles)
+        {
+            if (v < min)
+            {
+                min = v;
+            }
+
+            if (v > max)
+            {
+                max = v;
+            }
+        }
+
+        double effectiveMax = min == max ? min + 1.0 : max;
+        double range = effectiveMax - min;
+
+        int[] counts = BucketHelpers.Compute(doubles, bucketCount);
+
+        int maxCount = 0;
+        foreach (int c in counts)
+        {
+            if (c > maxCount)
+            {
+                maxCount = c;
+            }
+        }
+
+        int chartWidth = SvgWidth - PaddingLeft - PaddingRight;
+        int chartHeight = SvgHeight - PaddingTop - PaddingBottom;
+        double barWidth = (double)chartWidth / bucketCount;
+
+        StringBuilder sb = new();
+        sb.Append("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"");
+        sb.Append(SvgWidth);
+        sb.Append("\" height=\"");
+        sb.Append(SvgHeight);
+        sb.Append("\">");
+
+        for (int i = 0; i < bucketCount; i++)
+        {
+            double barHeight = maxCount > 0 ? (double)counts[i] / maxCount * chartHeight : 0;
+            double x = PaddingLeft + i * barWidth;
+            double y = PaddingTop + (chartHeight - barHeight);
+
+            sb.Append("<rect x=\"");
+            sb.Append(x.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" y=\"");
+            sb.Append(y.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" width=\"");
+            sb.Append((barWidth - 1).ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" height=\"");
+            sb.Append(barHeight.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" fill=\"steelblue\"/>");
+
+            double bucketMin = min + i * range / bucketCount;
+            double bucketMax = min + (i + 1) * range / bucketCount;
+            double labelX = x + barWidth / 2;
+            double labelY = SvgHeight - 5;
+
+            sb.Append("<text x=\"");
+            sb.Append(labelX.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" y=\"");
+            sb.Append(labelY.ToString("F2", CultureInfo.InvariantCulture));
+            sb.Append("\" font-size=\"8\" text-anchor=\"middle\">");
+            sb.Append(bucketMin.ToString("F1", CultureInfo.InvariantCulture));
+            sb.Append("-");
+            sb.Append(bucketMax.ToString("F1", CultureInfo.InvariantCulture));
+            sb.Append("</text>");
+        }
+
+        sb.Append("</svg>");
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## Description

Adds three internal HTML/SVG renderer classes to `Conjecture.LinqPad` for visualising strategy output in LINQPad:

- **`HtmlSampleTable`** — `<table>` of sampled values, capped at 50 rows with a truncation notice
- **`HtmlPreview`** — inline `<span>` of comma-separated values, capped at 100
- **`SvgHistogram`** — SVG bar chart using the bucketing algorithm ported from `TextHistogram` in `Conjecture.Interactive`

Shared helpers extracted: `BucketHelpers` (bucket-counting) and `SeedHelpers` (`int?`→`ulong?` coercion).

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #221
Part of #204