### PR TITLE
Switch developer and test-developer agents back to sonnet

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,6 +1,6 @@
 ---
 name: developer
-model: haiku
+model: sonnet
 color: green
 description: >
   Writes minimal production code to make failing tests pass (TDD Green phase)

--- a/.claude/agents/test-developer.md
+++ b/.claude/agents/test-developer.md
@@ -1,6 +1,6 @@
 ---
 name: test-developer
-model: haiku
+model: sonnet
 color: red
 description: >
   Writes failing xUnit tests for the Conjecture .NET project (TDD Red phase).


### PR DESCRIPTION
## Description

Switches the `developer` and `test-developer` subagents from `haiku` back to `sonnet` in their frontmatter.

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [x] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes (no production code changed)
- [x] New behavior is covered by tests (N/A — agent config only)
- [x] Follows `.editorconfig` code style