### PR TITLE
[65.3] GenFSharpTypes: built-in generators for F# list, option, Result, Map, Set, seq, and tuples

### DIFF
--- a/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
+++ b/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="GenTests.fs" />
     <Compile Include="GenBuilderTests.fs" />
+    <Compile Include="GenFSharpTypesTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.FSharp.Tests/GenFSharpTypesTests.fs
+++ b/src/Conjecture.FSharp.Tests/GenFSharpTypesTests.fs
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Tests.GenFSharpTypesTests
+
+open Xunit
+open Conjecture
+open Conjecture.Core
+
+[<Fact>]
+let ``Gen.list produces int list values`` () =
+    let gen = Gen.list (Gen.int (0, 10))
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 20)
+    for sample in samples do
+        for element in sample do
+            Assert.True(element >= 0 && element <= 10)
+
+[<Fact>]
+let ``Gen.option produces Some values`` () =
+    let gen = Gen.option Gen.bool
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 100)
+    let hasSome = samples |> Seq.exists Option.isSome
+    Assert.True(hasSome)
+
+[<Fact>]
+let ``Gen.option produces None values`` () =
+    let gen = Gen.option Gen.bool
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 100)
+    let hasNone = samples |> Seq.exists Option.isNone
+    Assert.True(hasNone)
+
+[<Fact>]
+let ``Gen.option Some values are true or false`` () =
+    let gen = Gen.option Gen.bool
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 50)
+    for sample in samples do
+        match sample with
+        | Some v -> Assert.True(v = true || v = false)
+        | None -> ()
+
+[<Fact>]
+let ``Gen.result produces Ok cases`` () =
+    let gen = Gen.result (Gen.int (0, 10)) (Gen.string (0, 5))
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 100)
+    let hasOk = samples |> Seq.exists (fun r -> match r with | Ok _ -> true | Error _ -> false)
+    Assert.True(hasOk)
+
+[<Fact>]
+let ``Gen.result produces Error cases`` () =
+    let gen = Gen.result (Gen.int (0, 10)) (Gen.string (0, 5))
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 100)
+    let hasError = samples |> Seq.exists (fun r -> match r with | Ok _ -> false | Error _ -> true)
+    Assert.True(hasError)
+
+[<Fact>]
+let ``Gen.result Ok values are within range`` () =
+    let gen = Gen.result (Gen.int (0, 10)) (Gen.string (0, 5))
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 50)
+    for sample in samples do
+        match sample with
+        | Ok v -> Assert.True(v >= 0 && v <= 10)
+        | Error _ -> ()
+
+[<Fact>]
+let ``Gen.set produces Set with deduplicated elements`` () =
+    let gen = Gen.set (Gen.int (0, 5))
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 20)
+    for sample in samples do
+        let asList = sample |> Set.toList
+        let asDistinct = asList |> List.distinct
+        Assert.Equal(asList.Length, asDistinct.Length)
+
+[<Fact>]
+let ``Gen.set elements are within the generator range`` () =
+    let gen = Gen.set (Gen.int (0, 5))
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 20)
+    for sample in samples do
+        for element in sample do
+            Assert.True(element >= 0 && element <= 5)
+
+[<Fact>]
+let ``Gen.tuple2 covers all four bool combinations across enough samples`` () =
+    let gen = Gen.tuple2 Gen.bool Gen.bool
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 200) |> Seq.toList
+    let hasFF = samples |> List.exists (fun (a, b) -> a = false && b = false)
+    let hasFT = samples |> List.exists (fun (a, b) -> a = false && b = true)
+    let hasTF = samples |> List.exists (fun (a, b) -> a = true && b = false)
+    let hasTT = samples |> List.exists (fun (a, b) -> a = true && b = true)
+    Assert.True(hasFF)
+    Assert.True(hasFT)
+    Assert.True(hasTF)
+    Assert.True(hasTT)
+
+[<Fact>]
+let ``Gen.tuple2 produces pairs with correct types`` () =
+    let gen = Gen.tuple2 Gen.bool Gen.bool
+    let sample = DataGen.SampleOne(gen |> Gen.unwrap)
+    let (a, b) = sample
+    Assert.True(a = true || a = false)
+    Assert.True(b = true || b = false)
+
+[<Fact>]
+let ``Gen.seq produces seq of int values within range`` () =
+    let gen = Gen.seq (Gen.int (0, 3))
+    let sample = DataGen.SampleOne(gen |> Gen.unwrap)
+    for element in sample do
+        Assert.True(element >= 0 && element <= 3)
+
+[<Fact>]
+let ``Gen.seq result type is seq of int`` () =
+    let gen : Gen<seq<int>> = Gen.seq (Gen.int (0, 3))
+    let sample : seq<int> = DataGen.SampleOne(gen |> Gen.unwrap)
+    Assert.True(sample |> Seq.forall (fun e -> e >= 0 && e <= 3))

