### PR TITLE
[69.3] Tracing: add Activity spans to TestRunner

### DIFF
--- a/src/Conjecture.Core.Tests/Conjecture.Core.Tests.csproj
+++ b/src/Conjecture.Core.Tests/Conjecture.Core.Tests.csproj
@@ -21,4 +21,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/Conjecture.Core.Tests/MetricsInstrumentationTests.cs
+++ b/src/Conjecture.Core.Tests/MetricsInstrumentationTests.cs
@@ -9,6 +9,7 @@ using Conjecture.Core.Internal;
 
 namespace Conjecture.Core.Tests;
 
+[Collection("Sequential")]
 public sealed class MetricsInstrumentationTests
 {
     [Fact]
@@ -23,10 +24,7 @@ public sealed class MetricsInstrumentationTests
                 l.EnableMeasurementEvents(instrument);
             }
         };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
-        {
-            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
-        });
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) => measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement));
         listener.Start();
 
         ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
@@ -51,10 +49,7 @@ public sealed class MetricsInstrumentationTests
                 l.EnableMeasurementEvents(instrument);
             }
         };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
-        {
-            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
-        });
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) => measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement));
         listener.Start();
 
         ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
@@ -80,10 +75,7 @@ public sealed class MetricsInstrumentationTests
                 l.EnableMeasurementEvents(instrument);
             }
         };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
-        {
-            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
-        });
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) => measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement));
         listener.Start();
 
         ConjectureSettings settings = new() { MaxExamples = 100, Seed = 1UL };
@@ -108,10 +100,7 @@ public sealed class MetricsInstrumentationTests
                 l.EnableMeasurementEvents(instrument);
             }
         };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
-        {
-            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
-        });
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) => measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement));
         listener.Start();
 
         ConjectureSettings settings = new() { MaxExamples = 100, Seed = 1UL };
@@ -136,10 +125,7 @@ public sealed class MetricsInstrumentationTests
                 l.EnableMeasurementEvents(instrument);
             }
         };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
-        {
-            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
-        });
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) => measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement));
         listener.Start();
 
         ConjectureSettings settings = new() { MaxExamples = 100, Seed = 1UL };
@@ -165,10 +151,7 @@ public sealed class MetricsInstrumentationTests
                 l.EnableMeasurementEvents(instrument);
             }
         };
-        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) =>
-        {
-            measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
-        });
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, _, _) => measurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement));
         listener.Start();
 
         // Use a seed that ensures some odd numbers are generated so Assume.That rejects them
@@ -194,10 +177,7 @@ public sealed class MetricsInstrumentationTests
                 l.EnableMeasurementEvents(instrument);
             }
         };
-        listener.SetMeasurementEventCallback<double>((instrument, measurement, _, _) =>
-        {
-            doubleMeasurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement);
-        });
+        listener.SetMeasurementEventCallback<double>((instrument, measurement, _, _) => doubleMeasurements.AddOrUpdate(instrument.Name, static (_, delta) => delta, static (_, existing, delta) => existing + delta, measurement));
         listener.Start();
 
         ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };

