### PR TITLE
[65.4] GenAuto: Gen.auto<'a> via FSharp.Reflection for records and discriminated unions

### DIFF
--- a/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
+++ b/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="GenTests.fs" />
     <Compile Include="GenBuilderTests.fs" />
     <Compile Include="GenFSharpTypesTests.fs" />
+    <Compile Include="GenAutoTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.FSharp.Tests/GenAutoTests.fs
+++ b/src/Conjecture.FSharp.Tests/GenAutoTests.fs
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Tests.GenAutoTests
+
+open Xunit
+open Conjecture
+open Conjecture.Core
+
+type Color = Red | Green | Blue
+type Shape = Circle of float | Rectangle of float * float
+type Person = { Name: string; Age: int }
+type Tree = Leaf | Node of Tree * Tree
+type Inf = A of Inf
+type MutA = { B: MutB }
+and MutB = { A: MutA }
+
+[<Fact>]
+let ``Gen.auto produces all Color cases across sufficient samples`` () =
+    let gen = Gen.auto<Color> ()
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 200) |> Seq.toList
+    Assert.True(samples |> List.exists (fun c -> c = Red))
+    Assert.True(samples |> List.exists (fun c -> c = Green))
+    Assert.True(samples |> List.exists (fun c -> c = Blue))
+
+[<Fact>]
+let ``Gen.auto produces Circle case for Shape`` () =
+    let gen = Gen.auto<Shape> ()
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 200) |> Seq.toList
+    let hasCircle = samples |> List.exists (fun s -> match s with | Circle _ -> true | _ -> false)
+    Assert.True(hasCircle)
+
+[<Fact>]
+let ``Gen.auto produces Rectangle case for Shape`` () =
+    let gen = Gen.auto<Shape> ()
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 200) |> Seq.toList
+    let hasRectangle = samples |> List.exists (fun s -> match s with | Rectangle _ -> true | _ -> false)
+    Assert.True(hasRectangle)
+
+[<Fact>]
+let ``Gen.auto produces Person records with string names`` () =
+    let gen = Gen.auto<Person> ()
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 100) |> Seq.toList
+    for person in samples do
+        Assert.True(person.Name.GetType() = typeof<string>)
+
+[<Fact>]
+let ``Gen.auto produces Person records across multiple samples`` () =
+    let gen = Gen.auto<Person> ()
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 100) |> Seq.toList
+    Assert.Equal(100, samples.Length)
+
+[<Fact>]
+let ``Gen.auto falls through to built-in int generator`` () =
+    let gen = Gen.auto<int> ()
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 10) |> Seq.toList
+    Assert.Equal(10, samples.Length)
+
+[<Fact>]
+let ``Gen.auto falls through to built-in string generator`` () =
+    let gen = Gen.auto<string> ()
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 10) |> Seq.toList
+    Assert.Equal(10, samples.Length)
+
+[<Fact>]
+let ``Gen.auto for deeply nested Tree DU terminates without infinite recursion`` () =
+    let gen = Gen.auto<Tree> ()
+    let samples = DataGen.Stream(gen |> Gen.unwrap, 20) |> Seq.toList
+    Assert.True(samples.Length > 0)
+
+[<Fact>]
+let ``Gen.auto for all-recursive DU with no base cases throws NotSupportedException`` () =
+    Assert.Throws<System.NotSupportedException>(fun () ->
+        let gen = Gen.auto<Inf> ()
+        DataGen.SampleOne(gen |> Gen.unwrap) |> ignore)
+
+[<Fact>]
+let ``Gen.auto for mutually recursive record types throws NotSupportedException`` () =
+    Assert.Throws<System.NotSupportedException>(fun () ->
+        let gen = Gen.auto<MutA> ()
+        DataGen.SampleOne(gen |> Gen.unwrap) |> ignore)

--- a/src/Conjecture.FSharp/Gen.fs
+++ b/src/Conjecture.FSharp/Gen.fs
@@ -3,7 +3,11 @@
 
 namespace Conjecture
 
+open System
+open System.Collections.Generic
+open System.Diagnostics.CodeAnalysis
 open Conjecture.Core
+open Microsoft.FSharp.Reflection
 
 [<Struct>]
 type Gen<'a> = internal Gen of Strategy: Strategy<'a>
@@ -83,3 +87,75 @@ module Gen =
             unwrap genA,
             System.Func<_, _>(fun a ->
                 StrategyExtensions.Select(unwrap genB, System.Func<_, _>(fun b -> (a, b))))))
