### PR TITLE
[204.3] StrategyCustomMemberProvider: ICustomMemberProvider for Strategy<T> auto-display

### DIFF
--- a/src/Conjecture.LinqPad.Tests/Conjecture.LinqPad.Tests.csproj
+++ b/src/Conjecture.LinqPad.Tests/Conjecture.LinqPad.Tests.csproj
@@ -14,6 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="LINQPadStub\**\*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- LINQPadStub compiles to LINQPad.Runtime.dll — satisfies the runtime dep on Conjecture.LinqPad.dll -->
+    <ProjectReference Include="LINQPadStub\LINQPadStub.csproj" />
     <ProjectReference Include="..\Conjecture.LinqPad\Conjecture.LinqPad.csproj" />
   </ItemGroup>
 

--- a/src/Conjecture.LinqPad.Tests/LINQPadStub/LINQPadStub.csproj
+++ b/src/Conjecture.LinqPad.Tests/LINQPadStub/LINQPadStub.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>LINQPad.Runtime</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!-- Disable public API enforcement for this stub project -->
+    <NoWarn>RS0016</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/src/Conjecture.LinqPad.Tests/LINQPadStub/LINQPadTypes.cs
+++ b/src/Conjecture.LinqPad.Tests/LINQPadStub/LINQPadTypes.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+
+namespace LINQPad;
+
+/// <summary>Stub for tests — mirrors the real LINQPad.ICustomMemberProvider interface.</summary>
+public interface ICustomMemberProvider
+{
+    IEnumerable<string> GetNames();
+    IEnumerable<System.Type> GetTypes();
+    IEnumerable<object?> GetValues();
+}
+
+/// <summary>Stub for tests — mirrors LINQPad.Util.</summary>
+public static class Util
+{
+    public static object RawHtml(string html)
+    {
+        return new RawHtml(html);
+    }
+}
+
+/// <summary>Stub for tests — mirrors LINQPad.RawHtml.</summary>
+public sealed class RawHtml(string html)
+{
+    public override string ToString()
+    {
+        return html;
+    }
+}

--- a/src/Conjecture.LinqPad.Tests/StrategyCustomMemberProviderTests.cs
+++ b/src/Conjecture.LinqPad.Tests/StrategyCustomMemberProviderTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Conjecture.Core;
+
+namespace Conjecture.LinqPad.Tests;
+
+public class StrategyCustomMemberProviderTests
+{
+    // --- GetNames() for numeric (IConvertible) strategy ---
+
+    [Fact]
+    public void GetNames_NumericStrategy_ReturnsPreviewSampleTableHistogram()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+        StrategyCustomMemberProvider<int> provider = new(strategy);
+
+        IEnumerable<string> names = provider.GetNames();
+
+        Assert.Equal(new[] { "Preview", "Sample Table", "Histogram" }, names);
+    }
+
+    // --- GetNames() for non-IConvertible strategy ---
+
+    [Fact]
+    public void GetNames_NonConvertibleStrategy_OmitsHistogram()
+    {
+        Strategy<object> strategy = Generate.Just(new object());
+        StrategyCustomMemberProvider<object> provider = new(strategy);
+
+        IEnumerable<string> names = provider.GetNames();
+
+        Assert.Equal(new[] { "Preview", "Sample Table" }, names);
+    }
+
+    // --- GetTypes() ---
+
+    [Fact]
+    public void GetTypes_NumericStrategy_AllTypesAreObject()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+        StrategyCustomMemberProvider<int> provider = new(strategy);
+
+        IEnumerable<Type> types = provider.GetTypes();
+
+        Assert.All(types, static t => Assert.Equal(typeof(object), t));
+    }
+
+    [Fact]
+    public void GetTypes_NumericStrategy_CountMatchesNameCount()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+        StrategyCustomMemberProvider<int> provider = new(strategy);
+
+        List<string> names = provider.GetNames().ToList();
+        List<Type> types = provider.GetTypes().ToList();
+
+        Assert.Equal(names.Count, types.Count);
+    }
+
+    [Fact]
+    public void GetTypes_NonConvertibleStrategy_CountMatchesNameCount()
+    {
+        Strategy<object> strategy = Generate.Just(new object());
+        StrategyCustomMemberProvider<object> provider = new(strategy);
+
+        List<string> names = provider.GetNames().ToList();
+        List<Type> types = provider.GetTypes().ToList();
+
+        Assert.Equal(names.Count, types.Count);
+    }
+
+    // --- GetValues() non-null ---
+
+    [Fact]
+    public void GetValues_NumericStrategy_AllValuesNonNull()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+        StrategyCustomMemberProvider<int> provider = new(strategy);
+
+        IEnumerable<object?> values = provider.GetValues();
+
+        Assert.All(values, v => Assert.NotNull(v));
+    }
+
+    [Fact]
+    public void GetValues_NonConvertibleStrategy_AllValuesNonNull()
+    {
+        Strategy<object> strategy = Generate.Just(new object());
+        StrategyCustomMemberProvider<object> provider = new(strategy);
+
+        IEnumerable<object?> values = provider.GetValues();
+
+        Assert.All(values, v => Assert.NotNull(v));
+    }
+
+    // --- GetValues() count matches names ---
+
+    [Fact]
+    public void GetValues_NumericStrategy_CountMatchesNameCount()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+        StrategyCustomMemberProvider<int> provider = new(strategy);
+
+        List<string> names = provider.GetNames().ToList();
+        List<object?> values = provider.GetValues().ToList();
+
+        Assert.Equal(names.Count, values.Count);
+    }
+
+    [Fact]
+    public void GetValues_NonConvertibleStrategy_CountMatchesNameCount()
+    {
+        Strategy<object> strategy = Generate.Just(new object());
+        StrategyCustomMemberProvider<object> provider = new(strategy);
+
+        List<string> names = provider.GetNames().ToList();
+        List<object?> values = provider.GetValues().ToList();
+
+        Assert.Equal(names.Count, values.Count);
+    }
+
+    // --- GetValues() wraps non-empty rendered HTML ---
+
+    [Fact]
+    public void GetValues_NumericStrategy_EachValueWrapsNonEmptyString()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+        StrategyCustomMemberProvider<int> provider = new(strategy);
+
+        IEnumerable<object?> values = provider.GetValues();
+
+        Assert.All(values, v =>
+        {
+            string? text = v!.ToString();
+            Assert.False(string.IsNullOrEmpty(text));
+        });
+    }
+
+    [Fact]
+    public void GetValues_NonConvertibleStrategy_EachValueWrapsNonEmptyString()
+    {
+        Strategy<object> strategy = Generate.Just(new object());
+        StrategyCustomMemberProvider<object> provider = new(strategy);
+
+        IEnumerable<object?> values = provider.GetValues();
+
+        Assert.All(values, v =>
+        {
+            string? text = v!.ToString();
+            Assert.False(string.IsNullOrEmpty(text));
+        });
+    }
+
+    // --- Implements ICustomMemberProvider ---
+
+    [Fact]
+    public void StrategyCustomMemberProvider_ImplementsICustomMemberProvider()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+        StrategyCustomMemberProvider<int> provider = new(strategy);
+
+        bool implementsInterface = provider
+            .GetType()
+            .GetInterfaces()
+            .Any(static i => i.FullName == "LINQPad.ICustomMemberProvider");
+
+        Assert.True(implementsInterface);
+    }
+}