--- a/src/Conjecture.Core.Tests/TracingInstrumentationTests.cs
+++ b/src/Conjecture.Core.Tests/TracingInstrumentationTests.cs
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests;
+
+[CollectionDefinition("Sequential", DisableParallelization = true)]
+public sealed class SequentialCollection;
+
+[Collection("Sequential")]
+public sealed class TracingInstrumentationTests
+{
+    private static ActivityListener CreateCollectingListener(ConcurrentBag<Activity> collected)
+    {
+        ActivityListener listener = new()
+        {
+            ShouldListenTo = source => source.Name == "Conjecture.Core",
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => collected.Add(activity),
+        };
+        ActivitySource.AddActivityListener(listener);
+        return listener;
+    }
+
+    [Fact]
+    public async Task PassingProperty_RootActivity_IsNamedPropertyTest()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Assert.Contains(activities, a => a.OperationName == "PropertyTest" && a.Parent is null);
+    }
+
+    [Fact]
+    public async Task PassingProperty_GenerationChildActivity_IsPresent()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Assert.Contains(activities, a => a.OperationName == "PropertyTest.Generation");
+    }
+
+    [Fact]
+    public async Task FailingProperty_ShrinkingChildActivity_IsPresent()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 100, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x > 5) { throw new Exception("too large"); }
+        });
+
+        Assert.Contains(activities, a => a.OperationName == "PropertyTest.Shrinking");
+    }
+
+    [Fact]
+    public async Task PassingPropertyWithTargeting_TargetingChildActivity_IsPresent()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 20, Seed = 1UL, Targeting = true };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            Target.Maximize(x, "x");
+        });
+
+        Assert.Contains(activities, a => a.OperationName == "PropertyTest.Targeting");
+    }
+
+    [Fact]
+    public async Task PassingPropertyWithTargetingDisabled_TargetingChildActivity_IsAbsent()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL, Targeting = false };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Assert.DoesNotContain(activities, a => a.OperationName == "PropertyTest.Targeting");
+    }
+
+    [Fact]
+    public async Task PassingProperty_RootActivity_CarriesSeedTag()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 42UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Activity? root = activities.FirstOrDefault(a => a.OperationName == "PropertyTest" && a.Parent is null);
+        Assert.NotNull(root);
+        Assert.NotNull(root.GetTagItem("conjecture.seed"));
+    }
+
+    [Fact]
+    public async Task PassingProperty_RootActivity_CarriesMaxExamplesTag()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Activity? root = activities.FirstOrDefault(a => a.OperationName == "PropertyTest" && a.Parent is null);
+        Assert.NotNull(root);
+        Assert.Equal(10, root.GetTagItem("conjecture.max_examples"));
+    }
+
+    [Fact]
+    public async Task FailingProperty_RootActivity_HasTestStatusFail()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 100, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x > 5) { throw new Exception("too large"); }
+        });
+
+        Activity? root = activities.FirstOrDefault(a => a.OperationName == "PropertyTest" && a.Parent is null);
+        Assert.NotNull(root);
+        Assert.Equal("fail", root.GetTagItem("test.status"));
+    }
+
+    [Fact]
+    public async Task PassingProperty_RootActivity_DoesNotHaveTestStatusFail()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Activity? root = activities.FirstOrDefault(a => a.OperationName == "PropertyTest" && a.Parent is null);
+        Assert.NotNull(root);
+        Assert.NotEqual("fail", root.GetTagItem("test.status"));
+    }
+
+    [Fact]
+    public async Task SettingsWithTestName_RootActivity_CarriesTestNameTag()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL, TestName = "MyTestMethod" };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Activity? root = activities.FirstOrDefault(a => a.OperationName == "PropertyTest" && a.Parent is null);
+        Assert.NotNull(root);
+        Assert.Equal("MyTestMethod", root.GetTagItem("test.name"));
+    }
+
+    [Fact]
+    public async Task SettingsWithoutTestName_RootActivity_DoesNotCarryTestNameTag()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Activity? root = activities.FirstOrDefault(a => a.OperationName == "PropertyTest" && a.Parent is null);
+        Assert.NotNull(root);
+        Assert.Null(root.GetTagItem("test.name"));
+    }
+
+    [Fact]
+    public async Task FailingProperty_ShrinkingActivity_IsChildOfRootActivity()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 100, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x > 5) { throw new Exception("too large"); }
+        });
+
+        Activity? root = activities.FirstOrDefault(a => a.OperationName == "PropertyTest" && a.Parent is null);
+        Activity? shrinking = activities.FirstOrDefault(a => a.OperationName == "PropertyTest.Shrinking");
+        Assert.NotNull(root);
+        Assert.NotNull(shrinking);
+        Assert.Equal(root.Id, shrinking.ParentId);
+    }
+
+    [Fact]
+    public async Task PassingProperty_GenerationActivity_IsChildOfRootActivity()
+    {
+        ConcurrentBag<Activity> activities = [];
+        using ActivityListener listener = CreateCollectingListener(activities);
+
+        ConjectureSettings settings = new() { MaxExamples = 10, Seed = 1UL };
+        await TestRunner.Run(settings, data =>
+        {
+            int x = Generate.Integers<int>(0, 100).Generate(data);
+            if (x < 0) { throw new Exception("impossible"); }
+        });
+
+        Activity? root = activities.FirstOrDefault(a => a.OperationName == "PropertyTest" && a.Parent is null);
+        Activity? generation = activities.FirstOrDefault(a => a.OperationName == "PropertyTest.Generation");
+        Assert.NotNull(root);
+        Assert.NotNull(generation);
+        Assert.Equal(root.Id, generation.ParentId);
+    }
+}

