### PR TITLE
[65.5] FSharpProperty: F#-idiomatic property support with %A counterexample formatting

### DIFF
--- a/src/Conjecture.Core/Conjecture.Core.csproj
+++ b/src/Conjecture.Core/Conjecture.Core.csproj
@@ -47,6 +47,9 @@
       <_Parameter1>Conjecture.Xunit</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Conjecture.FSharp</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Conjecture.Xunit.Tests</_Parameter1>
     </AssemblyAttribute>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
+++ b/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="GenBuilderTests.fs" />
     <Compile Include="GenFSharpTypesTests.fs" />
     <Compile Include="GenAutoTests.fs" />
+    <Compile Include="FSharpPropertyTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.FSharp.Tests/FSharpPropertyTests.fs
+++ b/src/Conjecture.FSharp.Tests/FSharpPropertyTests.fs
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Tests.FSharpPropertyTests
+
+open Xunit
+open Conjecture
+open Conjecture.Core
+
+type Point = { X: int; Y: int }
+
+[<Fact>]
+let ``PropertyRunner.runBool failing property reports Failed with F# record format`` () =
+    task {
+        let gen = Gen.auto<Point> ()
+        let! result = PropertyRunner.runBool gen (fun p -> p.X > 100 && p.Y > 100)
+        match result with
+        | PropertyResult.Failed message ->
+            Assert.Contains("{ X =", message)
+            Assert.Contains("Y =", message)
+        | PropertyResult.Passed ->
+            Assert.Fail("Expected property to fail but it passed")
+    }
+
+[<Fact>]
+let ``PropertyRunner.runBool failing property does not use C# record format`` () =
+    task {
+        let gen = Gen.auto<Point> ()
+        let! result = PropertyRunner.runBool gen (fun p -> p.X > 100 && p.Y > 100)
+        match result with
+        | PropertyResult.Failed message ->
+            Assert.DoesNotContain("Point {", message)
+        | PropertyResult.Passed ->
+            Assert.Fail("Expected property to fail but it passed")
+    }
+
+[<Fact>]
+let ``PropertyRunner.runUnit failing property reports Failed with counterexample`` () =
+    task {
+        let gen = Gen.auto<Point> ()
+        let! result = PropertyRunner.runUnit gen (fun _ ->
+            raise (System.Exception("always fails")))
+        match result with
+        | PropertyResult.Failed message ->
+            Assert.NotNull(message)
+            Assert.True(message.Length > 0)
+        | PropertyResult.Passed ->
+            Assert.Fail("Expected property to fail but it passed")
+    }
+
+[<Fact>]
+let ``PropertyRunner.runBool passing property reports Passed`` () =
+    task {
+        let gen = Gen.auto<Point> ()
+        let! result = PropertyRunner.runBool gen (fun _ -> true)
+        Assert.Equal(PropertyResult.Passed, result)
+    }
+
+[<Fact>]
+let ``PropertyRunner.runUnit passing property reports Passed`` () =
+    task {
+        let gen = Gen.auto<Point> ()
+        let! result = PropertyRunner.runUnit gen (fun _ -> ())
+        Assert.Equal(PropertyResult.Passed, result)
+    }

--- a/src/Conjecture.FSharp/Conjecture.FSharp.fsproj
+++ b/src/Conjecture.FSharp/Conjecture.FSharp.fsproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <Compile Include="Gen.fs" />
     <Compile Include="GenBuilder.fs" />
+    <Compile Include="FSharpFormatter.fs" />
+    <Compile Include="PropertyRunner.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.FSharp/FSharpFormatter.fs
+++ b/src/Conjecture.FSharp/FSharpFormatter.fs
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture
+
+open Microsoft.FSharp.Reflection
+
+module FSharpFormatter =
+    let private isFSharpType (t: System.Type) =
+        FSharpType.IsRecord(t) || FSharpType.IsUnion(t) || FSharpType.IsTuple(t)
+
+    let format (value: obj) : string =
+        if isFSharpType (value.GetType()) then sprintf "%A" value
+        else
+            match value.ToString() with
+            | null -> value.GetType().Name
+            | s -> s

