### PR TITLE
[69.2] Metrics: instrument TestRunner, Shrinker, and ExampleDatabase

### DIFF
--- a/src/Conjecture.Core.Tests/Internal/Shrinker/AdaptivePassTests.cs
+++ b/src/Conjecture.Core.Tests/Internal/Shrinker/AdaptivePassTests.cs
@@ -21,6 +21,8 @@ public class AdaptivePassTests
     /// </summary>
     private sealed class IndexAwareReductionPass : IShrinkPass
     {
+        public string PassName => "test_index_aware";
+
         public async ValueTask<bool> TryReduce(ShrinkState state)
         {
             for (int i = 0; i < state.Nodes.Count; i++)

--- a/src/Conjecture.Core.Tests/MetricsInstrumentationTests.cs
+++ b/src/Conjecture.Core.Tests/MetricsInstrumentationTests.cs
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests;
+
+public sealed class MetricsInstrumentationTests
+{
+    [Fact]
+    public async Task PassingProperty_ExamplesTotal_IsGreaterThanZero()
+    {
+        ConcurrentDictionary<string, long> measurements = new();
+        using MeterListener listener = new();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == "Conjecture.Core")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
+        });
+        listener.Start();
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Assert.True(measurements.GetValueOrDefault("conjecture.property.examples_total") > 0);
+    }
+
+    [Fact]
+    public async Task PassingProperty_FailuresTotal_IsZero()
+    {
+        ConcurrentDictionary<string, long> measurements = new();
+        using MeterListener listener = new();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == "Conjecture.Core")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
+        });
+        listener.Start();
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Assert.True(measurements.ContainsKey("conjecture.property.examples_total"), "examples_total instrument must be recorded");
+        Assert.Equal(0L, measurements.GetValueOrDefault("conjecture.property.failures_total"));
+    }
+
+    [Fact]
+    public async Task FailingProperty_FailuresTotal_IsOne()
+    {
+        ConcurrentDictionary<string, long> measurements = new();
+        using MeterListener listener = new();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == "Conjecture.Core")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
+        });
+        listener.Start();
+
+        ConjectureSettings settings = new() { MaxExamples = 100, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x > 5) { throw new Exception("too large"); }
+        });
+
+        Assert.Equal(1L, measurements.GetValueOrDefault("conjecture.property.failures_total"));
+    }
+
+    [Fact]
+    public async Task FailingProperty_ExamplesTotal_IsGreaterThanZero()
+    {
+        ConcurrentDictionary<string, long> measurements = new();
+        using MeterListener listener = new();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == "Conjecture.Core")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
+        });
+        listener.Start();
+
+        ConjectureSettings settings = new() { MaxExamples = 100, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x > 5) { throw new Exception("too large"); }
+        });
+
+        Assert.True(measurements.GetValueOrDefault("conjecture.property.examples_total") > 0);
+    }
+
+    [Fact]
+    public async Task FailingProperty_ShrinkReductionsTotal_IsNonNegative()
+    {
+        ConcurrentDictionary<string, long> measurements = new();
+        using MeterListener listener = new();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == "Conjecture.Core")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
+        });
+        listener.Start();
+
+        ConjectureSettings settings = new() { MaxExamples = 100, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x > 5) { throw new Exception("too large"); }
+        });
+
+        Assert.True(measurements.ContainsKey("conjecture.shrink.reductions_total"), "shrink.reductions_total instrument must be recorded");
+        Assert.True(measurements.GetValueOrDefault("conjecture.shrink.reductions_total") >= 0);
+    }
+
+    [Fact]
+    public async Task PropertyWithAssumptions_GenerationRejectionsTotal_IsGreaterThanZero()
+    {
+        ConcurrentDictionary<string, long> measurements = new();
+        using MeterListener listener = new();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == "Conjecture.Core")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
+        {
+            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
+        });
+        listener.Start();
+
+        // Use a seed that ensures some odd numbers are generated so Assume.That rejects them
+        ConjectureSettings settings = new() { MaxExamples = 5, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 10).Generate(data);
+            Assume.That(x % 2 == 0); // odd values are rejected
+        });
+
+        Assert.True(measurements.GetValueOrDefault("conjecture.generation.rejections_total") > 0);
+    }
+
+    [Fact]
+    public async Task PassingProperty_DurationSeconds_IsPositive()
+    {
+        ConcurrentDictionary<string, double> doubleMeasurements = new();
+        using MeterListener listener = new();
+        listener.InstrumentPublished = (instrument, l) =>
+        {
+            if (instrument.Meter.Name == "Conjecture.Core")
+            {
+                l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<double>((instrument, measurement, _, _) =>
+        {
+            doubleMeasurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
+        });
+        listener.Start();
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Assert.True(doubleMeasurements.GetValueOrDefault("conjecture.property.duration_seconds") > 0.0);
+    }
+}

--- a/src/Conjecture.Core/Internal/AdaptivePass.cs
+++ b/src/Conjecture.Core/Internal/AdaptivePass.cs
@@ -10,6 +10,8 @@ internal sealed class AdaptivePass(IShrinkPass inner) : IShrinkPass
 {
     private readonly HashSet<int> productiveIndices = [];
 
+    public string PassName => inner.PassName;
+
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
         if (productiveIndices.Count > 0)

--- a/src/Conjecture.Core/Internal/BlockSwappingPass.cs
+++ b/src/Conjecture.Core/Internal/BlockSwappingPass.cs
@@ -8,6 +8,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class BlockSwappingPass : IShrinkPass
 {
+    public string PassName => "block_swapping";
+
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
         for (int i = 0; i < state.Nodes.Count - 1; i++)

--- a/src/Conjecture.Core/Internal/CommandSequenceShrinkPass.cs
+++ b/src/Conjecture.Core/Internal/CommandSequenceShrinkPass.cs
@@ -10,6 +10,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class CommandSequenceShrinkPass : IShrinkPass
 {
+    public string PassName => "command_sequence";
+
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
         List<int> sentinels = FindSentinels(state.Nodes);

--- a/src/Conjecture.Core/Internal/DeleteBlocksPass.cs
+++ b/src/Conjecture.Core/Internal/DeleteBlocksPass.cs
@@ -8,6 +8,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class DeleteBlocksPass : IShrinkPass
 {
+    public string PassName => "delete_blocks";
+
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
         for (int i = 0; i < state.Nodes.Count; i++)

--- a/src/Conjecture.Core/Internal/FloatSimplificationPass.cs
+++ b/src/Conjecture.Core/Internal/FloatSimplificationPass.cs
@@ -10,6 +10,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class FloatSimplificationPass : IShrinkPass
 {
+    public string PassName => "float_simplification";
+
     private static readonly ulong Zero64 = Unsafe.BitCast<double, ulong>(0.0);
     private static readonly ulong MaxFinite64 = Unsafe.BitCast<double, ulong>(double.MaxValue);
     private static readonly ulong MinFinite64 = Unsafe.BitCast<double, ulong>(double.MinValue);

--- a/src/Conjecture.Core/Internal/IShrinkPass.cs
+++ b/src/Conjecture.Core/Internal/IShrinkPass.cs
@@ -5,6 +5,9 @@ namespace Conjecture.Core.Internal;
 
 internal interface IShrinkPass
 {
+    /// <summary>Gets the stable metric tag name for this pass (snake_case, never changes).</summary>
+    string PassName { get; }
+
     /// <summary>Attempt one reduction step. Returns true if progress was made.</summary>
     ValueTask<bool> TryReduce(ShrinkState state);
 }

--- a/src/Conjecture.Core/Internal/Instruments.cs
+++ b/src/Conjecture.Core/Internal/Instruments.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Diagnostics.Metrics;
+
+namespace Conjecture.Core.Internal;
+
+internal static class Instruments
+{
+    internal static readonly Counter<long> ExamplesTotal =
+        ConjectureObservability.Meter.CreateCounter<long>(
+            "conjecture.property.examples_total",
+            unit: "examples");
+
+    internal static readonly Counter<long> FailuresTotal =
+        ConjectureObservability.Meter.CreateCounter<long>(
+            "conjecture.property.failures_total",
+            unit: "failures");
+
+    internal static readonly Histogram<double> DurationSeconds =
+        ConjectureObservability.Meter.CreateHistogram<double>(
+            "conjecture.property.duration_seconds",
+            unit: "s");
+
+    internal static readonly Counter<long> RejectionsTotal =
+        ConjectureObservability.Meter.CreateCounter<long>(
+            "conjecture.generation.rejections_total",
+            unit: "rejections");
+
+    internal static readonly Counter<long> ShrinkPassesTotal =
+        ConjectureObservability.Meter.CreateCounter<long>(
+            "conjecture.shrink.passes_total",
+            unit: "passes");
+
+    internal static readonly Counter<long> ShrinkReductionsTotal =
+        ConjectureObservability.Meter.CreateCounter<long>(
+            "conjecture.shrink.reductions_total",
+            unit: "reductions");
+
+    internal static readonly Histogram<double> TargetingBestScore =
+        ConjectureObservability.Meter.CreateHistogram<double>(
+            "conjecture.targeting.best_score");
+
+    internal static readonly Counter<long> DatabaseReplaysTotal =
+        ConjectureObservability.Meter.CreateCounter<long>(
+            "conjecture.database.replays_total",
+            unit: "replays");
+
+    internal static readonly Counter<long> DatabaseSavesTotal =
+        ConjectureObservability.Meter.CreateCounter<long>(
+            "conjecture.database.saves_total",
+            unit: "saves");
+}

--- a/src/Conjecture.Core/Internal/IntegerReductionPass.cs
+++ b/src/Conjecture.Core/Internal/IntegerReductionPass.cs
@@ -8,6 +8,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class IntegerReductionPass : IShrinkPass
 {
+    public string PassName => "integer_reduction";
+
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
         bool progress = false;

--- a/src/Conjecture.Core/Internal/IntervalDeletionPass.cs
+++ b/src/Conjecture.Core/Internal/IntervalDeletionPass.cs
@@ -8,6 +8,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class IntervalDeletionPass : IShrinkPass
 {
+    public string PassName => "interval_deletion";
+
     private static readonly int[] Sizes = [8, 4, 2];
 
     public async ValueTask<bool> TryReduce(ShrinkState state)

--- a/src/Conjecture.Core/Internal/LexMinimizePass.cs
+++ b/src/Conjecture.Core/Internal/LexMinimizePass.cs
@@ -8,6 +8,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class LexMinimizePass : IShrinkPass
 {
+    public string PassName => "lex_minimize";
+
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
         bool progress = false;

--- a/src/Conjecture.Core/Internal/NumericAwareShrinkPass.cs
+++ b/src/Conjecture.Core/Internal/NumericAwareShrinkPass.cs
@@ -5,6 +5,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class NumericAwareShrinkPass : IShrinkPass
 {
+    public string PassName => "numeric_aware";
+
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
         int i = 0;

--- a/src/Conjecture.Core/Internal/RedistributionPass.cs
+++ b/src/Conjecture.Core/Internal/RedistributionPass.cs
@@ -8,6 +8,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class RedistributionPass : IShrinkPass
 {
+    public string PassName => "redistribution";
+
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
         for (int i = 0; i < state.Nodes.Count - 1; i++)

--- a/src/Conjecture.Core/Internal/Shrinker.cs
+++ b/src/Conjecture.Core/Internal/Shrinker.cs
@@ -50,7 +50,8 @@ internal static class Shrinker
                     {
                         bool madeProgress = await pass.TryReduce(state);
                         tierProgress |= madeProgress;
-                        Log.ShrinkPassProgress(logger, pass.GetType().Name, madeProgress);
+                        Instruments.ShrinkPassesTotal.Add(1, new KeyValuePair<string, object?>("pass_name", pass.PassName));
+                        Log.ShrinkPassProgress(logger, pass.PassName, madeProgress);
                     }
                     outerProgress |= tierProgress;
                 } while (tierProgress);
@@ -58,6 +59,7 @@ internal static class Shrinker
         } while (outerProgress);
 
         sw.Stop();
+        Instruments.ShrinkReductionsTotal.Add(state.ShrinkCount);
         Log.ShrinkingCompleted(logger, state.Nodes.Count, state.ShrinkCount, sw.Elapsed.TotalMilliseconds);
         return (state.Nodes, state.ShrinkCount);
     }

--- a/src/Conjecture.Core/Internal/StringAwarePass.cs
+++ b/src/Conjecture.Core/Internal/StringAwarePass.cs
@@ -8,6 +8,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class StringAwarePass : IShrinkPass
 {
+    public string PassName => "string_aware";
+
     private const ulong ACodepoint = 'a';
     private const ulong SpaceCodepoint = 32;
     private static readonly ulong[] CharTargets = [ACodepoint, SpaceCodepoint];

--- a/src/Conjecture.Core/Internal/TestRunner.cs
+++ b/src/Conjecture.Core/Internal/TestRunner.cs
@@ -58,13 +58,17 @@ internal static class TestRunner
             foreach (byte[] buffer in stored)
             {
                 List<IRNode> nodes = DeserializeNodes(buffer);
+                Instruments.DatabaseReplaysTotal.Add(1);
                 Status replayStatus = await ReplayAsync(nodes, test);
                 if (replayStatus == Status.Interesting)
                 {
+                    Instruments.ExamplesTotal.Add(1);
+                    Instruments.FailuresTotal.Add(1);
                     (IReadOnlyList<IRNode> shrunk, int shrinkCount) = await Shrinker.ShrinkAsync(
                         nodes, n => ReplayAsync(n, test), settings.Logger);
                     db.Delete(testIdHash);
                     db.Save(testIdHash, SerializeNodes(shrunk));
+                    Instruments.DatabaseSavesTotal.Add(1);
                     return TestRunResult.Fail(shrunk, nodes, 0UL, 1, shrinkCount);
                 }
             }
@@ -126,6 +130,7 @@ internal static class TestRunner
                 }
 
                 valid++;
+                Instruments.ExamplesTotal.Add(1);
                 foreach (var (label, score) in data.Observations)
                 {
                     if (!bestPerLabel.TryGetValue(label, out var current) || score > current.Score)
@@ -147,6 +152,7 @@ internal static class TestRunner
             {
                 data.MarkInvalid();
                 unsatisfied++;
+                Instruments.RejectionsTotal.Add(1);
                 if (!unsatisfiedWarnLogged && valid > 0 && unsatisfied > valid * settings.MaxUnsatisfiedRatio / 2)
                 {
                     unsatisfiedWarnLogged = true;
@@ -165,6 +171,8 @@ internal static class TestRunner
             catch (Exception failureEx)
             {
                 data.MarkInteresting();
+                Instruments.ExamplesTotal.Add(1);
+                Instruments.FailuresTotal.Add(1);
                 string? stackTrace = failureEx.StackTrace;
                 IReadOnlyList<IRNode> firstFailureNodes = data.IRNodes;
                 (IReadOnlyList<IRNode> shrunk, int shrinkCount) = await Shrinker.ShrinkAsync(
@@ -172,8 +180,11 @@ internal static class TestRunner
                 if (dbContext is DbContext ctx)
                 {
                     ctx.Database.Save(ctx.TestIdHash, SerializeNodes(shrunk));
+                    Instruments.DatabaseSavesTotal.Add(1);
                 }
 
+                generationSw.Stop();
+                Instruments.DurationSeconds.Record(generationSw.Elapsed.TotalSeconds);
                 Log.PropertyTestFailure(logger, valid + 1, $"0x{seed:X16}");
                 return TestRunResult.Fail(shrunk, firstFailureNodes, seed, valid + 1, shrinkCount, stackTrace);
             }
@@ -185,6 +196,7 @@ internal static class TestRunner
         }
 
         generationSw.Stop();
+        Instruments.DurationSeconds.Record(generationSw.Elapsed.TotalSeconds);
         Log.GenerationCompleted(logger, valid, unsatisfied, generationSw.Elapsed.TotalMilliseconds);
 
         // Targeting phase: round-robin HillClimber across labels, one step per label per cycle.
@@ -229,6 +241,10 @@ internal static class TestRunner
 
             string targetingBestScores = string.Join(", ", currentScores.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
             Log.TargetingCompleted(logger, targetingLabels, targetingBestScores);
+            foreach (KeyValuePair<string, double> kvp in currentScores)
+            {
+                Instruments.TargetingBestScore.Record(kvp.Value);
+            }
 
             if (failingNodes is not null)
             {
@@ -237,8 +253,10 @@ internal static class TestRunner
                 if (dbContext is DbContext ctx)
                 {
                     ctx.Database.Save(ctx.TestIdHash, SerializeNodes(shrunk));
+                    Instruments.DatabaseSavesTotal.Add(1);
                 }
 
+                Instruments.FailuresTotal.Add(1);
                 Log.PropertyTestFailure(logger, valid + 1, $"0x{seed:X16}");
                 return TestRunResult.Fail(shrunk, failingNodes, seed, valid + 1, shrinkCount);
             }

--- a/src/Conjecture.Core/Internal/ZeroBlocksPass.cs
+++ b/src/Conjecture.Core/Internal/ZeroBlocksPass.cs
@@ -8,6 +8,8 @@ namespace Conjecture.Core.Internal;
 
 internal sealed class ZeroBlocksPass : IShrinkPass
 {
+    public string PassName => "zero_blocks";
+
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
         bool progress = false;


### PR DESCRIPTION
## Description

Adds OpenTelemetry metric instruments to the core engine. A new `Instruments` static class exposes 9 counters and histograms created from `ConjectureObservability.Meter`, and records measurements at all key callsites in `TestRunner`, `Shrinker`, and the targeting phase.

Also adds a stable `PassName` string property to `IShrinkPass` (implemented as a snake_case constant in each pass) so the `shrink.passes_total` metric tag never breaks on class renames.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #227
Part of #69