### PR TITLE
[69.4] Documentation: add OTel observability how-to and reference

### DIFF
--- a/docs/site/articles/how-to/configure-otel.md
+++ b/docs/site/articles/how-to/configure-otel.md
@@ -1,0 +1,121 @@
+# How to configure OpenTelemetry observability
+
+Conjecture emits trace spans and metrics via `System.Diagnostics.ActivitySource` and `System.Diagnostics.Metrics.Meter`. No OTel SDK is required to receive them — any compatible listener or collector works.
+
+> [!NOTE]
+> Telemetry is inert until a listener is registered. There is zero overhead when no listener is attached.
+
+## Using the BCL listener API (zero dependencies)
+
+Register listeners directly in your test project — no NuGet packages required.
+
+### Traces
+
+```csharp
+using System.Diagnostics;
+
+ActivityListener listener = new()
+{
+    ShouldListenTo = source => source.Name == "Conjecture.Core",
+    Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+    ActivityStarted = activity => Console.WriteLine($"[START] {activity.OperationName}"),
+    ActivityStopped = activity =>
+        Console.WriteLine($"[STOP]  {activity.OperationName} status={activity.GetTagItem("test.status")}"),
+};
+ActivitySource.AddActivityListener(listener);
+```
+
+### Metrics
+
+```csharp
+using System.Diagnostics.Metrics;
+
+MeterListener meterListener = new();
+meterListener.InstrumentPublished = (instrument, listener) =>
+{
+    if (instrument.Meter.Name == "Conjecture.Core")
+    {
+        listener.EnableMeasurementEvents(instrument);
+    }
+};
+meterListener.SetMeasurementEventCallback<long>((instrument, value, _, _) =>
+    Console.WriteLine($"{instrument.Name}: {value}"));
+meterListener.SetMeasurementEventCallback<double>((instrument, value, _, _) =>
+    Console.WriteLine($"{instrument.Name}: {value:F3}"));
+meterListener.Start();
+```
+
+Dispose both listeners when done — typically in a `[CollectionDefinition]` fixture or `IDisposable` teardown.
+
+> [!TIP]
+> For tests that assert on specific metric values, use `[Collection("Sequential")]` and `parallelizeTestCollections: false` in `xunit.runner.json` to prevent cross-test listener bleed. See [configure-logging](configure-logging.md) for the pattern.
+
+## Using .NET Aspire
+
+Aspire's `IDistributedApplicationBuilder` auto-discovers `ActivitySource` and `Meter` registrations. In your `AppHost`:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddSource("Conjecture.Core"))
+    .WithMetrics(metrics => metrics.AddMeter("Conjecture.Core"));
+```
+
+Conjecture spans then appear in the Aspire dashboard alongside your service traces.
+
+## Using the OpenTelemetry SDK
+
+Install the OTel .NET SDK in your test project:
+
+```bash
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+```
+
+Then configure in your test setup:
+
+```csharp
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using OpenTelemetry.Metrics;
+
+TracerProvider tracerProvider = Sdk.CreateTracerProviderBuilder()
+    .AddSource("Conjecture.Core")
+    .AddOtlpExporter()
+    .Build();
+
+MeterProvider meterProvider = Sdk.CreateMeterProviderBuilder()
+    .AddMeter("Conjecture.Core")
+    .AddOtlpExporter()
+    .Build();
+```
+
+## Exporting to an OTLP collector in CI
+
+Set the standard OTel environment variables before running tests:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317 dotnet test
+```
+
+GitHub Actions example:
+
+```yaml
+- name: Run property tests
+  env:
+    OTEL_EXPORTER_OTLP_ENDPOINT: ${{ vars.OTEL_COLLECTOR_ENDPOINT }}
+  run: dotnet test --filter "Category=Property"
+```
+
+## Populating test identity tags
+
+The `test.name` and `test.class.name` tags on the root `PropertyTest` span are populated automatically by the xUnit, NUnit, MSTest, and MTP adapters. When running `TestRunner` directly, set them via `ConjectureSettings`:
+
+```csharp
+ConjectureSettings settings = new()
+{
+    TestName = "My_property_description",
+    TestClassName = "MyTestClass",
+};
+```
+
+See the [telemetry reference](../reference/telemetry.md) for the full span and metric catalog.

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -19,6 +19,8 @@ items:
     href: use-source-generators.md
   - name: Configure logging
     href: configure-logging.md
+  - name: Configure OpenTelemetry observability
+    href: configure-otel.md
   - name: Use DataGen outside tests
     href: use-data-gen.md
   - name: Use the CLI tool

--- a/docs/site/articles/reference/settings.md
+++ b/docs/site/articles/reference/settings.md
@@ -26,6 +26,8 @@ Settings are resolved in this order (most specific wins):
 | `Logger` | `ILogger` | `NullLogger.Instance` | Structured logging sink. Adapters auto-wire framework output. |
 | `ExportReproOnFailure` | `bool` | `false` | Write the shrunk counterexample byte buffer to a file on failure. |
 | `ReproOutputPath` | `string` | `".conjecture/repros/"` | Directory for exported repro files. Used when `ExportReproOnFailure = true`. |
+| `TestName` | `string?` | `null` | Test method name. Populated automatically by framework adapters; populates the `test.name` tag on the `PropertyTest` trace span. |
+| `TestClassName` | `string?` | `null` | Test class name. Populated automatically by framework adapters; populates the `test.class.name` tag on the `PropertyTest` trace span. |
 
 ## `[Property]` attribute properties
 

