### PR TITLE
[255.1] HierarchyTypeModel: model for abstract base types with discovered subtypes

### DIFF
--- a/src/Conjecture.Generators.Tests/HierarchyTypeModelExtractorTests.cs
+++ b/src/Conjecture.Generators.Tests/HierarchyTypeModelExtractorTests.cs
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+using Conjecture.Generators;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Conjecture.Generators.Tests;
+
+public sealed class HierarchyTypeModelExtractorTests
+{
+    [Fact]
+    public void Extract_AbstractClassWithTwoArbitraryConcreteSubtypes_ReturnsModelWithBothSubtypes()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            [Arbitrary] public partial class Rectangle : Shape { public Rectangle(int width, int height) { } }
+            """,
+            "MyApp.Shape");
+
+        INamedTypeSymbol circleSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            [Arbitrary] public partial class Rectangle : Shape { public Rectangle(int width, int height) { } }
+            """,
+            "MyApp.Circle");
+
+        INamedTypeSymbol rectangleSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            [Arbitrary] public partial class Rectangle : Shape { public Rectangle(int width, int height) { } }
+            """,
+            "MyApp.Rectangle");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [circleSymbol, rectangleSymbol];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(model);
+        Assert.Equal(2, model.Subtypes.Length);
+        Assert.Equal("MyApp.Circle", model.Subtypes[0].FullyQualifiedName);
+        Assert.Equal("MyApp.Rectangle", model.Subtypes[1].FullyQualifiedName);
+    }
+
+    [Fact]
+    public void Extract_AbstractRecordWithArbitraryConcreteSubtypes_ReturnsModelWithSubtypes()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract record Figure;
+            [Arbitrary] public sealed partial record Triangle(int Base, int Height) : Figure;
+            [Arbitrary] public sealed partial record Diamond(int Diagonal1, int Diagonal2) : Figure;
+            """,
+            "MyApp.Figure");
+
+        INamedTypeSymbol triangleSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract record Figure;
+            [Arbitrary] public sealed partial record Triangle(int Base, int Height) : Figure;
+            [Arbitrary] public sealed partial record Diamond(int Diagonal1, int Diagonal2) : Figure;
+            """,
+            "MyApp.Triangle");
+
+        INamedTypeSymbol diamondSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract record Figure;
+            [Arbitrary] public sealed partial record Triangle(int Base, int Height) : Figure;
+            [Arbitrary] public sealed partial record Diamond(int Diagonal1, int Diagonal2) : Figure;
+            """,
+            "MyApp.Diamond");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [triangleSymbol, diamondSymbol];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(model);
+        Assert.Equal(2, model.Subtypes.Length);
+    }
+
+    [Fact]
+    public void Extract_AbstractBaseWithZeroQualifyingSubtypes_ReturnsNullAndDiagnostic()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Widget { }
+            """,
+            "MyApp.Widget");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.Null(model);
+        Assert.NotEmpty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public void Extract_IntermediateAbstractSubtype_ExcludesIntermediateFromModel()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Animal { }
+            public abstract class Quadruped : Animal { }
+            [Arbitrary] public partial class Dog : Quadruped { public Dog(string name) { } }
+            """,
+            "MyApp.Animal");
+
+        INamedTypeSymbol dogSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Animal { }
+            public abstract class Quadruped : Animal { }
+            [Arbitrary] public partial class Dog : Quadruped { public Dog(string name) { } }
+            """,
+            "MyApp.Dog");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [dogSymbol];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(model);
+        Assert.Single(model.Subtypes);
+        Assert.Equal("MyApp.Dog", model.Subtypes[0].FullyQualifiedName);
+    }
+
+    [Fact]
+    public void Extract_GenericAbstractBaseWithGenericConcreteSubtype_ThreadsTypeParametersThroughModel()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Container<T> { }
+            [Arbitrary] public partial class Box<T> : Container<T> { public Box(T value) { } }
+            """,
+            "MyApp.Container`1");
+
+        INamedTypeSymbol boxSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Container<T> { }
+            [Arbitrary] public partial class Box<T> : Container<T> { public Box(T value) { } }
+            """,
+            "MyApp.Box`1");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [boxSymbol];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.Empty(diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+        Assert.NotNull(model);
+        Assert.Single(model.TypeParameters);
+        Assert.Equal("T", model.TypeParameters[0]);
+        Assert.Single(model.Subtypes);
+    }
+
+    [Fact]
+    public void Extract_PopulatesHierarchyTypeModelFields()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            """,
+            "MyApp.Shape");
+
+        INamedTypeSymbol circleSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            """,
+            "MyApp.Circle");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [circleSymbol];
+        (HierarchyTypeModel? model, _) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.NotNull(model);
+        Assert.Equal("MyApp.Shape", model.FullyQualifiedName);
+        Assert.Equal("MyApp", model.Namespace);
+        Assert.Equal("Shape", model.TypeName);
+    }
+
+    [Fact]
+    public void Extract_SubtypeModelPopulatesProviderTypeName()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            """,
+            "MyApp.Shape");
+
+        INamedTypeSymbol circleSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            """,
+            "MyApp.Circle");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [circleSymbol];
+        (HierarchyTypeModel? model, _) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.NotNull(model);
+        Assert.NotEmpty(model.Subtypes);
+        string providerTypeName = model.Subtypes[0].ProviderTypeName;
+        Assert.NotEmpty(providerTypeName);
+        Assert.EndsWith("Arbitrary", providerTypeName);
+    }
+
+    private static INamedTypeSymbol CompileAndGetSymbol(string source, string metadataName)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(typeof(Conjecture.Core.ArbitraryAttribute).Assembly.Location),
+            ],
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        INamedTypeSymbol? symbol = compilation.GetTypeByMetadataName(metadataName);
+        Assert.NotNull(symbol);
+        return symbol;
+    }
+}

--- a/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
@@ -4,3 +4,6 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 CON203 | Conjecture | Error | Multiple partial constructors declared on [Arbitrary] type
 CON204 | Conjecture | Error | Primary constructor combined with partial constructor on [Arbitrary] type
+CON300 | Conjecture | Error | [Arbitrary] base type must be abstract
+CON301 | Conjecture | Error | [Arbitrary] base type must be a class or record, not an interface or struct
+CON302 | Conjecture | Error | No concrete [Arbitrary] subtypes found for abstract base type

--- a/src/Conjecture.Generators/DiagnosticDescriptors.cs
+++ b/src/Conjecture.Generators/DiagnosticDescriptors.cs
@@ -46,4 +46,28 @@ internal static class DiagnosticDescriptors
         category: "Conjecture",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor Con300 = new(
+        id: "CON300",
+        title: "Base type must be abstract",
+        messageFormat: "Type '{0}' must be abstract",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor Con301 = new(
+        id: "CON301",
+        title: "Base type must be a class or record",
+        messageFormat: "Type '{0}' must be a class or record, not {1}",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor Con302 = new(
+        id: "CON302",
+        title: "No concrete subtypes found",
+        messageFormat: "No concrete subtypes found for abstract type '{0}'",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/Conjecture.Generators/HierarchyTypeModel.cs
+++ b/src/Conjecture.Generators/HierarchyTypeModel.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+
+namespace Conjecture.Generators;
+
+internal record HierarchyTypeModel(
+    string FullyQualifiedName,
+    string Namespace,
+    string TypeName,
+    ImmutableArray<string> TypeParameters,
+    ImmutableArray<SubtypeModel> Subtypes);
+
+internal record SubtypeModel(
+    string FullyQualifiedName,
+    string ProviderTypeName);

--- a/src/Conjecture.Generators/HierarchyTypeModelExtractor.cs
+++ b/src/Conjecture.Generators/HierarchyTypeModelExtractor.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+
+namespace Conjecture.Generators;
+
+internal static class HierarchyTypeModelExtractor
+{
+    internal static (HierarchyTypeModel? Model, ImmutableArray<Diagnostic> Diagnostics)
+        Extract(INamedTypeSymbol baseSymbol, IEnumerable<INamedTypeSymbol> allArbitrarySymbols)
+    {
+        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+
+        // Validate base is abstract
+        if (!baseSymbol.IsAbstract)
+        {
+            diagnostics.Add(Diagnostic.Create(
+                DiagnosticDescriptors.Con300,
+                baseSymbol.Locations.FirstOrDefault(),
+                baseSymbol.Name));
+            return (null, diagnostics.ToImmutable());
+        }
+
+        // Validate base is class or record (not interface or struct)
+        if (baseSymbol.TypeKind is not TypeKind.Class)
+        {
+            diagnostics.Add(Diagnostic.Create(
+                DiagnosticDescriptors.Con301,
+                baseSymbol.Locations.FirstOrDefault(),
+                baseSymbol.Name,
+                baseSymbol.TypeKind));
+            return (null, diagnostics.ToImmutable());
+        }
+
+        // Collect type parameters from base
+        ImmutableArray<string>.Builder typeParams = ImmutableArray.CreateBuilder<string>();
+        foreach (ITypeParameterSymbol typeParam in baseSymbol.TypeParameters)
+        {
+            typeParams.Add(typeParam.Name);
+        }
+
+        // Get fully qualified name of base for comparison (use OriginalDefinition so generic Base<T> matches Base<int> in subtype chains)
+        string baseOriginalFqn = baseSymbol.OriginalDefinition.ToDisplayString(TypeModelExtractor.TypeNameFormat);
+        string baseFullyQualifiedName = baseSymbol.ToDisplayString(TypeModelExtractor.TypeNameFormat);
+
+        // Filter arbitrary symbols to those in the base's type hierarchy and not abstract
+        ImmutableArray<SubtypeModel>.Builder subtypes = ImmutableArray.CreateBuilder<SubtypeModel>();
+        foreach (INamedTypeSymbol arbitrarySymbol in allArbitrarySymbols)
+        {
+            // Skip abstract types
+            if (arbitrarySymbol.IsAbstract)
+            {
+                continue;
+            }
+
+            // Check if arbitrarySymbol extends baseSymbol using display-name comparison so it works across compilations
+            INamedTypeSymbol? currentBase = arbitrarySymbol.BaseType;
+            bool isInHierarchy = false;
+
+            while (currentBase is not null)
+            {
+                if (currentBase.OriginalDefinition.ToDisplayString(TypeModelExtractor.TypeNameFormat) == baseOriginalFqn)
+                {
+                    isInHierarchy = true;
+                    break;
+                }
+
+                currentBase = currentBase.BaseType;
+            }
+
+            if (isInHierarchy)
+            {
+                string providerTypeName = arbitrarySymbol.Name + "Arbitrary";
+                string fullyQualifiedName = arbitrarySymbol.ToDisplayString(TypeModelExtractor.TypeNameFormat);
+                subtypes.Add(new SubtypeModel(fullyQualifiedName, providerTypeName));
+            }
+        }
+
+        // Return null if no concrete subtypes found
+        if (subtypes.Count == 0)
+        {
+            diagnostics.Add(Diagnostic.Create(
+                DiagnosticDescriptors.Con302,
+                baseSymbol.Locations.FirstOrDefault(),
+                baseSymbol.Name));
+            return (null, diagnostics.ToImmutable());
+        }
+
+        // Build the model
+        string baseNamespace = baseSymbol.ContainingNamespace.ToDisplayString();
+        string baseTypeName = baseSymbol.Name;
+
+        HierarchyTypeModel model = new(
+            FullyQualifiedName: baseFullyQualifiedName,
+            Namespace: baseNamespace,
+            TypeName: baseTypeName,
+            TypeParameters: typeParams.ToImmutable(),
+            Subtypes: subtypes.ToImmutable());
+
+        return (model, diagnostics.ToImmutable());
+    }
+}


### PR DESCRIPTION
## Description

Adds `HierarchyTypeModel` and `HierarchyTypeModelExtractor` to `Conjecture.Generators` — the type model layer for sealed class hierarchy strategy generation.

- `HierarchyTypeModel` record captures an abstract base type with its concrete `[Arbitrary]`-decorated subtypes; `SubtypeModel` carries the FQN and derived provider type name (e.g. `CircleArbitrary`)
- `HierarchyTypeModelExtractor.Extract` filters a set of arbitrary symbols to concrete types in the base's inheritance chain; abstract intermediates are excluded
- CON300/301/302 diagnostic descriptors added to `DiagnosticDescriptors.cs` for invalid base types and missing concrete subtypes
- Hierarchy walk uses `OriginalDefinition` display-name comparison so generic bases (`Base<T>`) match correctly across separate compilations

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #257
Part of #255