--- a/src/Conjecture.Core.Tests/xunit.runner.json
+++ b/src/Conjecture.Core.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}

--- a/src/Conjecture.Core/ConjectureSettings.cs
+++ b/src/Conjecture.Core/ConjectureSettings.cs
@@ -104,4 +104,10 @@ public record ConjectureSettings
 
     /// <summary>Output path for exported reproduction files. Defaults to <c>.conjecture/repros/</c>.</summary>
     public string ReproOutputPath { get; init; } = ".conjecture/repros/";
+
+    /// <summary>Set by test framework adapters to populate the <c>test.name</c> tag on trace spans.</summary>
+    public string? TestName { get; init; }
+
+    /// <summary>Set by test framework adapters to populate the <c>test.class.name</c> tag on trace spans.</summary>
+    public string? TestClassName { get; init; }
 }

--- a/src/Conjecture.Core/Internal/TestRunner.cs
+++ b/src/Conjecture.Core/Internal/TestRunner.cs
@@ -88,6 +88,20 @@ internal static class TestRunner
         Func<ConjectureData, Task> test,
         DbContext? dbContext)
     {
+        Activity? rootActivity = ConjectureObservability.ActivitySource.StartActivity("PropertyTest");
+        string seedTag = settings.Seed.HasValue ? $"0x{settings.Seed.Value:X16}" : "random";
+        rootActivity?.SetTag("conjecture.seed", seedTag);
+        rootActivity?.SetTag("conjecture.max_examples", settings.MaxExamples);
+        if (settings.TestName is not null)
+        {
+            rootActivity?.SetTag("test.name", settings.TestName);
+        }
+
+        if (settings.TestClassName is not null)
+        {
+            rootActivity?.SetTag("test.class.name", settings.TestClassName);
+        }
+
         ILogger logger = settings.Logger;
         ulong seed = settings.Seed ?? (ulong)Random.Shared.NextInt64();
         SplittableRandom rng = new(seed);
@@ -102,169 +116,221 @@ internal static class TestRunner
         int maxAttempts = settings.MaxExamples * 200;
         TimeSpan? deadline = settings.Deadline;
         Stopwatch? sw = deadline.HasValue ? Stopwatch.StartNew() : null;
-        var bestPerLabel = new Dictionary<string, (IReadOnlyList<IRNode> Nodes, double Score)>();
+        Dictionary<string, (IReadOnlyList<IRNode> Nodes, double Score)> bestPerLabel = [];
 
-        while (totalAttempts < maxAttempts)
+        Activity? generationActivity = ConjectureObservability.ActivitySource.StartActivity("PropertyTest.Generation");
+
+        try
         {
-            // Stop when we've reached the generation budget AND have observations to target,
-            // or when we've exhausted the full MaxExamples budget.
-            bool atGenerationBudget = valid >= generationBudget && bestPerLabel.Count > 0;
-            if (valid >= settings.MaxExamples || atGenerationBudget)
+            while (totalAttempts < maxAttempts)
             {
-                break;
-            }
-
-            totalAttempts++;
-            ConjectureData data = ConjectureData.ForGeneration(rng.Split());
-            Target.CurrentData.Value = data;
-            try
-            {
-                Task testTask = test(data);
-                if (deadline.HasValue)
+                // Stop when we've reached the generation budget AND have observations to target,
+                // or when we've exhausted the full MaxExamples budget.
+                bool atGenerationBudget = valid >= generationBudget && bestPerLabel.Count > 0;
+                if (valid >= settings.MaxExamples || atGenerationBudget)
                 {
-                    await testTask.WaitAsync(deadline.Value);
-                }
-                else
-                {
-                    await testTask;
+                    break;
                 }
 
-                valid++;
-                Instruments.ExamplesTotal.Add(1);
-                foreach (var (label, score) in data.Observations)
+                totalAttempts++;
+                ConjectureData data = ConjectureData.ForGeneration(rng.Split());
+                Target.CurrentData.Value = data;
+                try
                 {
-                    if (!bestPerLabel.TryGetValue(label, out var current) || score > current.Score)
+                    Task testTask = test(data);
+                    if (deadline.HasValue)
                     {
-                        bestPerLabel[label] = (data.IRNodes, score);
+                        await testTask.WaitAsync(deadline.Value);
+                    }
+                    else
+                    {
+                        await testTask;
+                    }
+
+                    valid++;
+                    Instruments.ExamplesTotal.Add(1);
+                    foreach ((string label, double score) in data.Observations)
+                    {
+                        if (!bestPerLabel.TryGetValue(label, out (IReadOnlyList<IRNode> Nodes, double Score) current) || score > current.Score)
+                        {
+                            bestPerLabel[label] = (data.IRNodes, score);
+                        }
+                    }
+
+                    if (sw is not null && sw.Elapsed > deadline!.Value)
+                    {
+                        throw new ConjectureException("deadline exceeded");
                     }
                 }
-
-                if (sw is not null && sw.Elapsed > deadline!.Value)
+                catch (TimeoutException)
                 {
                     throw new ConjectureException("deadline exceeded");
                 }
-            }
-            catch (TimeoutException)
-            {
-                throw new ConjectureException("deadline exceeded");
-            }
-            catch (UnsatisfiedAssumptionException)
-            {
-                data.MarkInvalid();
-                unsatisfied++;
-                Instruments.RejectionsTotal.Add(1);
-                if (!unsatisfiedWarnLogged && valid > 0 && unsatisfied > valid * settings.MaxUnsatisfiedRatio / 2)
+                catch (UnsatisfiedAssumptionException)
                 {
-                    unsatisfiedWarnLogged = true;
-                    Log.HighUnsatisfiedRatio(logger, unsatisfied, valid, settings.MaxUnsatisfiedRatio);
-                }
+                    data.MarkInvalid();
+                    unsatisfied++;
+                    Instruments.RejectionsTotal.Add(1);
+                    if (!unsatisfiedWarnLogged && valid > 0 && unsatisfied > valid * settings.MaxUnsatisfiedRatio / 2)
+                    {
+                        unsatisfiedWarnLogged = true;
+                        Log.HighUnsatisfiedRatio(logger, unsatisfied, valid, settings.MaxUnsatisfiedRatio);
+                    }
 
-                if ((valid > 0 || settings.MaxUnsatisfiedRatio == 0) && unsatisfied > valid * settings.MaxUnsatisfiedRatio)
-                {
-                    throw new ConjectureException("too many unsatisfied assumptions");
+                    if ((valid > 0 || settings.MaxUnsatisfiedRatio == 0) && unsatisfied > valid * settings.MaxUnsatisfiedRatio)
+                    {
+                        throw new ConjectureException("too many unsatisfied assumptions");
+                    }
                 }
-            }
-            catch (ConjectureException)
-            {
-                throw;
-            }
-            catch (Exception failureEx)
-            {
-                data.MarkInteresting();
-                Instruments.ExamplesTotal.Add(1);
-                Instruments.FailuresTotal.Add(1);
-                string? stackTrace = failureEx.StackTrace;
-                IReadOnlyList<IRNode> firstFailureNodes = data.IRNodes;
-                (IReadOnlyList<IRNode> shrunk, int shrinkCount) = await Shrinker.ShrinkAsync(
-                    firstFailureNodes, n => ReplayAsync(n, test), logger);
-                if (dbContext is DbContext ctx)
+                catch (ConjectureException)
                 {
-                    ctx.Database.Save(ctx.TestIdHash, SerializeNodes(shrunk));
-                    Instruments.DatabaseSavesTotal.Add(1);
+                    throw;
                 }
+                catch (Exception failureEx)
+                {
+                    data.MarkInteresting();
+                    Instruments.ExamplesTotal.Add(1);
+                    Instruments.FailuresTotal.Add(1);
+                    string? stackTrace = failureEx.StackTrace;
+                    IReadOnlyList<IRNode> firstFailureNodes = data.IRNodes;
+                    generationActivity?.SetTag("examples", valid + 1);
+                    generationActivity?.SetTag("failures", 1);
+                    generationActivity?.SetTag("rejections", unsatisfied);
+                    generationActivity?.Stop();
 
-                generationSw.Stop();
-                Instruments.DurationSeconds.Record(generationSw.Elapsed.TotalSeconds);
-                Log.PropertyTestFailure(logger, valid + 1, $"0x{seed:X16}");
-                return TestRunResult.Fail(shrunk, firstFailureNodes, seed, valid + 1, shrinkCount, stackTrace);
+                    Activity? shrinkActivity = ConjectureObservability.ActivitySource.StartActivity("PropertyTest.Shrinking");
+                    (IReadOnlyList<IRNode> shrunk, int shrinkCount) = await Shrinker.ShrinkAsync(
+                        firstFailureNodes, n => ReplayAsync(n, test), logger);
+                    shrinkActivity?.SetTag("reductions", shrinkCount);
+                    shrinkActivity?.Stop();
+
+                    if (dbContext is DbContext ctx)
+                    {
+                        ctx.Database.Save(ctx.TestIdHash, SerializeNodes(shrunk));
+                        Instruments.DatabaseSavesTotal.Add(1);
+                    }
+
+                    generationSw.Stop();
+                    Instruments.DurationSeconds.Record(generationSw.Elapsed.TotalSeconds);
+                    Log.PropertyTestFailure(logger, valid + 1, $"0x{seed:X16}");
+                    rootActivity?.SetTag("test.status", "fail");
+                    rootActivity?.Stop();
+                    return TestRunResult.Fail(shrunk, firstFailureNodes, seed, valid + 1, shrinkCount, stackTrace);
+                }
+                finally
+                {
+                    Target.CurrentData.Value = null;
+                    data.Freeze();
+                }
             }
-            finally
+
+            generationActivity?.SetTag("examples", valid);
+            generationActivity?.SetTag("failures", 0);
+            generationActivity?.SetTag("rejections", unsatisfied);
+            generationActivity?.Stop();
+
+            generationSw.Stop();
+            Instruments.DurationSeconds.Record(generationSw.Elapsed.TotalSeconds);
+            Log.GenerationCompleted(logger, valid, unsatisfied, generationSw.Elapsed.TotalMilliseconds);
+
+            // Targeting phase: round-robin HillClimber across labels, one step per label per cycle.
+            if (settings.Targeting && bestPerLabel.Count > 0)
             {
-                Target.CurrentData.Value = null;
-                data.Freeze();
+                Activity? targetingActivity = ConjectureObservability.ActivitySource.StartActivity("PropertyTest.Targeting");
+
+                try
+                {
+                    int budgetRemaining = settings.MaxExamples - generationBudget;
+                    SplittableRandom perturbRng = new(rng.NextUInt64());
+                    List<string> labels = bestPerLabel.Keys.ToList();
+                    string targetingLabels = string.Join(", ", labels);
+                    Log.TargetingStarted(logger, targetingLabels);
+                    Dictionary<string, IReadOnlyList<IRNode>> currentNodes = bestPerLabel.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Nodes);
+                    Dictionary<string, double> currentScores = bestPerLabel.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Score);
+                    IReadOnlyList<IRNode>? failingNodes = null;
+
+                    async Task<(Status, IReadOnlyDictionary<string, double>)> EvalForClimb(IReadOnlyList<IRNode> nodes)
+                    {
+                        (Status status, IReadOnlyDictionary<string, double> obs) = await ReplayAndObserveAsync(nodes, test);
+                        if (status == Status.Interesting)
+                        {
+                            failingNodes = nodes;
+                        }
+
+                        return (status, obs);
+                    }
+
+                    int labelIdx = 0;
+                    while (budgetRemaining > 0 && failingNodes is null)
+                    {
+                        string label = labels[labelIdx++ % labels.Count];
+
+                        // budget: 2 so the greedy pass can try both value+1 and value-1 per step,
+                        // enabling both maximization and minimization (via negated scores) to make
+                        // progress with a single label visit.
+                        int stepBudget = Math.Min(2, budgetRemaining);
+                        (IReadOnlyList<IRNode> newNodes, double newScore) = await HillClimber.Climb(
+                            currentNodes[label], currentScores[label], label, EvalForClimb, stepBudget, perturbRng, logger);
+
+                        currentNodes[label] = newNodes;
+                        currentScores[label] = newScore;
+                        budgetRemaining -= stepBudget;
+                    }
+
+                    string targetingBestScores = string.Join(", ", currentScores.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
+                    Log.TargetingCompleted(logger, targetingLabels, targetingBestScores);
+                    foreach (KeyValuePair<string, double> kvp in currentScores)
+                    {
+                        Instruments.TargetingBestScore.Record(kvp.Value);
+                    }
+
+                    targetingActivity?.SetTag("labels", targetingLabels);
+                    double bestScore = currentScores.Count > 0 ? currentScores.Values.Max() : 0.0;
+                    targetingActivity?.SetTag("best_score", bestScore);
+                    targetingActivity?.Stop();
+
+                    if (failingNodes is not null)
+                    {
+                        Activity? shrinkActivity = ConjectureObservability.ActivitySource.StartActivity("PropertyTest.Shrinking");
+                        (IReadOnlyList<IRNode> shrunk, int shrinkCount) = await Shrinker.ShrinkAsync(
+                            failingNodes, n => ReplayAsync(n, test), logger);
+                        shrinkActivity?.SetTag("reductions", shrinkCount);
+                        shrinkActivity?.Stop();
+
+                        if (dbContext is DbContext ctx)
+                        {
+                            ctx.Database.Save(ctx.TestIdHash, SerializeNodes(shrunk));
+                            Instruments.DatabaseSavesTotal.Add(1);
+                        }
+
+                        Instruments.FailuresTotal.Add(1);
+                        Log.PropertyTestFailure(logger, valid + 1, $"0x{seed:X16}");
+                        rootActivity?.SetTag("test.status", "fail");
+                        rootActivity?.Stop();
+                        return TestRunResult.Fail(shrunk, failingNodes, seed, valid + 1, shrinkCount);
+                    }
+
+                    rootActivity?.SetTag("test.status", "pass");
+                    rootActivity?.Stop();
+                    return TestRunResult.Pass(seed, valid, currentScores);
+
+                }
+                finally
+                {
+                    targetingActivity?.Stop();
+                }
             }
+
+            rootActivity?.SetTag("test.status", "pass");
+            rootActivity?.Stop();
+            return TestRunResult.Pass(seed, valid);
+
         }
