### PR TITLE
Improves AI tooling configuration and PR template

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-model: sonnet
+model: haiku
 color: green
 description: >
   Writes minimal production code to make failing tests pass (TDD Green phase)

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -22,7 +22,7 @@ You will receive one or more of:
 ## Steps
 
 1. Run `dotnet format src/ --include <changed_cs_files> --exclude-diagnostics IDE0130 --verify-no-changes` — all formatting must be correct. If this fails, report as FIX_IMPLEMENTATION.
-2. Run `dotnet test src/` — full regression. All tests must pass. If any fail, report as FIX_IMPLEMENTATION.
+2. Run `dotnet test` scoped to the affected test project(s) — e.g. `dotnet test src/Conjecture.Core.Tests/`. Only run the full `dotnet test src/` if the change touches shared infrastructure (types in `Conjecture.Core` used across multiple projects). All tests must pass. If any fail, report as FIX_IMPLEMENTATION.
 3. Review the changed production files for reuse, quality, and efficiency issues (see below).
 
 ## Output format

--- a/.claude/agents/test-developer.md
+++ b/.claude/agents/test-developer.md
@@ -1,6 +1,6 @@
 ---
 name: test-developer
-model: sonnet
+model: haiku
 color: red
 description: >
   Writes failing xUnit tests for the Conjecture .NET project (TDD Red phase).
@@ -19,7 +19,7 @@ You will receive:
 
 ## Steps
 
-1. Explore the relevant production project to understand existing types, patterns, and conventions. Check `docs/decisions/` for relevant ADRs.
+1. Read the files explicitly referenced in the `## Test` section (type names, file paths). Only explore the broader production project if types or conventions are unclear from those files. Check `docs/decisions/` for relevant ADRs only if the issue references a design decision.
 2. Determine the test file location using the production→test mapping in CLAUDE.md.
 3. Write tests that:
    - Cover the happy path, boundary values, and at least one failure/edge case

--- a/.claude/skills/implement-cycle/SKILL.md
+++ b/.claude/skills/implement-cycle/SKILL.md
@@ -41,6 +41,31 @@ Print a summary line so the user knows what is being worked on:
 Cycle <cycle-number>: <title>  (#<sub-issue-number>)
 ```
 
+Mark the sub-issue **and its parent** as **In Progress** on the Conjecture Roadmap project
+(skip the parent update if it is already In Progress):
+
+```bash
+# Helper: set an issue to In Progress by issue number
+set_in_progress() {
+  local number=$1
+  local item_id=$(gh project item-list 2 --owner kommundsen --format json \
+    --jq ".items[] | select(.content.number == $number) | .id")
+  gh project item-edit --project-id PVT_kwHOAAZ3vM4BTArq --id "$item_id" \
+    --field-id PVTSSF_lAHOAAZ3vM4BTArqzhAYMcQ \
+    --single-select-option-id 47fc9ee4
+}
+
+# Mark sub-issue In Progress
+set_in_progress <sub-issue-number>
+
+# Mark parent In Progress only if not already
+PARENT_STATUS=$(gh project item-list 2 --owner kommundsen --format json \
+  --jq ".items[] | select(.content.number == <parent-number>) | .status")
+if [ "$PARENT_STATUS" != "In Progress" ]; then
+  set_in_progress <parent-number>
+fi
+```
+
 ### 2. Create a branch
 
 Branch name format: `feat/#<parent>-#<sub>-<slug>`

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -129,11 +129,54 @@ Key points to document: [bullet the main decisions already resolved in Steps 3�
 ```
 No `## Test` section for ADR sub-issues.
 
+**Assess cross-cutting concerns** after designing the implementation sub-issues:
+
+- Does `Conjecture.Mcp` expose this feature? If yes, append an MCP sub-issue.
+- Does the docs site need a new or updated page? If yes, append a docs sub-issue.
+
+Append them **in that order** after the last implementation sub-issue. They use the same
+milestone and labels as the other sub-issues.
+
+**MCP sub-issue body:**
+```markdown
+Part of #<parent>.
+
+## Dependencies
+- #<last-impl-sub-issue>
+
+## Implement
+
+Update `Conjecture.Mcp/` to expose the new feature as an MCP tool or update existing
+tool definitions. Key changes: [specific tools/resources to add or modify]
+
+## Test
+
+Verify the MCP tool surfaces the feature correctly.
+```
+
+**Docs sub-issue body:**
+```markdown
+Part of #<parent>.
+
+## Dependencies
+- #<mcp-sub-issue-or-last-impl>
+
+## Implement
+
+Invoke the `diataxis` skill to write or update documentation for <feature>.
+Key sections: [which doc types are needed — tutorial / how-to / reference / explanation]
+
+## Test
+
+N/A — reviewed by author.
+```
+
 **Sequencing rules:**
 - Dependencies flow forward — later sub-issues depend on earlier ones, never the reverse.
 - Shared infrastructure (a renderer, a base class) comes before anything that uses it.
 - CLI commands come after the core logic they call.
-- MCP/integration changes come last.
+- MCP sub-issues come after all implementation sub-issues.
+- Docs sub-issues come after MCP sub-issues (or after the last implementation sub-issue if no MCP).
 
 ## Step 8 — Create and link sub-issues
 
@@ -157,6 +200,13 @@ gh api repos/kommundsen/Conjecture/issues/<parent>/sub_issues \
 
 > Note: `jq` may not be available — use `--jq '.id'` in the `gh api` call directly (gh has
 > built-in jq support).
+
+Then add **every issue** — the parent and each sub-issue — to the Conjecture Roadmap project:
+
+```bash
+gh project item-add 2 --owner kommundsen \
+  --url "https://github.com/kommundsen/Conjecture/issues/<number>"
+```
 
 ## Step 9 — Add a tasklist comment to the parent issue
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 - [ ] New feature / strategy
 - [ ] Refactor (no behavior change)
 - [ ] Documentation / chore
+- [ ] AI tools adjustments
 
 ## Checklist
 

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -1,5 +1,5 @@
 - Be extremely concise in your responses. Sacrifice grammer for concision
-- Never auto-commit code. Commits are to be done by user.
+- Never auto-commit code. Commits are only to be done if explicitly prompted for.
 - Follow .editorconfig rules when writing code.
 - Use workspace-relative paths in all tool calls (not absolute paths)
 
@@ -66,6 +66,9 @@ Solution file: `src/Conjecture.slnx`
 | `src/Conjecture.Time/` | `src/Conjecture.Time.Tests/` |
 | `src/Conjecture.FSharp/` | `src/Conjecture.FSharp.Tests/` |
 | `src/Conjecture.FSharp.Expecto/` | `src/Conjecture.FSharp.Expecto.Tests/` |
+| `src/Conjecture.Interactive/` | `src/Conjecture.Interactive.Tests/` |
+| `src/Conjecture.LinqPad/` | `src/Conjecture.LinqPad.Tests/` |
+| `src/Conjecture.TestingPlatform/` | `src/Conjecture.TestingPlatform.Tests/` |
 | `src/Conjecture.Benchmarks/` | _(benchmark project, not a test project)_ |
 | `src/Conjecture.SelfTests/` | _(integration self-tests, no paired prod project)_ |
 


### PR DESCRIPTION
## Description

Improves the Claude Code harness configuration: tightens commit policy wording in CLAUDE.md, adds missing project-to-test mappings, and adds an "AI tools adjustments" change type to the PR template.

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [x] AI tools adjustments

## Checklist

- [ ] `dotnet test src/` passes
- [ ] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [ ] Follows `.editorconfig` code style