--- a/src/Conjecture.LinqPad/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.LinqPad/PublicAPI.Unshipped.txt
@@ -1,1 +1,6 @@
 #nullable enable
+Conjecture.LinqPad.StrategyCustomMemberProvider<T>
+Conjecture.LinqPad.StrategyCustomMemberProvider<T>.StrategyCustomMemberProvider(Conjecture.Core.Strategy<T>! strategy) -> void
+Conjecture.LinqPad.StrategyCustomMemberProvider<T>.GetNames() -> System.Collections.Generic.IEnumerable<string!>!
+Conjecture.LinqPad.StrategyCustomMemberProvider<T>.GetTypes() -> System.Collections.Generic.IEnumerable<System.Type!>!
+Conjecture.LinqPad.StrategyCustomMemberProvider<T>.GetValues() -> System.Collections.Generic.IEnumerable<object?>!

--- a/src/Conjecture.LinqPad/StrategyCustomMemberProvider.cs
+++ b/src/Conjecture.LinqPad/StrategyCustomMemberProvider.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Conjecture.Core;
+
+using LINQPad;
+
+namespace Conjecture.LinqPad;
+
+/// <summary>Wraps a <see cref="Strategy{T}"/> and implements <see cref="ICustomMemberProvider"/> for LINQPad display.</summary>
+/// <param name="strategy">The strategy to display.</param>
+public class StrategyCustomMemberProvider<T>(Strategy<T> strategy) : ICustomMemberProvider
+{
+    private static readonly bool IsConvertible = typeof(IConvertible).IsAssignableFrom(typeof(T));
+
+    // SvgHistogram.Render<T> has where T : IConvertible — unreachable from unconstrained T without reflection.
+    // Cached per generic instantiation so GetValues() enumeration doesn't re-fetch the MethodInfo.
+    private static readonly MethodInfo? SvgHistogramRender =
+        IsConvertible
+            ? typeof(SvgHistogram)
+                .GetMethod("Render", BindingFlags.NonPublic | BindingFlags.Static)!
+                .MakeGenericMethod(typeof(T))
+            : null;
+
+    /// <inheritdoc/>
+    public IEnumerable<string> GetNames()
+    {
+        yield return "Preview";
+        yield return "Sample Table";
+        if (IsConvertible)
+        {
+            yield return "Histogram";
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<Type> GetTypes()
+    {
+        yield return typeof(object);
+        yield return typeof(object);
+        if (IsConvertible)
+        {
+            yield return typeof(object);
+        }
+    }
+
+    /// <inheritdoc/>
+    public IEnumerable<object?> GetValues()
+    {
+        yield return WrapHtml(HtmlPreview.Render(strategy));
+        yield return WrapHtml(HtmlSampleTable.Render(strategy));
+        if (IsConvertible)
+        {
+            string histogramHtml = (string)SvgHistogramRender!.Invoke(null, new object?[] { strategy, 1000, 20, null })!;
+            yield return WrapHtml(histogramHtml);
+        }
+    }
+
+    private static object WrapHtml(string html)
+    {
+        try
+        {
+            return Util.RawHtml(html);
+        }
+        catch (FileLoadException)
+        {
+            return new HtmlString(html);
+        }
+    }
+
+    private sealed class HtmlString(string html)
+    {
+        public override string ToString()
+        {
+            return html;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Implements `StrategyCustomMemberProvider<T>` — a `LINQPad.ICustomMemberProvider` wrapper for `Strategy<T>` that makes `.Dump()` in LINQPad automatically render Preview, Sample Table, and (for `IConvertible` types) Histogram panels without any explicit method calls.

Also adds a `LINQPadStub` sub-project that compiles to `LINQPad.Runtime.dll`, providing source-compiled runtime stubs for `ICustomMemberProvider`, `Util.RawHtml`, and `RawHtml` — replacing a gitignored binary with versioned source.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #222
Part of #204