### PR TITLE
[255.4] HierarchyDiagnostics: CON205 for non-decorated concrete subtypes

### DIFF
--- a/src/Conjecture.Generators.Tests/HierarchyTypeModelExtractorTests.cs
+++ b/src/Conjecture.Generators.Tests/HierarchyTypeModelExtractorTests.cs
@@ -19,6 +19,7 @@ public sealed class HierarchyTypeModelExtractorTests
     {
         INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Shape { }
             [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
@@ -28,6 +29,7 @@ public sealed class HierarchyTypeModelExtractorTests
 
         INamedTypeSymbol circleSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Shape { }
             [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
@@ -37,6 +39,7 @@ public sealed class HierarchyTypeModelExtractorTests
 
         INamedTypeSymbol rectangleSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Shape { }
             [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
@@ -59,6 +62,7 @@ public sealed class HierarchyTypeModelExtractorTests
     {
         INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract record Figure;
             [Arbitrary] public sealed partial record Triangle(int Base, int Height) : Figure;
@@ -68,6 +72,7 @@ public sealed class HierarchyTypeModelExtractorTests
 
         INamedTypeSymbol triangleSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract record Figure;
             [Arbitrary] public sealed partial record Triangle(int Base, int Height) : Figure;
@@ -77,6 +82,7 @@ public sealed class HierarchyTypeModelExtractorTests
 
         INamedTypeSymbol diamondSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract record Figure;
             [Arbitrary] public sealed partial record Triangle(int Base, int Height) : Figure;
@@ -114,6 +120,7 @@ public sealed class HierarchyTypeModelExtractorTests
     {
         INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Animal { }
             public abstract class Quadruped : Animal { }
@@ -123,6 +130,7 @@ public sealed class HierarchyTypeModelExtractorTests
 
         INamedTypeSymbol dogSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Animal { }
             public abstract class Quadruped : Animal { }
@@ -144,6 +152,7 @@ public sealed class HierarchyTypeModelExtractorTests
     {
         INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Container<T> { }
             [Arbitrary] public partial class Box<T> : Container<T> { public Box(T value) { } }
@@ -152,6 +161,7 @@ public sealed class HierarchyTypeModelExtractorTests
 
         INamedTypeSymbol boxSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Container<T> { }
             [Arbitrary] public partial class Box<T> : Container<T> { public Box(T value) { } }
@@ -173,6 +183,7 @@ public sealed class HierarchyTypeModelExtractorTests
     {
         INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Shape { }
             [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
@@ -181,6 +192,7 @@ public sealed class HierarchyTypeModelExtractorTests
 
         INamedTypeSymbol circleSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Shape { }
             [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
@@ -201,6 +213,7 @@ public sealed class HierarchyTypeModelExtractorTests
     {
         INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Shape { }
             [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
@@ -209,6 +222,7 @@ public sealed class HierarchyTypeModelExtractorTests
 
         INamedTypeSymbol circleSymbol = CompileAndGetSymbol(
             """
+            using Conjecture.Core;
             namespace MyApp;
             public abstract class Shape { }
             [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
@@ -225,7 +239,149 @@ public sealed class HierarchyTypeModelExtractorTests
         Assert.EndsWith("Arbitrary", providerTypeName);
     }
 
+    [Fact]
+    public void Extract_ConcreteSubtypeWithoutArbitraryAttribute_EmitsCon205()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            public partial class Circle : Shape { public Circle(int radius) { } }
+            """,
+            "MyApp.Shape");
+
+        INamedTypeSymbol circleSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            public partial class Circle : Shape { public Circle(int radius) { } }
+            """,
+            "MyApp.Circle");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [circleSymbol];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.Null(model);
+        Assert.Single(diagnostics.Where(d => d.Id == "CON302"));
+        Diagnostic con205 = Assert.Single(diagnostics.Where(d => d.Id == "CON205"));
+        Assert.Contains("Circle", con205.GetMessage());
+        Assert.Contains("Shape", con205.GetMessage());
+    }
+
+    [Fact]
+    public void Extract_ConcreteSubtypeWithArbitraryAttribute_DoesNotEmitCon205()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            using Conjecture.Core;
+            namespace MyApp;
+            public abstract class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            """,
+            "MyApp.Shape");
+
+        INamedTypeSymbol circleSymbol = CompileAndGetSymbol(
+            """
+            using Conjecture.Core;
+            namespace MyApp;
+            public abstract class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            """,
+            "MyApp.Circle");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [circleSymbol];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.Empty(diagnostics.Where(d => d.Id == "CON205"));
+    }
+
+    [Fact]
+    public void Extract_TwoNonDecoratedConcreteSubtypes_EmitsTwoCon205Diagnostics()
+    {
+        INamedTypeSymbol baseSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            public partial class Circle : Shape { public Circle(int radius) { } }
+            public partial class Rectangle : Shape { public Rectangle(int width, int height) { } }
+            """,
+            "MyApp.Shape");
+
+        INamedTypeSymbol circleSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            public partial class Circle : Shape { public Circle(int radius) { } }
+            public partial class Rectangle : Shape { public Rectangle(int width, int height) { } }
+            """,
+            "MyApp.Circle");
+
+        INamedTypeSymbol rectangleSymbol = CompileAndGetSymbol(
+            """
+            namespace MyApp;
+            public abstract class Shape { }
+            public partial class Circle : Shape { public Circle(int radius) { } }
+            public partial class Rectangle : Shape { public Rectangle(int width, int height) { } }
+            """,
+            "MyApp.Rectangle");
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [circleSymbol, rectangleSymbol];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols);
+
+        Assert.Null(model);
+        Assert.Single(diagnostics.Where(d => d.Id == "CON302"));
+        ImmutableArray<Diagnostic> con205Diagnostics = diagnostics.Where(d => d.Id == "CON205").ToImmutableArray();
+        Assert.Equal(2, con205Diagnostics.Length);
+    }
+
+    [Fact]
+    public void Extract_WithCompilation_SubtypeInBothArbitrarySymbolsAndCompilation_EmitsExactlyOneCon205()
+    {
+        const string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public abstract partial class Shape { }
+            public partial class Circle : Shape { public Circle(int radius) { } }
+            """;
+
+        (INamedTypeSymbol baseSymbol, CSharpCompilation compilation) = CompileAndGetSymbolWithCompilation(source, "MyApp.Shape");
+        INamedTypeSymbol circleSymbol = compilation.GetTypeByMetadataName("MyApp.Circle")!;
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [circleSymbol];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols, compilation);
+
+        Assert.Single(diagnostics.Where(d => d.Id == "CON205"));
+    }
+
+    [Fact]
+    public void Extract_WithCompilation_EmitsCon205ForSubtypeAbsentFromArbitrarySymbols()
+    {
+        const string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public abstract partial class Shape { }
+            [Arbitrary] public partial class Circle : Shape { public Circle(int radius) { } }
+            public partial class Square : Shape { public Square(int side) { } }
+            """;
+
+        (INamedTypeSymbol baseSymbol, CSharpCompilation compilation) = CompileAndGetSymbolWithCompilation(source, "MyApp.Shape");
+        INamedTypeSymbol circleSymbol = compilation.GetTypeByMetadataName("MyApp.Circle")!;
+
+        ImmutableArray<INamedTypeSymbol> arbitrarySymbols = [circleSymbol];
+        (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, arbitrarySymbols, compilation);
+
+        Diagnostic con205 = Assert.Single(diagnostics.Where(d => d.Id == "CON205"));
+        Assert.Contains("Square", con205.GetMessage());
+        Assert.Contains("Shape", con205.GetMessage());
+    }
+
     private static INamedTypeSymbol CompileAndGetSymbol(string source, string metadataName)
+    {
+        (INamedTypeSymbol symbol, _) = CompileAndGetSymbolWithCompilation(source, metadataName);
+        return symbol;
+    }
+
+    private static (INamedTypeSymbol Symbol, CSharpCompilation Compilation) CompileAndGetSymbolWithCompilation(string source, string metadataName)
     {
         string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
         CSharpCompilation compilation = CSharpCompilation.Create(
@@ -241,6 +397,6 @@ public sealed class HierarchyTypeModelExtractorTests
 
         INamedTypeSymbol? symbol = compilation.GetTypeByMetadataName(metadataName);
         Assert.NotNull(symbol);
-        return symbol;
+        return (symbol, compilation);
     }
 }

--- a/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
@@ -4,6 +4,7 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 CON203 | Conjecture | Error | Multiple partial constructors declared on [Arbitrary] type
 CON204 | Conjecture | Error | Primary constructor combined with partial constructor on [Arbitrary] type
+CON205 | Conjecture | Warning | Concrete subtype excluded from sealed hierarchy strategy; lacks [Arbitrary] attribute
 CON300 | Conjecture | Error | [Arbitrary] base type must be abstract
 CON301 | Conjecture | Error | [Arbitrary] base type must be a class or record, not an interface or struct
 CON302 | Conjecture | Error | No concrete [Arbitrary] subtypes found for abstract base type

--- a/src/Conjecture.Generators/ArbitraryGenerator.cs
+++ b/src/Conjecture.Generators/ArbitraryGenerator.cs
@@ -61,13 +61,15 @@ public sealed class ArbitraryGenerator : IIncrementalGenerator
 
         IncrementalValueProvider<ImmutableArray<INamedTypeSymbol>> allArbitrarySymbols = types.Collect();
 
-        IncrementalValuesProvider<(INamedTypeSymbol BaseSymbol, ImmutableArray<INamedTypeSymbol> AllSymbols)> hierarchyCombined =
-            abstractTypes.Combine(allArbitrarySymbols);
+        IncrementalValueProvider<Compilation> compilationProvider = context.CompilationProvider;
+
+        IncrementalValuesProvider<((INamedTypeSymbol BaseSymbol, ImmutableArray<INamedTypeSymbol> AllSymbols) Left, Compilation Right)> hierarchyCombined =
+            abstractTypes.Combine(allArbitrarySymbols).Combine(compilationProvider);
 
         context.RegisterSourceOutput(hierarchyCombined, static (ctx, item) =>
         {
-            (INamedTypeSymbol baseSymbol, ImmutableArray<INamedTypeSymbol> allSymbols) = item;
-            (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, allSymbols);
+            ((INamedTypeSymbol baseSymbol, ImmutableArray<INamedTypeSymbol> allSymbols), Compilation compilation) = item;
+            (HierarchyTypeModel? model, ImmutableArray<Diagnostic> diagnostics) = HierarchyTypeModelExtractor.Extract(baseSymbol, allSymbols, compilation);
 
             bool hasHierarchyError = false;
             foreach (Diagnostic d in diagnostics)

--- a/src/Conjecture.Generators/DiagnosticDescriptors.cs
+++ b/src/Conjecture.Generators/DiagnosticDescriptors.cs
@@ -47,6 +47,14 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    internal static readonly DiagnosticDescriptor Con205 = new(
+        id: "CON205",
+        title: "Concrete subtype excluded from sealed hierarchy strategy",
+        messageFormat: "'{0}' is a concrete subtype of '{1}' but lacks [Arbitrary]; it will not be included in the generated OneOf strategy. Add [Arbitrary] to include it.",
+        category: "Conjecture",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     internal static readonly DiagnosticDescriptor Con300 = new(
         id: "CON300",
         title: "Base type must be abstract",

--- a/src/Conjecture.Generators/HierarchyTypeModelExtractor.cs
+++ b/src/Conjecture.Generators/HierarchyTypeModelExtractor.cs
@@ -2,7 +2,6 @@
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
 using System.Collections.Immutable;
-using System.Linq;
 
 using Microsoft.CodeAnalysis;
 
@@ -11,11 +10,10 @@ namespace Conjecture.Generators;
 internal static class HierarchyTypeModelExtractor
 {
     internal static (HierarchyTypeModel? Model, ImmutableArray<Diagnostic> Diagnostics)
-        Extract(INamedTypeSymbol baseSymbol, IEnumerable<INamedTypeSymbol> allArbitrarySymbols)
+        Extract(INamedTypeSymbol baseSymbol, IEnumerable<INamedTypeSymbol> allArbitrarySymbols, Compilation? compilation = null)
     {
         ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
 
-        // Validate base is abstract
         if (!baseSymbol.IsAbstract)
         {
             diagnostics.Add(Diagnostic.Create(
@@ -25,7 +23,6 @@ internal static class HierarchyTypeModelExtractor
             return (null, diagnostics.ToImmutable());
         }
 
-        // Validate base is class or record (not interface or struct)
         if (baseSymbol.TypeKind is not TypeKind.Class)
         {
             diagnostics.Add(Diagnostic.Create(
@@ -36,51 +33,52 @@ internal static class HierarchyTypeModelExtractor
             return (null, diagnostics.ToImmutable());
         }
 
-        // Collect type parameters from base
         ImmutableArray<string>.Builder typeParams = ImmutableArray.CreateBuilder<string>();
         foreach (ITypeParameterSymbol typeParam in baseSymbol.TypeParameters)
         {
             typeParams.Add(typeParam.Name);
         }
 
-        // Get fully qualified name of base for comparison (use OriginalDefinition so generic Base<T> matches Base<int> in subtype chains)
+        // OriginalDefinition so generic Base<T> matches Base<int> in subtype chains
         string baseOriginalFqn = baseSymbol.OriginalDefinition.ToDisplayString(TypeModelExtractor.TypeNameFormat);
         string baseFullyQualifiedName = baseSymbol.ToDisplayString(TypeModelExtractor.TypeNameFormat);
 
-        // Filter arbitrary symbols to those in the base's type hierarchy and not abstract
+        HashSet<string> processedFqns = [];
+
         ImmutableArray<SubtypeModel>.Builder subtypes = ImmutableArray.CreateBuilder<SubtypeModel>();
         foreach (INamedTypeSymbol arbitrarySymbol in allArbitrarySymbols)
         {
-            // Skip abstract types
             if (arbitrarySymbol.IsAbstract)
             {
                 continue;
             }
 
-            // Check if arbitrarySymbol extends baseSymbol using display-name comparison so it works across compilations
-            INamedTypeSymbol? currentBase = arbitrarySymbol.BaseType;
-            bool isInHierarchy = false;
-
-            while (currentBase is not null)
+            if (!IsInHierarchy(arbitrarySymbol, baseOriginalFqn))
             {
-                if (currentBase.OriginalDefinition.ToDisplayString(TypeModelExtractor.TypeNameFormat) == baseOriginalFqn)
-                {
-                    isInHierarchy = true;
-                    break;
-                }
-
-                currentBase = currentBase.BaseType;
+                continue;
             }
 
-            if (isInHierarchy)
+            string fullyQualifiedName = arbitrarySymbol.ToDisplayString(TypeModelExtractor.TypeNameFormat);
+            processedFqns.Add(fullyQualifiedName);
+
+            if (!SymbolHelpers.HasArbitraryAttribute(arbitrarySymbol))
             {
-                string providerTypeName = arbitrarySymbol.Name + "Arbitrary";
-                string fullyQualifiedName = arbitrarySymbol.ToDisplayString(TypeModelExtractor.TypeNameFormat);
-                subtypes.Add(new SubtypeModel(fullyQualifiedName, providerTypeName));
+                diagnostics.Add(Diagnostic.Create(
+                    DiagnosticDescriptors.Con205,
+                    arbitrarySymbol.Locations.FirstOrDefault(),
+                    arbitrarySymbol.Name,
+                    baseSymbol.Name));
+                continue;
             }
+
+            subtypes.Add(new SubtypeModel(fullyQualifiedName, arbitrarySymbol.Name + "Arbitrary"));
         }
 
-        // Return null if no concrete subtypes found
+        if (compilation is not null)
+        {
+            WalkNamespace(compilation.GlobalNamespace, baseSymbol, baseOriginalFqn, diagnostics, processedFqns);
+        }
+
         if (subtypes.Count == 0)
         {
             diagnostics.Add(Diagnostic.Create(
@@ -90,7 +88,6 @@ internal static class HierarchyTypeModelExtractor
             return (null, diagnostics.ToImmutable());
         }
 
-        // Build the model
         string baseNamespace = baseSymbol.ContainingNamespace.ToDisplayString();
         string baseTypeName = baseSymbol.Name;
 
@@ -102,5 +99,82 @@ internal static class HierarchyTypeModelExtractor
             Subtypes: subtypes.ToImmutable());
 
         return (model, diagnostics.ToImmutable());
+    }
+
+    private static bool IsInHierarchy(INamedTypeSymbol symbol, string baseOriginalFqn)
+    {
+        INamedTypeSymbol? current = symbol.BaseType;
+        while (current is not null)
+        {
+            if (current.OriginalDefinition.ToDisplayString(TypeModelExtractor.TypeNameFormat) == baseOriginalFqn)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
+    }
+
+    private static void WalkNamespace(
+        INamespaceSymbol ns,
+        INamedTypeSymbol baseSymbol,
+        string baseOriginalFqn,
+        ImmutableArray<Diagnostic>.Builder diagnostics,
+        HashSet<string> processedFqns)
+    {
+        foreach (INamedTypeSymbol typeSymbol in ns.GetTypeMembers())
+        {
+            CheckTypeForMissingArbitraryAttribute(typeSymbol, baseSymbol, baseOriginalFqn, diagnostics, processedFqns);
+        }
+
+        foreach (INamespaceSymbol childNs in ns.GetNamespaceMembers())
+        {
+            WalkNamespace(childNs, baseSymbol, baseOriginalFqn, diagnostics, processedFqns);
+        }
+    }
+
+    private static void CheckTypeForMissingArbitraryAttribute(
+        INamedTypeSymbol typeSymbol,
+        INamedTypeSymbol baseSymbol,
+        string baseOriginalFqn,
+        ImmutableArray<Diagnostic>.Builder diagnostics,
+        HashSet<string> processedFqns)
+    {
+        if (typeSymbol.IsAbstract)
+        {
+            return;
+        }
+
+        if (!IsInHierarchy(typeSymbol, baseOriginalFqn))
+        {
+            foreach (INamedTypeSymbol nestedType in typeSymbol.GetTypeMembers())
+            {
+                CheckTypeForMissingArbitraryAttribute(nestedType, baseSymbol, baseOriginalFqn, diagnostics, processedFqns);
+            }
+
+            return;
+        }
+
+        string typeFqn = typeSymbol.ToDisplayString(TypeModelExtractor.TypeNameFormat);
+        if (!processedFqns.Add(typeFqn))
+        {
+            return;
+        }
+
+        if (!SymbolHelpers.HasArbitraryAttribute(typeSymbol))
+        {
+            diagnostics.Add(Diagnostic.Create(
+                DiagnosticDescriptors.Con205,
+                typeSymbol.Locations.FirstOrDefault(),
+                typeSymbol.Name,
+                baseSymbol.Name));
+        }
+
+        foreach (INamedTypeSymbol nestedType in typeSymbol.GetTypeMembers())
+        {
+            CheckTypeForMissingArbitraryAttribute(nestedType, baseSymbol, baseOriginalFqn, diagnostics, processedFqns);
+        }
     }
 }


### PR DESCRIPTION
## Description

Adds the CON205 diagnostic (Warning) that fires when a concrete subtype of an `[Arbitrary]`-decorated abstract base lacks its own `[Arbitrary]` attribute and will therefore be excluded from the generated `OneOf` strategy.

Detection runs in two passes:

1. **Loop pass** – symbols supplied via `allArbitrarySymbols` are checked with `SymbolHelpers.HasArbitraryAttribute`; undecorated in-hierarchy types emit CON205 and are skipped.
2. **Compilation walk** – when a `Compilation` is provided (production path via `CompilationProvider`), `WalkNamespace` scans all named types to catch concrete subtypes never seen by the `[Arbitrary]`-filtered provider.

A shared `IsInHierarchy` helper eliminates the duplicated base-chain traversal, and a `processedFqns` set deduplicates CON205 across both passes.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #260
Part of #255