--- a/docs/site/articles/reference/telemetry.md
+++ b/docs/site/articles/reference/telemetry.md
@@ -1,0 +1,132 @@
+# Telemetry reference
+
+Conjecture emits OpenTelemetry traces and metrics via the BCL `System.Diagnostics` APIs. Both are always available; they produce zero overhead when no listener is registered.
+
+See [How to configure OpenTelemetry observability](../how-to/configure-otel.md) for wiring instructions.
+
+## ActivitySource
+
+**Name:** `"Conjecture.Core"`
+**Version:** assembly informational version
+
+Subscribe with `source.Name == "Conjecture.Core"` in your `ActivityListener.ShouldListenTo` predicate.
+
+### Spans
+
+#### `PropertyTest`
+
+Root span — one per property test run.
+
+| Tag | Type | Description |
+|---|---|---|
+| `conjecture.seed` | `string` | Hex seed used for generation (e.g. `"0x00000000DEADBEEF"`), or `"random"` when no seed was pinned |
+| `conjecture.max_examples` | `int` | Value of `ConjectureSettings.MaxExamples` |
+| `test.name` | `string` | Test method name. Set by framework adapters; `null` when not configured |
+| `test.class.name` | `string` | Test class name. Set by framework adapters; `null` when not configured |
+| `test.status` | `string` | `"pass"` or `"fail"` — set immediately before the span is stopped |
+
+#### `PropertyTest.Generation`
+
+Child of `PropertyTest`. Wraps the generation loop.
+
+| Tag | Type | Description |
+|---|---|---|
+| `examples` | `int` | Number of valid examples generated |
+| `failures` | `int` | Number of failures found during generation (`0` or `1`) |
+| `rejections` | `int` | Number of examples rejected by `Assume.That()` |
+
+#### `PropertyTest.Shrinking`
+
+Child of `PropertyTest`. Only emitted when a failure was found and shrinking runs.
+
+| Tag | Type | Description |
+|---|---|---|
+| `reductions` | `int` | Number of successful shrink steps |
+
+#### `PropertyTest.Targeting`
+
+Child of `PropertyTest`. Only emitted when `ConjectureSettings.Targeting = true` and at least one label was observed during generation.
+
+| Tag | Type | Description |
+|---|---|---|
+| `labels` | `string` | Comma-separated list of targeting label names |
+| `best_score` | `double` | Highest score achieved across all labels |
+
+---
+
+## Meter
+
+**Name:** `"Conjecture.Core"`
+**Version:** assembly informational version
+
+Subscribe with `instrument.Meter.Name == "Conjecture.Core"` in your `MeterListener.InstrumentPublished` callback.
+
+### Metrics
+
+#### `conjecture.property.examples_total`
+
+**Type:** Counter (`long`)
+**Unit:** `{examples}`
+
+Total number of valid examples generated across all property test runs.
+
+#### `conjecture.property.failures_total`
+
+**Type:** Counter (`long`)
+**Unit:** `{failures}`
+
+Total number of failures found. One failure equals one failing property run, regardless of how many examples were generated.
+
+#### `conjecture.property.duration_seconds`
+
+**Type:** Histogram (`double`)
+**Unit:** `s`
+
+End-to-end duration of each property test run, in seconds. Recorded once per run, after generation (and targeting if applicable) completes.
+
+#### `conjecture.generation.rejections_total`
+
+**Type:** Counter (`long`)
+**Unit:** `{rejections}`
+
+Total number of examples rejected by `Assume.That()`. High values relative to `examples_total` indicate an over-constrained strategy.
+
+#### `conjecture.shrink.passes_total`
+
+**Type:** Counter (`long`)
+**Unit:** `{passes}`
+
+Number of shrink pass invocations. Tagged by pass name (e.g. `"ZeroBlocks"`, `"DeleteBlocks"`, `"LexMin"`). Only incremented when shrinking runs.
+
+#### `conjecture.shrink.reductions_total`
+
+**Type:** Counter (`long`)
+**Unit:** `{reductions}`
+
+Total number of successful shrink reductions across all passes.
+
+#### `conjecture.targeting.best_score`
+
+**Type:** Histogram (`double`)
+
+Final best score per targeting label at the end of each targeting phase. Tagged by label name. Only recorded when targeting runs.
+
+#### `conjecture.database.replays_total`
+
+**Type:** Counter (`long`)
+**Unit:** `{replays}`
+
+Number of stored failing examples replayed from the example database at the start of a run.
+
+#### `conjecture.database.saves_total`
+
+**Type:** Counter (`long`)
+**Unit:** `{saves}`
+
+Number of shrunk counterexamples saved to the example database.
+
+---
+
+## Schema URL
+
+The authoritative machine-readable schema is at `docs/telemetry-schema.json` in the repository. The schema URL is embedded as a tag on the `Meter` (`conjecture.schema.url`) for tooling integrations.

--- a/docs/site/articles/reference/toc.yml
+++ b/docs/site/articles/reference/toc.yml
@@ -15,3 +15,5 @@ items:
     href: time-strategies.md
   - name: Formatters
     href: formatters.md
+  - name: Telemetry
+    href: telemetry.md


### PR DESCRIPTION
## Description

Documents the OTel observability features shipped in cycles 69.1–69.3.

- **`how-to/configure-otel.md`** — step-by-step guide covering three approaches: BCL `ActivityListener`/`MeterListener` (zero dependencies), .NET Aspire (`AddOpenTelemetry`), and OTLP collector export in CI
- **`reference/telemetry.md`** — full reference for all emitted spans (`PropertyTest`, `PropertyTest.Generation`, `PropertyTest.Shrinking`, `PropertyTest.Targeting`) and 9 metrics instruments with types, units, and tag descriptions
- **`reference/settings.md`** — adds `TestName` and `TestClassName` to the settings table
- Both new pages wired into `toc.yml`

## Type of change

- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #252
Part of #69