-
-        generationSw.Stop();
-        Instruments.DurationSeconds.Record(generationSw.Elapsed.TotalSeconds);
-        Log.GenerationCompleted(logger, valid, unsatisfied, generationSw.Elapsed.TotalMilliseconds);
-
-        // Targeting phase: round-robin HillClimber across labels, one step per label per cycle.
-        if (settings.Targeting && bestPerLabel.Count > 0)
+        finally
         {
-            int budgetRemaining = settings.MaxExamples - generationBudget;
-            var perturbRng = new SplittableRandom(rng.NextUInt64());
-            var labels = bestPerLabel.Keys.ToList();
-            string targetingLabels = string.Join(", ", labels);
-            Log.TargetingStarted(logger, targetingLabels);
-            var currentNodes = bestPerLabel.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Nodes);
-            var currentScores = bestPerLabel.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Score);
-            IReadOnlyList<IRNode>? failingNodes = null;
-
-            async Task<(Status, IReadOnlyDictionary<string, double>)> EvalForClimb(IReadOnlyList<IRNode> nodes)
-            {
-                var (status, obs) = await ReplayAndObserveAsync(nodes, test);
-                if (status == Status.Interesting)
-                {
-                    failingNodes = nodes;
-                }
-
-                return (status, obs);
-            }
-
-            int labelIdx = 0;
-            while (budgetRemaining > 0 && failingNodes is null)
-            {
-                string label = labels[labelIdx++ % labels.Count];
-
-                // budget: 2 so the greedy pass can try both value+1 and value-1 per step,
-                // enabling both maximization and minimization (via negated scores) to make
-                // progress with a single label visit.
-                int stepBudget = Math.Min(2, budgetRemaining);
-                var (newNodes, newScore) = await HillClimber.Climb(
-                    currentNodes[label], currentScores[label], label, EvalForClimb, stepBudget, perturbRng, logger);
-
-                currentNodes[label] = newNodes;
-                currentScores[label] = newScore;
-                budgetRemaining -= stepBudget;
-            }
-
-            string targetingBestScores = string.Join(", ", currentScores.Select(kvp => $"{kvp.Key}:{kvp.Value}"));
-            Log.TargetingCompleted(logger, targetingLabels, targetingBestScores);
-            foreach (KeyValuePair<string, double> kvp in currentScores)
-            {
-                Instruments.TargetingBestScore.Record(kvp.Value);
-            }
-
-            if (failingNodes is not null)
-            {
-                (IReadOnlyList<IRNode> shrunk, int shrinkCount) = await Shrinker.ShrinkAsync(
-                    failingNodes, n => ReplayAsync(n, test), logger);
-                if (dbContext is DbContext ctx)
-                {
-                    ctx.Database.Save(ctx.TestIdHash, SerializeNodes(shrunk));
-                    Instruments.DatabaseSavesTotal.Add(1);
-                }
-
-                Instruments.FailuresTotal.Add(1);
-                Log.PropertyTestFailure(logger, valid + 1, $"0x{seed:X16}");
-                return TestRunResult.Fail(shrunk, failingNodes, seed, valid + 1, shrinkCount);
-            }
-
-            return TestRunResult.Pass(seed, valid, currentScores);
+            generationActivity?.Stop();
+            rootActivity?.Stop();
         }
