### PR TITLE
[65.1] GenCore: scaffold Conjecture.FSharp and define Gen<'a> type and Gen module

### DIFF
--- a/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
+++ b/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="GenTests.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.FSharp\Conjecture.FSharp.fsproj" />
+    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Conjecture.FSharp.Tests/GenTests.fs
+++ b/src/Conjecture.FSharp.Tests/GenTests.fs
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Tests.GenTests
+
+open Xunit
+open Conjecture
+open Conjecture.Core
+
+[<Fact>]
+let ``Gen.constant creates a generator that always produces the same value`` () =
+    let value = 42
+    let gen = Gen.constant value
+    let sample = DataGen.SampleOne(gen |> Gen.unwrap)
+    Assert.Equal(value, sample)
+
+[<Fact>]
+let ``Gen.map applies a function to generated values`` () =
+    let gen = Gen.constant 42 |> Gen.map ((*) 2)
+    let sample = DataGen.SampleOne(gen |> Gen.unwrap)
+    Assert.Equal(84, sample)
+
+[<Fact>]
+let ``Gen.int generates values within the specified range`` () =
+    let gen = Gen.int (1, 10)
+    let samples = Conjecture.Core.DataGen.Stream(gen |> Gen.unwrap, 10)
+    for sample in samples do
+        Assert.True(sample >= 1 && sample <= 10)
+
+[<Fact>]
+let ``Gen.filter produces only values that satisfy the predicate`` () =
+    let gen = Gen.int (1, 10) |> Gen.filter (fun x -> x > 5)
+    let samples = Conjecture.Core.DataGen.Stream(gen |> Gen.unwrap, 10)
+    for sample in samples do
+        Assert.True(sample > 5 && sample <= 10)
+
+[<Fact>]
+let ``Gen.oneOf produces values from one of the given generators`` () =
+    let gen = Gen.oneOf [Gen.constant 1; Gen.constant 2]
+    let samples = Conjecture.Core.DataGen.Stream(gen |> Gen.unwrap, 10)
+    for sample in samples do
+        Assert.True(sample = 1 || sample = 2)
+
+[<Fact>]
+let ``open Conjecture brings Gen into scope`` () =
+    // This test verifies that after 'open Conjecture', we can use Gen without module qualification
+    let gen = Gen.constant 42
+    let sample = DataGen.SampleOne(gen |> Gen.unwrap)
+    Assert.Equal(42, sample)
+
+[<Fact>]
+let ``Gen.bind chains generators together`` () =
+    let gen = Gen.constant 5 |> Gen.bind (fun x -> Gen.constant (x * 3))
+    let sample = DataGen.SampleOne(gen |> Gen.unwrap)
+    Assert.Equal(15, sample)
+
+[<Fact>]
+let ``Gen.float generates values within the specified range`` () =
+    let gen = Gen.float (0.0, 1.0)
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 10)
+    for sample in samples do
+        Assert.True(sample >= 0.0 && sample <= 1.0)
+
+[<Fact>]
+let ``Gen.string generates strings with length in the specified range`` () =
+    let gen = Gen.string (3, 5)
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 10)
+    for sample in samples do
+        let len = String.length sample
+        Assert.True(len >= 3 && len <= 5)
+
+[<Fact>]
+let ``Gen.bool generates only true or false`` () =
+    let gen = Gen.bool
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 10)
+    for sample in samples do
+        Assert.True(sample = true || sample = false)

--- a/src/Conjecture.FSharp/Conjecture.FSharp.fsproj
+++ b/src/Conjecture.FSharp/Conjecture.FSharp.fsproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>F# support for Conjecture.NET property-based testing</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Gen.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Conjecture.FSharp/Gen.fs
+++ b/src/Conjecture.FSharp/Gen.fs
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture
+
+open Conjecture.Core
+
+[<Struct>]
+type Gen<'a> = internal Gen of Strategy: Strategy<'a>
+
+module Gen =
+    let unwrap (gen: Gen<'a>) : Strategy<'a> =
+        let (Gen s) = gen
+        s
+
+    let constant (value: 'a) : Gen<'a> =
+        Gen(Generate.Just(value))
+
+    let map (f: 'a -> 'b) (gen: Gen<'a>) : Gen<'b> =
+        let strategy = unwrap gen
+        Gen(StrategyExtensions.Select(strategy, System.Func<_, _>(f)))
+
+    let filter (predicate: 'a -> bool) (gen: Gen<'a>) : Gen<'a> =
+        let strategy = unwrap gen
+        Gen(StrategyExtensions.Where(strategy, System.Func<_, _>(predicate)))
+
+    let bind (f: 'a -> Gen<'b>) (gen: Gen<'a>) : Gen<'b> =
+        let strategy = unwrap gen
+        let selector (a: 'a) : Strategy<'b> = unwrap (f a)
+        Gen(StrategyExtensions.SelectMany(strategy, System.Func<_, _>(selector)))
+
+    let oneOf (gens: Gen<'a> list) : Gen<'a> =
+        let strategies = List.toArray (List.map unwrap gens)
+        Gen(Generate.OneOf(strategies))
+
+    let int (range: int * int) : Gen<int> =
+        let (min, max) = range
+        Gen(Generate.Integers<int>(min, max))
+
+    let float (range: float * float) : Gen<float> =
+        let (min, max) = range
+        Gen(Generate.Doubles(min, max))
+
+    let string (range: int * int) : Gen<string> =
+        let (minLen, maxLen) = range
+        Gen(Generate.Strings(minLen, maxLen))
+
+    let bool : Gen<bool> =
+        Gen(Generate.Booleans())

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -30,4 +30,6 @@
   <Project Path="Conjecture.TestingPlatform.Tests/Conjecture.TestingPlatform.Tests.csproj" />
   <Project Path="Conjecture.LinqPad/Conjecture.LinqPad.csproj" />
   <Project Path="Conjecture.LinqPad.Tests/Conjecture.LinqPad.Tests.csproj" />
+  <Project Path="Conjecture.FSharp/Conjecture.FSharp.fsproj" />
+  <Project Path="Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj" />
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -67,5 +67,8 @@
     <PackageVersion Include="Microsoft.Testing.Platform" Version="1.9.1" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="1.9.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="1.9.1" />
+
+    <!-- F# -->
+    <PackageVersion Include="FSharp.Core" Version="10.1.201" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Scaffolds the `Conjecture.FSharp` project and implements the foundational `Gen<'a>` type and `Gen` module, giving F# users an idiomatic API for property-based testing.

- New `Conjecture.FSharp` project (net10.0) referencing `Conjecture.Core`
- New `Conjecture.FSharp.Tests` project; both added to the solution
- `[<Struct>] type Gen<'a>` wraps `Strategy<'a>` from Conjecture.Core
- `module Gen` with: `constant`, `map`, `filter`, `bind`, `oneOf`, `int`, `float`, `string`, `bool`, `unwrap`
- Placed in `namespace Conjecture` so `open Conjecture` brings `Gen` into scope
- `FSharp.Core 10.1.201` added to central package management

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #262
Part of #65