### PR TITLE
[71.2] TypeModelExtractor: detect partial constructor declarations + CON203/CON204

### DIFF
--- a/src/Conjecture.Generators.Tests/PartialConstructorExtractionTests.cs
+++ b/src/Conjecture.Generators.Tests/PartialConstructorExtractionTests.cs
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+using Conjecture.Generators;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Conjecture.Generators.Tests;
+
+public sealed class PartialConstructorExtractionTests
+{
+    // --- single partial constructor: happy path ---
+
+    [Fact]
+    public void Extract_SinglePartialConstructor_ReturnsPartialConstructorMode()
+    {
+        INamedTypeSymbol symbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public partial class Widget
+            {
+                public string Name { get; init; } = "";
+                public int Value { get; init; }
+                public partial Widget(string name, int value);
+            }
+            """,
+            "MyApp.Widget");
+
+        (TypeModel? model, ImmutableArray<Diagnostic> diagnostics) = TypeModelExtractor.Extract(symbol);
+
+        Assert.Empty(diagnostics.Where(static d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(model);
+        Assert.Equal(ConstructionMode.PartialConstructor, model.ConstructionMode);
+    }
+
+    [Fact]
+    public void Extract_SinglePartialConstructor_ExtractsMembersFromInitProperties()
+    {
+        INamedTypeSymbol symbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public partial class Widget
+            {
+                public string Name { get; init; } = "";
+                public int Value { get; init; }
+                public partial Widget(string name, int value);
+            }
+            """,
+            "MyApp.Widget");
+
+        (TypeModel? model, _) = TypeModelExtractor.Extract(symbol);
+
+        Assert.NotNull(model);
+        Assert.Equal(2, model.Members.Length);
+        Assert.Contains(model.Members, static m => m.Name == "Name" && m.TypeFullName == "System.String");
+        Assert.Contains(model.Members, static m => m.Name == "Value" && m.TypeFullName == "System.Int32");
+    }
+
+    // --- no partial constructor: existing behaviour unaffected ---
+
+    [Fact]
+    public void Extract_NoPartialConstructor_DoesNotSetPartialConstructorMode()
+    {
+        INamedTypeSymbol symbol = CompileAndGetSymbol(
+            "namespace MyApp; public partial class Plain { public Plain(int x) { } }",
+            "MyApp.Plain");
+
+        (TypeModel? model, _) = TypeModelExtractor.Extract(symbol);
+
+        Assert.NotNull(model);
+        Assert.NotEqual(ConstructionMode.PartialConstructor, model.ConstructionMode);
+    }
+
+    // --- two partial constructors: CON203 ---
+
+    [Fact]
+    public void Extract_TwoPartialConstructors_ReturnsCon203Diagnostic()
+    {
+        INamedTypeSymbol symbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public partial class Ambiguous
+            {
+                public int X { get; init; }
+                public int Y { get; init; }
+                public partial Ambiguous(int x);
+                public partial Ambiguous(int x, int y);
+            }
+            """,
+            "MyApp.Ambiguous");
+
+        (TypeModel? model, ImmutableArray<Diagnostic> diagnostics) = TypeModelExtractor.Extract(symbol);
+
+        Assert.Null(model);
+        Assert.Contains(diagnostics, static d => d.Id == DiagnosticDescriptors.Con203.Id);
+    }
+
+    [Fact]
+    public void Extract_TwoPartialConstructors_Con203IsError()
+    {
+        INamedTypeSymbol symbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public partial class Ambiguous
+            {
+                public int X { get; init; }
+                public int Y { get; init; }
+                public partial Ambiguous(int x);
+                public partial Ambiguous(int x, int y);
+            }
+            """,
+            "MyApp.Ambiguous");
+
+        (_, ImmutableArray<Diagnostic> diagnostics) = TypeModelExtractor.Extract(symbol);
+        Diagnostic? diag = diagnostics.FirstOrDefault(static d => d.Id == DiagnosticDescriptors.Con203.Id);
+
+        Assert.NotNull(diag);
+        Assert.Equal(DiagnosticSeverity.Error, diag.Severity);
+    }
+
+    // --- primary constructor + partial constructor: CON204 ---
+
+    [Fact]
+    public void Extract_PrimaryAndPartialConstructor_ReturnsCon204Diagnostic()
+    {
+        INamedTypeSymbol symbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public partial class Conflict(int x)
+            {
+                public int X { get; init; }
+                public partial Conflict(int x, int y);
+            }
+            """,
+            "MyApp.Conflict");
+
+        (TypeModel? model, ImmutableArray<Diagnostic> diagnostics) = TypeModelExtractor.Extract(symbol);
+
+        Assert.Null(model);
+        Assert.Contains(diagnostics, static d => d.Id == DiagnosticDescriptors.Con204.Id);
+    }
+
+    [Fact]
+    public void Extract_PrimaryAndPartialConstructor_Con204IsError()
+    {
+        INamedTypeSymbol symbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public partial class Conflict(int x)
+            {
+                public int X { get; init; }
+                public partial Conflict(int x, int y);
+            }
+            """,
+            "MyApp.Conflict");
+
+        (_, ImmutableArray<Diagnostic> diagnostics) = TypeModelExtractor.Extract(symbol);
+        Diagnostic? diag = diagnostics.FirstOrDefault(static d => d.Id == DiagnosticDescriptors.Con204.Id);
+
+        Assert.NotNull(diag);
+        Assert.Equal(DiagnosticSeverity.Error, diag.Severity);
+    }
+
+    // --- partial constructor on non-[Arbitrary] type via generator: no Conjecture diagnostic ---
+
+    [Fact]
+    public void Generator_PartialConstructorOnNonArbitraryType_EmitsNoConjectureDiagnostic()
+    {
+        string source = """
+            namespace MyApp;
+            public partial class NotArbitrary
+            {
+                public int X { get; init; }
+                public partial NotArbitrary(int x);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = RunGeneratorDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, static d =>
+            d.Id.StartsWith("CON", System.StringComparison.Ordinal));
+    }
+
+    // --- full generator round-trip: CON203 and CON204 ---
+
+    [Fact]
+    public void Generator_TwoPartialConstructors_EmitsCon203()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial class Ambiguous
+            {
+                public int X { get; init; }
+                public partial Ambiguous(int x);
+                public partial Ambiguous(int x, int y);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = RunGeneratorDiagnostics(source);
+
+        Assert.Contains(diagnostics, static d => d.Id == DiagnosticDescriptors.Con203.Id);
+    }
+
+    [Fact]
+    public void Generator_PrimaryAndPartialConstructor_EmitsCon204()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial class Conflict(int x)
+            {
+                public int X { get; init; }
+                public partial Conflict(int x, int y);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = RunGeneratorDiagnostics(source);
+
+        Assert.Contains(diagnostics, static d => d.Id == DiagnosticDescriptors.Con204.Id);
+    }
+
+    // --- helpers ---
+
+    private static INamedTypeSymbol CompileAndGetSymbol(string source, string metadataName)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+            ],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        INamedTypeSymbol? symbol = compilation.GetTypeByMetadataName(metadataName);
+        Assert.NotNull(symbol);
+        return symbol;
+    }
+
+    private static ImmutableArray<Diagnostic> RunGeneratorDiagnostics(string source)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        CSharpCompilation inputCompilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
+                MetadataReference.CreateFromFile(typeof(Conjecture.Core.ArbitraryAttribute).Assembly.Location),
+            ],
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new ArbitraryGenerator());
+        GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
+        return result.Diagnostics;
+    }
+}

--- a/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
@@ -2,3 +2,5 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+CON203 | Conjecture | Error | Multiple partial constructors declared on [Arbitrary] type
+CON204 | Conjecture | Error | Primary constructor combined with partial constructor on [Arbitrary] type

--- a/src/Conjecture.Generators/DiagnosticDescriptors.cs
+++ b/src/Conjecture.Generators/DiagnosticDescriptors.cs
@@ -30,4 +30,20 @@ internal static class DiagnosticDescriptors
         category: "Conjecture",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor Con203 = new(
+        id: "CON203",
+        title: "Multiple partial constructors",
+        messageFormat: "[Arbitrary] type declares more than one partial constructor",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor Con204 = new(
+        id: "CON204",
+        title: "Primary constructor combined with partial constructor",
+        messageFormat: "[Arbitrary] type combines a primary constructor with a partial constructor declaration; use the standard path without a partial constructor",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/Conjecture.Generators/TypeModel.cs
+++ b/src/Conjecture.Generators/TypeModel.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Conjecture.Generators;
 
-internal enum ConstructionMode { Constructor, ObjectInitializer }
+internal enum ConstructionMode { Constructor, ObjectInitializer, PartialConstructor }
 
 internal enum MemberGenerationKind { Primitive, Enum, NullableValue, List, ArbitraryReference, ExternalStrategyProvider, Unsupported }
 

--- a/src/Conjecture.Generators/TypeModelExtractor.cs
+++ b/src/Conjecture.Generators/TypeModelExtractor.cs
@@ -29,6 +29,18 @@ internal static class TypeModelExtractor
             return (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con201, location, symbol.Name)));
         }
 
+        List<ConstructorDeclarationSyntax> partialCtors = FindPartialConstructors(symbol);
+
+        if (partialCtors.Count > 1)
+        {
+            return (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con203, location)));
+        }
+
+        if (partialCtors.Count == 1 && HasPrimaryConstructor(symbol))
+        {
+            return (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con204, location)));
+        }
+
         IMethodSymbol? bestCtor = FindBestConstructor(symbol);
 
         string ns = symbol.ContainingNamespace.IsGlobalNamespace
@@ -41,7 +53,12 @@ internal static class TypeModelExtractor
         ImmutableArray<MemberModel> members;
         ConstructionMode mode;
 
-        if (bestCtor is not null)
+        if (partialCtors.Count == 1)
+        {
+            members = BuildInitPropertyMembers(symbol, warnings, providerRegistry);
+            mode = ConstructionMode.PartialConstructor;
+        }
+        else if (bestCtor is not null)
         {
             members = BuildMembers(bestCtor, warnings, providerRegistry);
             mode = ConstructionMode.Constructor;
@@ -69,19 +86,63 @@ internal static class TypeModelExtractor
         return (model, warnings.ToImmutableArray());
     }
 
+    private static bool HasModifier(SyntaxTokenList modifiers, SyntaxKind kind)
+    {
+        foreach (SyntaxToken modifier in modifiers)
+        {
+            if (modifier.IsKind(kind))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static bool IsPartial(INamedTypeSymbol symbol)
     {
         foreach (SyntaxReference syntaxRef in symbol.DeclaringSyntaxReferences)
         {
             if (syntaxRef.GetSyntax() is TypeDeclarationSyntax typeDecl)
             {
-                foreach (SyntaxToken modifier in typeDecl.Modifiers)
+                if (HasModifier(typeDecl.Modifiers, SyntaxKind.PartialKeyword))
                 {
-                    if (modifier.IsKind(SyntaxKind.PartialKeyword))
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static List<ConstructorDeclarationSyntax> FindPartialConstructors(INamedTypeSymbol symbol)
+    {
+        List<ConstructorDeclarationSyntax> result = [];
+        foreach (SyntaxReference syntaxRef in symbol.DeclaringSyntaxReferences)
+        {
+            if (syntaxRef.GetSyntax() is TypeDeclarationSyntax typeDecl)
+            {
+                foreach (MemberDeclarationSyntax member in typeDecl.Members)
+                {
+                    if (member is ConstructorDeclarationSyntax ctorDecl
+                        && HasModifier(ctorDecl.Modifiers, SyntaxKind.PartialKeyword))
                     {
-                        return true;
+                        result.Add(ctorDecl);
                     }
                 }
+            }
+        }
+
+        return result;
+    }
+
+    private static bool HasPrimaryConstructor(INamedTypeSymbol symbol)
+    {
+        foreach (SyntaxReference syntaxRef in symbol.DeclaringSyntaxReferences)
+        {
+            if (syntaxRef.GetSyntax() is TypeDeclarationSyntax { ParameterList: not null })
+            {
+                return true;
             }
         }
 


### PR DESCRIPTION
## Description

Adds detection of partial constructor declarations in `TypeModelExtractor`. When a type marked `[Arbitrary]` declares a single partial constructor, the extractor sets `ConstructionMode.PartialConstructor` and extracts members from `init` properties. Two new diagnostics guard invalid configurations:

- **CON203** (Error): more than one partial constructor declared
- **CON204** (Error): primary constructor combined with a partial constructor declaration

Also extracts a `HasModifier` helper to eliminate duplicated modifier-scanning logic.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #231
Part of #71