### PR TITLE
[65.2] GenBuilder: gen { } computation expression with and! support

### DIFF
--- a/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
+++ b/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="GenTests.fs" />
+    <Compile Include="GenBuilderTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.FSharp.Tests/GenBuilderTests.fs
+++ b/src/Conjecture.FSharp.Tests/GenBuilderTests.fs
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Tests.GenBuilderTests
+
+open Xunit
+open Conjecture
+open Conjecture.Core
+
+[<Fact>]
+let ``gen builder with return produces the value`` () =
+    let result = gen {
+        return 42
+    }
+    let sample = DataGen.SampleOne(result |> Gen.unwrap)
+    Assert.Equal(42, sample)
+
+[<Fact>]
+let ``gen builder with let! and return chains generators`` () =
+    let result = gen {
+        let! x = Gen.int (0, 10)
+        return x * 2
+    }
+    let samples = DataGen.Stream(result |> Gen.unwrap, 20)
+    for sample in samples do
+        Assert.True(sample >= 0 && sample <= 20)
+        Assert.True(sample % 2 = 0)
+
+[<Fact>]
+let ``gen builder with and! combines generators`` () =
+    let result = gen {
+        let! x = Gen.int (0, 10)
+        and! y = Gen.bool
+        return x, y
+    }
+    let samples = DataGen.Stream(result |> Gen.unwrap, 20)
+    for sample in samples do
+        let (x, y) = sample
+        Assert.True(x >= 0 && x <= 10)
+        Assert.True(y = true || y = false)
+
+[<Fact>]
+let ``gen builder with multiple let! bindings produces correct range`` () =
+    let result = gen {
+        let! x = Gen.int (1, 5)
+        let! y = Gen.int (1, 5)
+        return x + y
+    }
+    let samples = DataGen.Stream(result |> Gen.unwrap, 30)
+    for sample in samples do
+        Assert.True(sample >= 2 && sample <= 10)
+
+[<Fact>]
+let ``gen builder with nested blocks composes correctly`` () =
+    let innerGen = gen {
+        let! x = Gen.int (1, 3)
+        return x * 2
+    }
+    let outerGen = gen {
+        let! doubled = innerGen
+        let! y = Gen.int (1, 3)
+        return doubled + y
+    }
+    let samples = DataGen.Stream(outerGen |> Gen.unwrap, 30)
+    for sample in samples do
+        Assert.True(sample >= 3 && sample <= 9)

--- a/src/Conjecture.FSharp/Conjecture.FSharp.fsproj
+++ b/src/Conjecture.FSharp/Conjecture.FSharp.fsproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <Compile Include="Gen.fs" />
+    <Compile Include="GenBuilder.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.FSharp/GenBuilder.fs
+++ b/src/Conjecture.FSharp/GenBuilder.fs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture
+
+type GenBuilder() =
+    member _.Bind(gen: Gen<'a>, f: 'a -> Gen<'b>) : Gen<'b> =
+        Gen.bind f gen
+
+    member _.Return(value: 'a) : Gen<'a> =
+        Gen.constant value
+
+    member _.ReturnFrom(gen: Gen<'a>) : Gen<'a> =
+        gen
+
+    member _.MergeSources(gen1: Gen<'a>, gen2: Gen<'b>) : Gen<'a * 'b> =
+        gen1 |> Gen.bind (fun a -> gen2 |> Gen.map (fun b -> a, b))
+
+[<AutoOpen>]
+module GenBuilderValue =
+    let gen = GenBuilder()


### PR DESCRIPTION
## Description

Adds `GenBuilder` — the F# computation expression builder that enables `gen { }` syntax for composing generators in `Conjecture.FSharp`.

- `Bind` handles `let!` bindings via `Gen.bind`
- `Return` / `ReturnFrom` handle `return` / `return!`
- `MergeSources` enables `and!` parallel binding, producing `Gen<'a * 'b>` tuples
- `[<AutoOpen>]` module exposes the `gen` value automatically on `open Conjecture`

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #263
Part of #65