### PR TITLE
[65.6] Expecto: scaffold Conjecture.FSharp.Expecto and implement property combinator

### DIFF
--- a/src/Conjecture.FSharp.Expecto.Tests/Conjecture.FSharp.Expecto.Tests.fsproj
+++ b/src/Conjecture.FSharp.Expecto.Tests/Conjecture.FSharp.Expecto.Tests.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ExpectoPropertyTests.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Expecto" />
+    <PackageReference Include="FSharp.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.FSharp.Expecto\Conjecture.FSharp.Expecto.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Conjecture.FSharp.Expecto.Tests/ExpectoPropertyTests.fs
+++ b/src/Conjecture.FSharp.Expecto.Tests/ExpectoPropertyTests.fs
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Expecto.Tests.ExpectoPropertyTests
+
+open Expecto
+open Conjecture.FSharp.Expecto
+
+/// Run a single Test synchronously via Expecto's CLI runner and return the exit code.
+let private runTest (t: Test) : int =
+    runTestsWithCLIArgs [] [||] t
+
+let tests =
+    testList "Conjecture.FSharp.Expecto.property" [
+
+        testCase "always-true bool property passes" <| fun () ->
+            let t = property "always true" (fun (x: int) -> true)
+            let exitCode = runTest t
+            Expect.equal exitCode 0 "always-true property should report 0 failures"
+
+        testCase "always-false bool property fails" <| fun () ->
+            let t = property "always false" (fun (x: int) -> false)
+            // Either exit code is non-zero or the runner throws — both indicate failure.
+            let failed =
+                try
+                    let exitCode = runTest t
+                    exitCode <> 0
+                with _ ->
+                    true
+            Expect.isTrue failed "always-false property should report at least one failure"
+
+        testCase "unit assertion-style property passes" <| fun () ->
+            // Uses the unit-returning overload of `property`.
+            let t : Test = property "assertion style" (fun (xs: int list) -> ignore (List.rev (List.rev xs)))
+            let exitCode = runTest t
+            Expect.equal exitCode 0 "unit-returning property that never throws should pass"
+
+        testCase "properties compose into testList without error" <| fun () ->
+            let suite =
+                testList "composed" [
+                    property "p1" (fun (x: int) -> true)
+                    property "p2" (fun (s: string) -> true)
+                ]
+            // Composition must not raise; a non-null Test value is sufficient.
+            Expect.isNotNull (box suite) "testList composition should produce a non-null Test value"
+    ]

--- a/src/Conjecture.FSharp.Expecto.Tests/Program.fs
+++ b/src/Conjecture.FSharp.Expecto.Tests/Program.fs
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Expecto.Tests.Program
+
+open Expecto
+
+[<EntryPoint>]
+let main argv =
+    runTestsWithCLIArgs [] argv ExpectoPropertyTests.tests

--- a/src/Conjecture.FSharp.Expecto/Conjecture.FSharp.Expecto.fsproj
+++ b/src/Conjecture.FSharp.Expecto/Conjecture.FSharp.Expecto.fsproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Description>Expecto integration for Conjecture.FSharp property-based testing</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Property.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Expecto" />
+    <PackageReference Include="FSharp.Core" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.FSharp\Conjecture.FSharp.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Conjecture.FSharp.Expecto/Property.fs
+++ b/src/Conjecture.FSharp.Expecto/Property.fs
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Expecto
+
+open Expecto
+open Conjecture
+
+let property (name: string) (test: 'a -> 'r) : Test =
+    testCase name (fun () ->
+        let handleResult result =
+            match result with
+            | PropertyResult.Passed -> ()
+            | PropertyResult.Failed msg -> failwith msg
+        let returnType = typeof<'r>
+        if returnType = typeof<bool> then
+            let boolTest = fun a -> test a |> box |> unbox<bool>
+            PropertyRunner.runBool (Gen.auto<'a> ()) boolTest |> Async.AwaitTask |> Async.RunSynchronously |> handleResult
+        elif returnType = typeof<unit> then
+            let unitTest = test >> ignore
+            PropertyRunner.runUnit (Gen.auto<'a> ()) unitTest |> Async.AwaitTask |> Async.RunSynchronously |> handleResult
+        else
+            failwithf "property: unsupported return type '%s'. Use 'a -> bool or 'a -> unit." typeof<'r>.Name)

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -32,4 +32,6 @@
   <Project Path="Conjecture.LinqPad.Tests/Conjecture.LinqPad.Tests.csproj" />
   <Project Path="Conjecture.FSharp/Conjecture.FSharp.fsproj" />
   <Project Path="Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj" />
+  <Project Path="Conjecture.FSharp.Expecto/Conjecture.FSharp.Expecto.fsproj" />
+  <Project Path="Conjecture.FSharp.Expecto.Tests/Conjecture.FSharp.Expecto.Tests.fsproj" />
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -70,5 +70,6 @@
 
     <!-- F# -->
     <PackageVersion Include="FSharp.Core" Version="10.1.201" />
+    <PackageVersion Include="Expecto" Version="10.2.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Scaffolds the `Conjecture.FSharp.Expecto` project and implements the `property` combinator, which wraps a Conjecture property run as an Expecto `Test` value. Supports both `'a -> bool` (falsification style) and `'a -> unit` (assertion style) via a single generic function with runtime dispatch. Unsupported return types raise a clear error rather than silently passing.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #267
Part of #65