### PR TITLE
[69.1] ConjectureObservability: define static ActivitySource and Meter

### DIFF
--- a/docs/telemetry-schema.json
+++ b/docs/telemetry-schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Conjecture Telemetry Schema",
+  "description": "Canonical metric names, descriptions, units, and attribute keys for Conjecture OTel instrumentation.",
+  "source": "Conjecture.Core",
+  "metrics": [
+    {
+      "name": "conjecture.database.replays_total",
+      "type": "Counter",
+      "unit": "{replays}",
+      "description": "Number of test-case replays read from the example database.",
+      "attributes": [
+        { "key": "test.name", "description": "Test method name." },
+        { "key": "test.class.name", "description": "Test class name." }
+      ]
+    },
+    {
+      "name": "conjecture.database.saves_total",
+      "type": "Counter",
+      "unit": "{saves}",
+      "description": "Number of test cases saved to the example database.",
+      "attributes": [
+        { "key": "test.name", "description": "Test method name." },
+        { "key": "test.class.name", "description": "Test class name." }
+      ]
+    }
+  ],
+  "traces": {
+    "activitySource": "Conjecture.Core",
+    "activities": [
+      {
+        "name": "conjecture.test",
+        "description": "Root span for a single property-based test run.",
+        "attributes": [
+          { "key": "test.name", "description": "Test method name." },
+          { "key": "test.class.name", "description": "Test class name." },
+          { "key": "test.framework", "description": "Test framework (e.g. xunit, nunit, mstest)." },
+          { "key": "conjecture.seed", "description": "Reproducibility seed." },
+          { "key": "conjecture.max_examples", "description": "Configured max_examples setting." }
+        ]
+      },
+      {
+        "name": "conjecture.generation",
+        "description": "Span wrapping the generation loop phase."
+      },
+      {
+        "name": "conjecture.shrinking",
+        "description": "Span wrapping the shrink loop phase."
+      },
+      {
+        "name": "conjecture.targeting",
+        "description": "Span wrapping the targeting / hill-climbing phase."
+      }
+    ]
+  }
+}

--- a/src/Conjecture.Core.Tests/ConjectureObservabilityTests.cs
+++ b/src/Conjecture.Core.Tests/ConjectureObservabilityTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+using Conjecture.Core;
+
+namespace Conjecture.Core.Tests;
+
+public sealed class ConjectureObservabilityTests
+{
+    [Fact]
+    public void ActivitySource_Name_EqualsConjectureCore()
+    {
+        Assert.Equal("Conjecture.Core", ConjectureObservability.ActivitySource.Name);
+    }
+
+    [Fact]
+    public void Meter_Name_EqualsConjectureCore()
+    {
+        Assert.Equal("Conjecture.Core", ConjectureObservability.Meter.Name);
+    }
+
+    [Fact]
+    public void ActivitySource_Version_IsNotNullOrEmpty()
+    {
+        Assert.False(string.IsNullOrEmpty(ConjectureObservability.ActivitySource.Version));
+    }
+
+    [Fact]
+    public void Meter_Version_IsNotNullOrEmpty()
+    {
+        Assert.False(string.IsNullOrEmpty(ConjectureObservability.Meter.Version));
+    }
+
+    [Fact]
+    public void ActivitySource_HasListeners_DoesNotThrow()
+    {
+        // Verifies ActivitySource has not been disposed
+        bool result = ConjectureObservability.ActivitySource.HasListeners();
+        Assert.False(result); // no listeners registered in unit tests
+    }
+}

--- a/src/Conjecture.Core/ConjectureObservability.cs
+++ b/src/Conjecture.Core/ConjectureObservability.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+
+namespace Conjecture.Core;
+
+/// <summary>Static singletons for Conjecture's OpenTelemetry <see cref="ActivitySource"/> and <see cref="Meter"/>.</summary>
+public static class ConjectureObservability
+{
+    internal const string SchemaUrl = "https://github.com/kommundsen/Conjecture/blob/main/docs/telemetry-schema.json";
+
+    private static readonly string Version =
+        typeof(ConjectureObservability).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion ?? "0.0.0";
+
+    /// <summary>Gets the <see cref="System.Diagnostics.ActivitySource"/> used to emit Conjecture trace spans.</summary>
+    public static ActivitySource ActivitySource { get; } = new("Conjecture.Core", Version);
+
+    /// <summary>Gets the <see cref="System.Diagnostics.Metrics.Meter"/> used to emit Conjecture metrics.</summary>
+    public static Meter Meter { get; } = new("Conjecture.Core", Version);
+}

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Conjecture.Core.ConjectureObservability
 Conjecture.Core.PartialConstructorContext
+static Conjecture.Core.ConjectureObservability.ActivitySource.get -> System.Diagnostics.ActivitySource!
+static Conjecture.Core.ConjectureObservability.Meter.get -> System.Diagnostics.Metrics.Meter!
 static Conjecture.Core.PartialConstructorContext.Current.get -> Conjecture.Core.IGeneratorContext!
 static Conjecture.Core.PartialConstructorContext.Use(Conjecture.Core.IGeneratorContext! ctx) -> System.IDisposable!


### PR DESCRIPTION
## Description

Adds `ConjectureObservability` — a public static class that owns the library's OTel infrastructure, exposing a named `ActivitySource` and `Meter` for `Conjecture.Core`. Version is derived from `AssemblyInformationalVersionAttribute` (MinVer). Also adds `docs/telemetry-schema.json` documenting the metric and trace activity names per ADR-0050.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #226
Part of #69