### PR TITLE
[255.5] Docs: sealed class hierarchy strategies

### DIFF
--- a/docs/site/articles/explanation/sealed-hierarchy-strategies.md
+++ b/docs/site/articles/explanation/sealed-hierarchy-strategies.md
@@ -1,0 +1,62 @@
+# Understanding sealed hierarchy strategies
+
+C# developers model discriminated union-like types with a sealed abstract base class and a closed set of concrete subtypes. Conjecture's source generator recognizes this pattern and derives a `Generate.OneOf` strategy automatically.
+
+## The pattern
+
+Before native union types arrived in C#, the idiomatic way to represent a fixed set of alternatives was:
+
+```csharp
+public abstract class Shape { }
+public class Circle : Shape { }
+public class Rectangle : Shape { }
+```
+
+Pattern matching over such a hierarchy is exhaustive when the hierarchy is sealed — the compiler can verify you've handled every case. C# 14 formalized this with sealed class modifiers and `switch` exhaustiveness checks.
+
+When generating `Shape` values for property tests you want every subtype represented, not just one. `Generate.OneOf` is the right combinator: it picks uniformly among a set of strategies. Writing this by hand is mechanical repetition — exactly what a source generator should eliminate.
+
+## How the generator works
+
+When `[Arbitrary]` is applied to an abstract class, the generator switches to hierarchy mode:
+
+1. It walks the entire compilation looking for concrete classes that inherit (directly or indirectly) from the base.
+2. For each concrete subtype decorated with `[Arbitrary]`, it collects the subtype's own generated `IStrategyProvider<T>`.
+3. It emits a provider for the base type that calls `Generate.OneOf` over all the collected subtype strategies, casting each result up to the base type.
+
+The output for `Shape` / `Circle` / `Rectangle` looks like:
+
+```csharp
+public sealed class ShapeArbitrary : IStrategyProvider<Shape>
+{
+    public Strategy<Shape> Create() =>
+        Generate.OneOf(
+            new CircleArbitrary().Create().Select(static x => (Shape)x),
+            new RectangleArbitrary().Create().Select(static x => (Shape)x)
+        );
+}
+```
+
+Each subtype appears with equal probability. Shrinking works correctly because `Generate.OneOf` delegates shrinking to whichever branch was chosen.
+
+## The same-compilation constraint
+
+The generator only sees types in the current compilation. Subtypes defined in a referenced assembly are invisible to Roslyn's incremental generator pipeline — they are not part of the syntax tree being processed.
+
+This is intentional, not a limitation to work around. A hierarchy that spans assemblies is not a closed set from the generator's perspective: there is no way to enumerate all subtypes statically. The pattern is most useful precisely when the set of cases is closed and known at compile time.
+
+If you control an external subtype assembly and want it included, move the subtype into the same project, or define a manual `IStrategyProvider<Base>` implementation that assembles the `OneOf` by hand.
+
+Concrete subtypes that exist in the compilation but lack `[Arbitrary]` trigger a **CON205** warning so you don't silently miss a case.
+
+## Relationship to C# 15 union types
+
+C# 15 is expected to introduce a first-class `union` keyword that eliminates the sealed-abstract-class boilerplate and gives the compiler direct knowledge of the case set. Conjecture tracks this in [issue #79](https://github.com/kommundsen/Conjecture/issues/79).
+
+The current `[Arbitrary]`-on-abstract-base pattern is designed to migrate cleanly: the generator already treats the abstract base as a discriminated union. When native unions land, the plan is to recognize the `union` syntax directly without requiring `[Arbitrary]` on each case — the decorated-abstract-class form will remain supported for backward compatibility.
+
+## Further reading
+
+- [How to generate sealed class hierarchies](../how-to/use-sealed-hierarchy-strategies.md)
+- [Reference: Analyzers — CON205, CON300–CON302](../reference/analyzers.md#source-generator-diagnostics)
+- [How to use source generators](../how-to/use-source-generators.md) — the concrete-type path

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -3,6 +3,8 @@ items:
     href: property-based-testing.md
   - name: Shrinking
     href: shrinking.md
+  - name: Sealed hierarchy strategies
+    href: sealed-hierarchy-strategies.md
   - name: Targeted testing
     href: targeted-testing.md
   - name: The example database

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -17,6 +17,8 @@ items:
     href: manage-example-database.md
   - name: Use source generators
     href: use-source-generators.md
+  - name: Use sealed hierarchy strategies
+    href: use-sealed-hierarchy-strategies.md
   - name: Configure logging
     href: configure-logging.md
   - name: Configure OpenTelemetry observability

--- a/docs/site/articles/how-to/use-sealed-hierarchy-strategies.md
+++ b/docs/site/articles/how-to/use-sealed-hierarchy-strategies.md
@@ -1,0 +1,113 @@
+# How to generate sealed class hierarchies
+
+Annotate an abstract base class and each concrete subtype with `[Arbitrary]` to get a `Generate.OneOf` strategy that picks uniformly among all subtypes.
+
+## Requirements
+
+- The abstract base must be `abstract`, `partial`, and annotated with `[Arbitrary]`
+- Each subtype you want included must be `partial` and annotated with `[Arbitrary]`
+- All types must be in the same compilation (external assembly subtypes are not detected)
+
+## Steps
+
+### 1. Mark the abstract base
+
+```csharp
+using Conjecture.Core;
+
+[Arbitrary]
+public abstract partial class Shape { }
+```
+
+### 2. Mark each concrete subtype
+
+```csharp
+[Arbitrary]
+public partial class Circle : Shape
+{
+    public Circle(double radius) { }
+}
+
+[Arbitrary]
+public partial class Rectangle : Shape
+{
+    public Rectangle(double width, double height) { }
+}
+```
+
+The generator emits `ShapeArbitrary` that picks uniformly across all decorated subtypes:
+
+```csharp
+// Auto-generated
+public sealed class ShapeArbitrary : IStrategyProvider<Shape>
+{
+    public Strategy<Shape> Create() =>
+        Generate.OneOf(
+            new CircleArbitrary().Create().Select(static x => (Shape)x),
+            new RectangleArbitrary().Create().Select(static x => (Shape)x)
+        );
+}
+```
+
+### 3. Use it in a property test
+
+# [xUnit v2](#tab/xunit-v2)
+
+```csharp
+[Property]
+public bool Shape_area_is_non_negative([From<ShapeArbitrary>] Shape shape)
+{
+    return shape.Area() >= 0;
+}
+```
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+[Property]
+public bool Shape_area_is_non_negative([From<ShapeArbitrary>] Shape shape)
+{
+    return shape.Area() >= 0;
+}
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+[Property]
+public bool Shape_area_is_non_negative([From<ShapeArbitrary>] Shape shape)
+{
+    return shape.Area() >= 0;
+}
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+[Property]
+public bool Shape_area_is_non_negative([From<ShapeArbitrary>] Shape shape)
+{
+    return shape.Area() >= 0;
+}
+```
+
+***
+
+## Undecorated subtypes
+
+If a concrete subtype exists but is not annotated with `[Arbitrary]`, Conjecture emits a **CON205** warning at the subtype declaration site:
+
+```csharp
+[Arbitrary]
+public abstract partial class Shape { }
+
+public partial class Triangle : Shape { }  // CON205: excluded from ShapeArbitrary
+```
+
+`Triangle` will not appear in the generated `OneOf`. Add `[Arbitrary]` to include it, or suppress CON205 if exclusion is intentional.
+
+## See also
+
+- [Understanding sealed hierarchy strategies](../explanation/sealed-hierarchy-strategies.md) — design rationale and scope constraints
+- [Reference: Analyzers](analyzers.md) — CON205, CON300–CON302 diagnostic details
+- [How to use source generators](use-source-generators.md) — generating strategies for concrete types

--- a/docs/site/articles/reference/analyzers.md
+++ b/docs/site/articles/reference/analyzers.md
@@ -217,11 +217,27 @@ var pos = Generate.Integers<int>().Positive;
 
 The `[Arbitrary]` source generator reports its own set of diagnostics:
 
+### Concrete type diagnostics (CON200–CON202)
+
 | ID | Severity | Description |
 |---|---|---|
 | CON200 | Error | No accessible constructor found on `[Arbitrary]` type |
 | CON201 | Error | `[Arbitrary]` type is not `partial` |
 | CON202 | Warning | Constructor parameter type has no resolvable strategy |
+
+### Sealed hierarchy diagnostics (CON205, CON300–CON302)
+
+These fire when `[Arbitrary]` is applied to an abstract class (hierarchy mode).
+
+| ID | Severity | Description |
+|---|---|---|
+| CON205 | Warning | Concrete subtype of `[Arbitrary]`-decorated abstract base lacks `[Arbitrary]`; it will not be included in the generated `OneOf` strategy |
+| CON300 | Error | `[Arbitrary]` base type is not abstract |
+| CON301 | Error | `[Arbitrary]` base type is not a class or record (interfaces are not supported) |
+| CON302 | Error | No concrete `[Arbitrary]`-decorated subtypes found in compilation |
+
+> [!NOTE]
+> The generator only detects subtypes in the same compilation. Subtypes defined in external assemblies are silently excluded — CON205 does not fire for them. See [Understanding sealed hierarchy strategies](../explanation/sealed-hierarchy-strategies.md#the-same-compilation-constraint) for details.
 
 ## Suppressing diagnostics
 


### PR DESCRIPTION
## Description

Adds documentation for the sealed class hierarchy strategy feature introduced in cycles 255.1–255.4.

Three pieces of content:

- **How-to** (`how-to/use-sealed-hierarchy-strategies.md`): step-by-step guide for annotating an abstract base and its concrete subtypes with `[Arbitrary]`, showing the generated `OneOf` output and usage in a `[Property]` test via `[From<ShapeArbitrary>]`. Includes a note on CON205 for undecorated subtypes.
- **Explanation** (`explanation/sealed-hierarchy-strategies.md`): design rationale for the sealed-abstract-class discriminated union pattern, how the generator walks the compilation to produce `Generate.OneOf`, the same-compilation scope constraint and why it's intentional, and the planned migration path to C# 15 native `union` types (#79).
- **Reference update** (`reference/analyzers.md`): extends the source generator diagnostics section with CON205 and CON300–CON302 in a dedicated "Sealed hierarchy diagnostics" subsection, plus a NOTE on the same-compilation scope limitation.

Both toc.yml files updated to wire in the new pages.

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #271
Part of #255