+
+    let private combineFieldGens (gens: Gen<obj> list) : Gen<obj list> =
+        gens
+        |> List.fold
+            (fun accGen fieldGen ->
+                accGen
+                |> bind (fun (acc: obj list) ->
+                    fieldGen |> map (fun v -> v :: acc)))
+            (constant [])
+
+    [<RequiresUnreferencedCode("Uses FSharp.Reflection and is not trim-safe.")>]
+    let rec private autoWithDepth (cache: Dictionary<struct (int * Type), Gen<obj>>) (depth: int) (t: Type) : Gen<obj> =
+        let key = struct (depth, t)
+        match cache.TryGetValue(key) with
+        | true, cached -> cached
+        | false, _ ->
+            let gen =
+                if FSharpType.IsRecord(t) then
+                    let fields = FSharpType.GetRecordFields(t)
+                    if depth <= 0 && fields.Length > 0 then
+                        raise (NotSupportedException($"Gen.auto cannot generate type '{t.FullName}': depth limit reached."))
+                    let fieldGens =
+                        fields
+                        |> Array.map (fun f -> autoWithDepth cache (depth - 1) f.PropertyType)
+                        |> Array.toList
+                    combineFieldGens fieldGens
+                    |> map (fun values ->
+                        let result = FSharpValue.MakeRecord(t, values |> List.rev |> List.toArray)
+                        Unchecked.nonNull result)
+                elif FSharpType.IsUnion(t) then
+                    let cases = FSharpType.GetUnionCases(t)
+                    let baseCases = cases |> Array.filter (fun c -> c.GetFields().Length = 0)
+                    if depth <= 0 && baseCases.Length = 0 then
+                        raise (NotSupportedException($"Gen.auto cannot generate type '{t.FullName}': depth limit reached with no base cases."))
+                    let effectiveCases =
+                        if depth <= 0 && baseCases.Length > 0 then baseCases else cases
+                    let caseGens =
+                        effectiveCases
+                        |> Array.map (fun case ->
+                            let fieldTypes = case.GetFields()
+                            if fieldTypes.Length = 0 then
+                                constant (Unchecked.nonNull (FSharpValue.MakeUnion(case, [||])))
+                            else
+                                let fieldGens =
+                                    fieldTypes
+                                    |> Array.map (fun f -> autoWithDepth cache (depth - 1) f.PropertyType)
+                                    |> Array.toList
+                                combineFieldGens fieldGens
+                                |> map (fun values ->
+                                    Unchecked.nonNull (FSharpValue.MakeUnion(case, values |> List.rev |> List.toArray))))
+                        |> Array.toList
+                    oneOf caseGens
+                elif t = typeof<int> then
+                    int (-1000, 1000) |> map (fun x -> x :> obj)
+                elif t = typeof<string> then
+                    string (0, 20) |> map (fun x -> x :> obj)
+                elif t = typeof<bool> then
+                    bool |> map (fun x -> x :> obj)
+                elif t = typeof<float> then
+                    float (-1000.0, 1000.0) |> map (fun x -> x :> obj)
+                elif t = typeof<float32> then
+                    float (-1000.0, 1000.0) |> map (fun x -> float32 x :> obj)
+                else
+                    raise (NotSupportedException($"Gen.auto does not support type: {t.FullName}"))
+            cache[key] <- gen
+            gen
+
+    [<RequiresUnreferencedCode("Uses FSharp.Reflection and is not trim-safe.")>]
+    let auto<'a> () : Gen<'a> =
+        let cache = Dictionary<struct (int * Type), Gen<obj>>()
+        autoWithDepth cache 3 typeof<'a> |> map (fun o -> o :?> 'a)
+


### PR DESCRIPTION
## Description

Implements `Gen.auto<'a>()` in `Conjecture.FSharp`, enabling reflection-based automatic generation for F# records, discriminated unions, and primitives — without requiring the user to wire up generators manually.

Resolution order:
1. F# records — each field generated recursively, constructed with `FSharpValue.MakeRecord`
2. Discriminated unions — a case sampled uniformly, fields generated recursively, constructed with `FSharpValue.MakeUnion`
3. Primitives — int, string, bool, float, float32 delegated to built-in generators
4. Anything else — `NotSupportedException` with a descriptive message

A depth limit of 3 prevents infinite recursion for recursive types (`Tree`, mutually recursive records). When the limit is reached with no base case available, `NotSupportedException` is raised rather than stack-overflowing. A per-call `Dictionary` cache avoids redundant reflection work within a single `auto<'a>()` invocation. Annotated `[<RequiresUnreferencedCode>]` as it is not trim-safe.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #265
Part of #65