### PR TITLE
[69.0] ADR: OTel observability design

### DIFF
--- a/docs/decisions/0037-observability.md
+++ b/docs/decisions/0037-observability.md
@@ -45,5 +45,5 @@ The Conjecture framework has zero observability. Users cannot see assumption rej
 
 - **DI-based ILoggerFactory**: Rejected — Core has no DI container; adds unnecessary complexity
 - **EventSource**: Rejected — `ILogger` is the modern standard for .NET libraries; EventSource is lower-level infrastructure
-- **ActivitySource/Meter**: Deferred — designed for distributed tracing and metrics in services; not appropriate for single-process test runs
+- **ActivitySource/Meter**: Deferred at the time of this ADR — later accepted in ADR-0050 for distributed tracing and aggregate metrics; `ILogger` remains the human-readable diagnostics layer
 - **Per-draw/per-shrink instrumentation**: Rejected — these are tight inner loops; instrumentation would meaningfully degrade performance

--- a/docs/decisions/0050-otel-observability-design.md
+++ b/docs/decisions/0050-otel-observability-design.md
@@ -1,0 +1,78 @@
+# 0050. OTel Observability: ActivitySource and Meter for Distributed Tracing and Metrics
+
+**Date:** 2026-04-16
+**Status:** Accepted
+
+## Context
+
+ADR-0037 established `ILogger`/`[LoggerMessage]` as Conjecture's structured-logging layer and explicitly deferred `ActivitySource`/`Meter` as "designed for distributed tracing and metrics in services; not appropriate for single-process test runs."
+
+Since then, two developments changed the calculus:
+
+1. **Aspire adoption** — teams running Conjecture inside Aspire-orchestrated solutions want Conjecture test spans to appear alongside their service traces in the Aspire dashboard, without any bespoke adapter code.
+2. **Aggregate metrics demand** — users want Prometheus/OTel-Collector–exportable metrics (e.g. shrink counts, assumption rejection rates) without parsing log output.
+
+`ILogger` is the right vehicle for human-readable, per-run diagnostics. `ActivitySource`/`Meter` is the right vehicle for machine-consumable, cross-process observability. Both are needed; they are complementary, not alternatives.
+
+## Decision
+
+**Static singletons on `ConjectureObservability`**
+
+Expose a single internal (later public) class `ConjectureObservability` in `Conjecture.Core` that owns:
+
+- `static readonly ActivitySource ActivitySource` — name `"Conjecture"`, version from assembly
+- `static readonly Meter Meter` — name `"Conjecture"`, version from assembly
+
+Both are always instantiated; the OTel SDK's listener model means zero overhead is incurred when no `ActivityListener` or `MeterListener` is registered.
+
+**Phase-level spans only**
+
+A root `Activity` (`conjecture.test`) is started for each test run. Three child activities are started and stopped around each phase:
+
+| Activity name | Phase |
+|---|---|
+| `conjecture.generation` | Generation loop |
+| `conjecture.shrinking` | Shrink loop |
+| `conjecture.targeting` | Targeting / hill-climbing |
+
+No per-example or per-draw spans are emitted — these are tight inner loops where span overhead would meaningfully degrade performance (consistent with ADR-0037's "Hot Path Protection" principle).
+
+**Standard test attributes on the root span**
+
+| Attribute key | Source |
+|---|---|
+| `test.name` | Test method name |
+| `test.class.name` | Test class name |
+| `test.framework` | e.g. `"xunit"`, `"nunit"`, `"mstest"` |
+| `conjecture.seed` | Reproducibility seed |
+| `conjecture.max_examples` | Setting value |
+
+**Metric naming and schema**
+
+All metrics use the `conjecture.*` prefix. The canonical list, types, units, and attribute keys are documented in a versioned JSON schema at `docs/telemetry-schema.json`. The schema URL is embedded as a tag on the `Meter` (`conjecture.schema.url`).
+
+Database metrics are in scope:
+
+| Metric | Type | Unit |
+|---|---|---|
+| `conjecture.database.replays_total` | Counter | `{replays}` |
+| `conjecture.database.saves_total` | Counter | `{saves}` |
+
+**No built-in exporter; no library-side sampling**
+
+Conjecture ships no OTLP exporter and configures no sampler. Export and sampling are the host application's responsibility. Aspire wiring is deferred to a separate issue.
+
+## Consequences
+
+- `System.Diagnostics.DiagnosticSource` (already in the BCL for .NET 8+) is the only new dependency — no NuGet package required for `ActivitySource`/`Meter`.
+- `ConjectureObservability` is `internal` initially; it will be made `public` once the API is stable.
+- `TestRunner` gains three `Activity`-bracketed sections per run; the added overhead is a handful of dictionary lookups gated on `ActivitySource.HasListeners()`.
+- `ExampleDatabase` gains two counter increments per replay/save path.
+- `docs/telemetry-schema.json` becomes the authoritative reference for third-party tooling integrations.
+
+## Alternatives Considered
+
+- **Per-example spans**: Rejected — inner loops run thousands of iterations; span creation cost would be significant and the data volume would overwhelm any collector.
+- **EventSource / ETW**: Rejected — ETW is Windows-only; `ActivitySource` is the modern cross-platform standard and integrates directly with OTel.
+- **Third-party OTel NuGet in Core**: Rejected — `System.Diagnostics.DiagnosticSource` is BCL-level; pulling `OpenTelemetry` into Core would impose a heavy transitive dependency on every Conjecture user.
+- **Opt-in ActivitySource (created on demand)**: Rejected — always-on singletons are idiomatic for .NET libraries; the listener model already provides zero-overhead no-op behaviour when no listener is attached.


### PR DESCRIPTION
## Description

Records ADR-0050 documenting the OTel observability design for Conjecture.Core:

- `ActivitySource` and `Meter` as always-on static singletons on `ConjectureObservability`; zero overhead when no listener registered
- Phase-level spans only (`conjecture.test` root + `conjecture.generation` / `conjecture.shrinking` / `conjecture.targeting` children) — no per-example spans
- Standard test attributes on the root span: `test.name`, `test.class.name`, `test.framework`, `conjecture.seed`, `conjecture.max_examples`
- `conjecture.*` metric prefix; database metrics (`conjecture.database.replays_total`, `conjecture.database.saves_total`) in scope
- No built-in exporter; no library-side sampling; Aspire wiring deferred to a separate issue
- Telemetry schema versioned in `docs/telemetry-schema.json`

Also updates ADR-0037 to note that the `ActivitySource`/`Meter` deferral was later accepted.

## Type of change

- [x] Documentation / chore

## Checklist

- [ ] `dotnet test src/` passes
- [ ] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #225
Part of #69