### PR TITLE
[71.1] PartialConstructorContext: AsyncLocal IGeneratorContext holder

### DIFF
--- a/src/Conjecture.Core.Tests/PartialConstructorContextTests.cs
+++ b/src/Conjecture.Core.Tests/PartialConstructorContextTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+namespace Conjecture.Core.Tests;
+
+public class PartialConstructorContextTests
+{
+    [Fact]
+    public void Current_WithNoScopeActive_ThrowsInvalidOperationException()
+    {
+        Assert.Throws<InvalidOperationException>(static () => _ = PartialConstructorContext.Current);
+    }
+
+    [Fact]
+    public void Current_InsideUseScope_ReturnsProvidedContext()
+    {
+        IGeneratorContext ctx = new StubGeneratorContext();
+
+        using IDisposable scope = PartialConstructorContext.Use(ctx);
+
+        Assert.Equal(ctx, PartialConstructorContext.Current);
+    }
+
+    [Fact]
+    public void Current_AfterUseScopeDisposed_ThrowsInvalidOperationException()
+    {
+        IGeneratorContext ctx = new StubGeneratorContext();
+        IDisposable scope = PartialConstructorContext.Use(ctx);
+
+        scope.Dispose();
+
+        Assert.Throws<InvalidOperationException>(static () => _ = PartialConstructorContext.Current);
+    }
+
+    [Fact]
+    public void Current_InnerNestedScope_SeesInnerContext()
+    {
+        IGeneratorContext outer = new StubGeneratorContext();
+        IGeneratorContext inner = new StubGeneratorContext();
+
+        using IDisposable outerScope = PartialConstructorContext.Use(outer);
+        using IDisposable innerScope = PartialConstructorContext.Use(inner);
+
+        Assert.Equal(inner, PartialConstructorContext.Current);
+    }
+
+    [Fact]
+    public void Current_AfterInnerScopeDisposed_RestoredToOuterContext()
+    {
+        IGeneratorContext outer = new StubGeneratorContext();
+        IGeneratorContext inner = new StubGeneratorContext();
+
+        using IDisposable outerScope = PartialConstructorContext.Use(outer);
+        IDisposable innerScope = PartialConstructorContext.Use(inner);
+
+        innerScope.Dispose();
+
+        Assert.Equal(outer, PartialConstructorContext.Current);
+    }
+
+    [Fact]
+    public async Task Current_TaskRunStartedOutsideScope_DoesNotSeeAmbientContext()
+    {
+        // Task is started BEFORE the scope is opened — it must not see the context
+        // set later by the parent. This verifies sibling-task isolation: AsyncLocal
+        // values do not flow backwards to tasks already in flight.
+        Task<bool> taskStartedBeforeScope = Task.Run(static async () =>
+        {
+            await Task.Yield();
+            try
+            {
+                _ = PartialConstructorContext.Current;
+                return false; // should not reach here
+            }
+            catch (InvalidOperationException)
+            {
+                return true;
+            }
+        });
+
+        IGeneratorContext ctx = new StubGeneratorContext();
+        using IDisposable scope = PartialConstructorContext.Use(ctx);
+
+        bool threwOutsideScope = await taskStartedBeforeScope;
+        Assert.True(threwOutsideScope);
+    }
+
+    [Fact]
+    public async Task Current_TaskRunStartedInsideScope_SeesAmbientContext()
+    {
+        // With AsyncLocal, child tasks inherit the parent's value. A Task.Run
+        // launched *inside* the scope should therefore see the same context.
+        // This test distinguishes AsyncLocal from [ThreadStatic] behaviour.
+        IGeneratorContext ctx = new StubGeneratorContext();
+
+        using IDisposable scope = PartialConstructorContext.Use(ctx);
+
+        IGeneratorContext contextSeenInsideTask = await Task.Run(() =>
+            // Capture inside the task — no static capture so lambda is not static.
+            PartialConstructorContext.Current);
+
+        Assert.Equal(ctx, contextSeenInsideTask);
+    }
+
+    private sealed class StubGeneratorContext : IGeneratorContext
+    {
+        public T Generate<T>(Strategy<T> strategy) => throw new NotSupportedException();
+        public void Assume(bool condition) { }
+        public void Target(double observation, string label = "default") { }
+    }
+}

--- a/src/Conjecture.Core/PartialConstructorContext.cs
+++ b/src/Conjecture.Core/PartialConstructorContext.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core;
+
+/// <summary>Ambient context that flows an <see cref="IGeneratorContext"/> to partial constructors via <see cref="AsyncLocal{T}"/>.</summary>
+public static class PartialConstructorContext
+{
+    private static readonly AsyncLocal<IGeneratorContext?> Current_ = new();
+
+    /// <summary>Gets the ambient <see cref="IGeneratorContext"/> for the current async context.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when no scope is active.</exception>
+    public static IGeneratorContext Current =>
+        Current_.Value
+            ?? throw new InvalidOperationException(
+                "No IGeneratorContext is active. Partial constructors may only be called inside a Conjecture test.");
+
+    /// <summary>Sets <paramref name="ctx"/> as the ambient context for the duration of the returned scope.</summary>
+    public static IDisposable Use(IGeneratorContext ctx)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+        IGeneratorContext? previous = Current_.Value;
+        Current_.Value = ctx;
+        return new Scope(previous);
+    }
+
+    private sealed class Scope(IGeneratorContext? previous) : IDisposable
+    {
+        public void Dispose()
+        {
+            Current_.Value = previous;
+        }
+    }
+}

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Conjecture.Core.PartialConstructorContext
+static Conjecture.Core.PartialConstructorContext.Current.get -> Conjecture.Core.IGeneratorContext!
+static Conjecture.Core.PartialConstructorContext.Use(Conjecture.Core.IGeneratorContext! ctx) -> System.IDisposable!


### PR DESCRIPTION
## Description

Adds `PartialConstructorContext` — a public static class backed by `AsyncLocal<IGeneratorContext?>` that gives generator-emitted partial constructors access to the ambient `IGeneratorContext` during a Conjecture test run.

- `Use(ctx)` opens a scope via save/restore; nested scopes work correctly and restore on dispose
- `Current` throws `InvalidOperationException` when no scope is active
- Child `Task.Run` calls started inside the scope inherit the context (AsyncLocal parent→child flow); sibling tasks started before the scope do not

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #230
Part of #71