### PR TITLE
[204.4] ShrinkTraceLinqPad: HTML shrink trace renderer and extension method

### DIFF
--- a/src/Conjecture.LinqPad.Tests/ShrinkTraceLinqPadTests.cs
+++ b/src/Conjecture.LinqPad.Tests/ShrinkTraceLinqPadTests.cs
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using Conjecture.Core;
+
+using LINQPad;
+
+namespace Conjecture.LinqPad.Tests;
+
+public class ShrinkTraceLinqPadTests
+{
+    // --- HtmlShrinkTrace.Render ---
+
+    [Fact]
+    public void HtmlShrinkTrace_Render_OutputContainsTableElement()
+    {
+        List<int> steps = [10, 5, 3];
+
+        string html = HtmlShrinkTrace.Render<int>(steps);
+
+        Assert.Contains("<table", html);
+    }
+
+    [Fact]
+    public void HtmlShrinkTrace_Render_OutputContainsStepColumnHeader()
+    {
+        List<int> steps = [10, 5, 3];
+
+        string html = HtmlShrinkTrace.Render<int>(steps);
+
+        Assert.Contains("Step", html);
+    }
+
+    [Fact]
+    public void HtmlShrinkTrace_Render_OutputContainsValueColumnHeader()
+    {
+        List<int> steps = [10, 5, 3];
+
+        string html = HtmlShrinkTrace.Render<int>(steps);
+
+        Assert.Contains("Value", html);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    [InlineData(5)]
+    public void HtmlShrinkTrace_Render_ContainsExactlyStepCountRows(int count)
+    {
+        List<int> steps = [];
+        for (int i = 0; i < count; i++)
+        {
+            steps.Add(i);
+        }
+
+        string html = HtmlShrinkTrace.Render<int>(steps);
+
+        int trCount = Regex.Matches(html, "<tr", RegexOptions.IgnoreCase).Count;
+        Assert.Equal(count, trCount);
+    }
+
+    [Fact]
+    public void HtmlShrinkTrace_Render_EmptyList_OutputContainsTableWithNoRows()
+    {
+        List<int> steps = [];
+
+        string html = HtmlShrinkTrace.Render<int>(steps);
+
+        Assert.Contains("<table", html);
+        Assert.DoesNotContain("<tr>", html, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void HtmlShrinkTrace_Render_SingleStep_ContainsStepValue()
+    {
+        List<int> steps = [42];
+
+        string html = HtmlShrinkTrace.Render<int>(steps);
+
+        Assert.Contains("42", html);
+    }
+
+    // --- StrategyLinqPadExtensions.ShrinkTraceHtml ---
+
+    [Fact]
+    public void ShrinkTraceHtml_ReturnsNonNull()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+
+        object result = strategy.ShrinkTraceHtml(seed: 0, static x => x > 0);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public void ShrinkTraceHtml_ToStringContainsTableElement()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+
+        object result = strategy.ShrinkTraceHtml(seed: 0, static x => x > 0);
+
+        Assert.Contains("<table", result.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ShrinkTraceHtml_ToStringContainsAtLeastOneTrElement()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+
+        object result = strategy.ShrinkTraceHtml(seed: 0, static x => x > 0);
+
+        Assert.Contains("<tr", result.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ShrinkTraceHtml_SameSeedTwice_ProducesIdenticalOutput()
+    {
+        Strategy<int> strategy = Generate.Integers<int>(1, 100);
+
+        object first = strategy.ShrinkTraceHtml(seed: 1, static x => x > 0);
+        object second = strategy.ShrinkTraceHtml(seed: 1, static x => x > 0);
+
+        Assert.Equal(first.ToString(), second.ToString());
+    }
+}

--- a/src/Conjecture.LinqPad/Conjecture.LinqPad.csproj
+++ b/src/Conjecture.LinqPad/Conjecture.LinqPad.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+    <ProjectReference Include="..\Conjecture.Interactive\Conjecture.Interactive.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.LinqPad/HtmlShrinkTrace.cs
+++ b/src/Conjecture.LinqPad/HtmlShrinkTrace.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Text;
+
+namespace Conjecture.LinqPad;
+
+internal static class HtmlShrinkTrace
+{
+    internal static string Render<T>(IReadOnlyList<T> steps)
+    {
+        StringBuilder sb = new();
+        sb.Append("<table><thead><th>Step</th><th>Value</th></thead>");
+        for (int i = 0; i < steps.Count; i++)
+        {
+            sb.Append("<tr><td>");
+            sb.Append(i);
+            sb.Append("</td><td>");
+            sb.Append(steps[i]?.ToString() ?? "");
+            sb.Append("</td></tr>");
+        }
+
+        sb.Append("</table>");
+        return sb.ToString();
+    }
+}

--- a/src/Conjecture.LinqPad/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.LinqPad/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ Conjecture.LinqPad.StrategyCustomMemberProvider<T>.StrategyCustomMemberProvider(
 Conjecture.LinqPad.StrategyCustomMemberProvider<T>.GetNames() -> System.Collections.Generic.IEnumerable<string!>!
 Conjecture.LinqPad.StrategyCustomMemberProvider<T>.GetTypes() -> System.Collections.Generic.IEnumerable<System.Type!>!
 Conjecture.LinqPad.StrategyCustomMemberProvider<T>.GetValues() -> System.Collections.Generic.IEnumerable<object?>!
+Conjecture.LinqPad.StrategyLinqPadExtensions
+static Conjecture.LinqPad.StrategyLinqPadExtensions.ShrinkTraceHtml<T>(this Conjecture.Core.Strategy<T>! strategy, int seed, System.Func<T, bool>! failingProperty) -> object!

--- a/src/Conjecture.LinqPad/SeedHelpers.cs
+++ b/src/Conjecture.LinqPad/SeedHelpers.cs
@@ -5,5 +5,7 @@ namespace Conjecture.LinqPad;
 
 internal static class SeedHelpers
 {
+    internal static ulong ToUlong(int seed) => (ulong)seed;
+
     internal static ulong? ToUlong(int? seed) => seed.HasValue ? (ulong)seed.Value : null;
 }

--- a/src/Conjecture.LinqPad/StrategyLinqPadExtensions.cs
+++ b/src/Conjecture.LinqPad/StrategyLinqPadExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+
+using Conjecture.Core;
+using Conjecture.Interactive;
+
+using LINQPad;
+
+namespace Conjecture.LinqPad;
+
+/// <summary>LINQPad extension methods for shrink trace visualisation.</summary>
+public static class StrategyLinqPadExtensions
+{
+    /// <summary>Runs a shrink trace and returns an HTML table as a LINQPad raw-HTML object.</summary>
+    public static object ShrinkTraceHtml<T>(
+        this Strategy<T> strategy, int seed, Func<T, bool> failingProperty)
+    {
+        ShrinkTraceResult<T> result = StrategyExtensionsInteractive.ShrinkTrace(strategy, SeedHelpers.ToUlong(seed), failingProperty);
+        List<T> values = new(result.Steps.Count);
+        foreach (ShrinkStep<T> step in result.Steps)
+        {
+            values.Add(step.Value);
+        }
+
+        string html = HtmlShrinkTrace.Render(values);
+        return Util.RawHtml(html);
+    }
+}


### PR DESCRIPTION
## Description

Adds `StrategyLinqPadExtensions.ShrinkTraceHtml` — a LINQPad extension method that runs a shrink trace for a strategy and returns an HTML table (`Util.RawHtml`) for direct `.Dump()` use.

- `HtmlShrinkTrace.Render<T>` builds a `<table>` with Step / Value columns from a list of shrink step values
- `ShrinkTraceHtml` delegates to `Conjecture.Interactive.StrategyExtensionsInteractive.ShrinkTrace` to avoid duplicating shrink logic, maps `ShrinkStep<T>` → `T`, and wraps the result in `Util.RawHtml`
- `SeedHelpers` gains a non-nullable `ToUlong(int)` overload, consistent with the rest of the package
- `Conjecture.Interactive` added as a project reference

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #223
Part of #204