--- a/src/Conjecture.FSharp/PropertyRunner.fs
+++ b/src/Conjecture.FSharp/PropertyRunner.fs
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture
+
+open System.Collections.Generic
+open System.Threading.Tasks
+open Conjecture.Core
+open Conjecture.Core.Internal
+
+/// Result of running a property test via <see cref="PropertyRunner"/>.
+[<RequireQualifiedAccess>]
+type PropertyResult =
+    | Passed
+    | Failed of message: string
+
+module PropertyRunner =
+    let private defaultSettings = ConjectureSettings()
+
+    let private buildMessage (gen: Gen<'a>) (nodes: IReadOnlyList<IRNode>) (seed: uint64) (exampleCount: int) (shrinkCount: int) : string =
+        let replay = ConjectureData.ForRecord(nodes)
+        let value = (Gen.unwrap gen).Generate(replay)
+        let formatted = FSharpFormatter.format (value :> obj)
+        sprintf "Falsifying example found after %d examples (shrunk %d times)\nCounterexample: %s\nReproduce with: [Property(Seed = 0x%X)]" exampleCount shrinkCount formatted seed
+
+    /// Runs a bool-returning property. <c>false</c> is treated as a test failure.
+    let runBool (gen: Gen<'a>) (test: 'a -> bool) : Task<PropertyResult> =
+        task {
+            let strategy = Gen.unwrap gen
+            let! result =
+                TestRunner.Run(defaultSettings, fun (data: ConjectureData) ->
+                    let value = strategy.Generate(data)
+                    if not (test value) then
+                        raise (System.Exception("Property returned false"))
+                )
+            if result.Passed then
+                return PropertyResult.Passed
+            else
+                match result.Counterexample with
+                | null -> return PropertyResult.Failed "Property failed (counterexample unavailable)"
+                | nodes ->
+                    let msg = buildMessage gen nodes result.Seed.Value result.ExampleCount result.ShrinkCount
+                    return PropertyResult.Failed msg
+        }
+
+    /// Runs a unit-returning property. Any exception thrown is treated as a test failure.
+    let runUnit (gen: Gen<'a>) (test: 'a -> unit) : Task<PropertyResult> =
+        task {
+            let strategy = Gen.unwrap gen
+            let! result =
+                TestRunner.Run(defaultSettings, fun (data: ConjectureData) ->
+                    let value = strategy.Generate(data)
+                    test value
+                )
+            if result.Passed then
+                return PropertyResult.Passed
+            else
+                match result.Counterexample with
+                | null -> return PropertyResult.Failed "Property failed (counterexample unavailable)"
+                | nodes ->
+                    let msg = buildMessage gen nodes result.Seed.Value result.ExampleCount result.ShrinkCount
+                    return PropertyResult.Failed msg
+        }


### PR DESCRIPTION
## Description

Adds `FSharpFormatter` and `PropertyRunner` modules to `Conjecture.FSharp`, enabling F#-idiomatic property testing with `%A`-formatted counterexample output.

- `FSharpFormatter.format` detects F# records, unions, and tuples and formats them with `sprintf "%A"`; falls back to `ToString()` for other types
- `PropertyRunner.runBool` accepts a `Gen<'a>` and a `'a -> bool` predicate — `false` return is treated as a test failure
- `PropertyRunner.runUnit` accepts a `Gen<'a>` and a `'a -> unit` function — any exception is treated as a test failure
- Both functions return a `PropertyResult` (Passed | Failed of message) with a shrunken, `%A`-formatted counterexample
- `InternalsVisibleTo` added for `Conjecture.FSharp` in Core so `PropertyRunner` can drive `TestRunner.Run` and `Strategy<T>.Generate` directly

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #266
Part of #65