--- a/src/Conjecture.FSharp/Gen.fs
+++ b/src/Conjecture.FSharp/Gen.fs
@@ -47,3 +47,39 @@ module Gen =
 
     let bool : Gen<bool> =
         Gen(Generate.Booleans())
+
+    let list (gen: Gen<'a>) : Gen<'a list> =
+        let inner = unwrap gen
+        Gen(StrategyExtensions.Select(Generate.Lists(inner), System.Func<_, _>(fun (lst: System.Collections.Generic.List<'a>) -> lst |> Seq.toList)))
+
+    let option (gen: Gen<'a>) : Gen<'a option> =
+        Gen(StrategyExtensions.SelectMany(
+            Generate.Booleans(),
+            System.Func<_, _>(fun flag ->
+                if flag then
+                    StrategyExtensions.Select(unwrap gen, System.Func<_, _>(Some))
+                else
+                    Generate.Just(None))))
+
+    let result (okGen: Gen<'ok>) (errGen: Gen<'err>) : Gen<Result<'ok, 'err>> =
+        Gen(StrategyExtensions.SelectMany(
+            Generate.Booleans(),
+            System.Func<_, _>(fun flag ->
+                if flag then
+                    StrategyExtensions.Select(unwrap okGen, System.Func<_, _>(Ok))
+                else
+                    StrategyExtensions.Select(unwrap errGen, System.Func<_, _>(Error)))))
+
+    let set (gen: Gen<'a>) : Gen<Set<'a>> =
+        let inner = unwrap gen
+        Gen(StrategyExtensions.Select(Generate.Lists(inner), System.Func<_, _>(fun (lst: System.Collections.Generic.List<'a>) -> lst |> Set.ofSeq)))
+
+    let seq (gen: Gen<'a>) : Gen<seq<'a>> =
+        let inner = unwrap gen
+        Gen(StrategyExtensions.Select(Generate.Lists(inner), System.Func<_, _>(fun (lst: System.Collections.Generic.List<'a>) -> lst :> seq<'a>)))
+
+    let tuple2 (genA: Gen<'a>) (genB: Gen<'b>) : Gen<'a * 'b> =
+        Gen(StrategyExtensions.SelectMany(
+            unwrap genA,
+            System.Func<_, _>(fun a ->
+                StrategyExtensions.Select(unwrap genB, System.Func<_, _>(fun b -> (a, b))))))


### PR DESCRIPTION
## Description

Adds F# collection and type generators to the `Gen` module in `Conjecture.FSharp`:

- `Gen.list` — wraps `Generate.Lists` to produce `'a list`
- `Gen.option` — 50/50 coin flip yielding `Some` or `None`
- `Gen.result` — 50/50 coin flip yielding `Ok` or `Error` from separate generators
- `Gen.set` — produces `Set<'a>` with deduplication via `Set.ofSeq`
- `Gen.seq` — upcasts the generated `List<'a>` to `seq<'a>`
- `Gen.tuple2` — monadic bind over two generators to produce F# tuple pairs

All functions added directly to `Gen.fs` (F# does not support clean partial module definitions across files).

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #264
Part of #65