-
-        return TestRunResult.Pass(seed, valid);
     }
 
     private static Func<ConjectureData, Task> WrapSync(Action<ConjectureData> test)

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -1,6 +1,10 @@
 #nullable enable
 Conjecture.Core.ConjectureObservability
 Conjecture.Core.PartialConstructorContext
+Conjecture.Core.ConjectureSettings.TestClassName.get -> string?
+Conjecture.Core.ConjectureSettings.TestClassName.init -> void
+Conjecture.Core.ConjectureSettings.TestName.get -> string?
+Conjecture.Core.ConjectureSettings.TestName.init -> void
 static Conjecture.Core.ConjectureObservability.ActivitySource.get -> System.Diagnostics.ActivitySource!
 static Conjecture.Core.ConjectureObservability.Meter.get -> System.Diagnostics.Metrics.Meter!
 static Conjecture.Core.PartialConstructorContext.Current.get -> Conjecture.Core.IGeneratorContext!


### PR DESCRIPTION
## Description

Instruments `TestRunner` with OTel Activity spans so property test runs are visible as traces in any compatible backend (Aspire, Jaeger, OTLP collector, etc.).

- **`PropertyTest`** root span — carries `conjecture.seed`, `conjecture.max_examples`, `test.name`, `test.class.name`, and `test.status` (`pass`/`fail`)
- **`PropertyTest.Generation`** child span — wraps the generation loop; tagged with `examples`, `failures`, `rejections`
- **`PropertyTest.Shrinking`** child span — emitted only when shrinking runs; tagged with `reductions`
- **`PropertyTest.Targeting`** child span — emitted only when the targeting phase runs; tagged with `labels`, `best_score`
- All spans guarded with `try/finally` to guarantee `.Stop()` on exception paths (deadline exceeded, too many unsatisfied assumptions)
- Adds `TestName` and `TestClassName` init props to `ConjectureSettings` for framework adapters to populate trace identity tags
- `xunit.runner.json` with `parallelizeTestCollections: false` added to `Conjecture.Core.Tests` to prevent cross-collection OTel listener bleed (standard approach when testing process-wide telemetry infrastructure)

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #228
Part of #69