### PR TITLE
[65.7] Docs: tutorial, how-to, and reference for Conjecture.FSharp

### DIFF
--- a/docs/site/articles/explanation/fsharp-wrapper.md
+++ b/docs/site/articles/explanation/fsharp-wrapper.md
@@ -1,0 +1,90 @@
+# Why F# has its own Conjecture package
+
+Conjecture.NET's core is written in C#. F# can call it directly — `Strategy<T>` is just a class — but doing so produces code that doesn't look or feel like F#. `Conjecture.FSharp` is a thin wrapper that bridges the gap.
+
+## The problem with calling C# from F# directly
+
+C# APIs reflect C# idioms: `Func<T, TResult>`, fluent extension methods, mutable `List<T>`, null-returning overloads, PascalCase members. F# code that leans on them reads awkwardly:
+
+```fsharp
+// C# API, called from F#
+let s : Strategy<int> =
+    StrategyExtensions.Select(
+        Generate.Integers(0, 100),
+        System.Func<_, _>(fun x -> x * 2))
+```
+
+Compare with the wrapper:
+
+```fsharp
+let s : Gen<int> =
+    Gen.int (0, 100) |> Gen.map (fun x -> x * 2)
+```
+
+Both do the same thing. The second one looks like F#.
+
+## What the wrapper actually does
+
+`Gen<'a>` is a `[<Struct>]` DU wrapping `Strategy<'a>`:
+
+```fsharp
+[<Struct>]
+type Gen<'a> = internal Gen of Strategy: Strategy<'a>
+```
+
+The `Gen` module is a hand-curated F# surface over `Generate.*` and `StrategyExtensions.*`, with:
+
+- Tuples for ranges (`int * int`) instead of positional overloads
+- F# collection types as outputs (`'a list`, `'a option`, `Set<'a>`)
+- Lowercase `camelCase` module functions
+- `|>`-friendly parameter order: the generator comes last
+
+The `GenBuilder` computation expression wraps `bind`/`map`/`MergeSources` so you can write:
+
+```fsharp
+gen {
+    let! x = Gen.int (0, 100)
+    let! y = Gen.int (0, 100)
+    return x + y
+}
+```
+
+Nothing magical — just sugar for `Gen.bind` calls. The same technique powers `async { }`, `task { }`, and many F# DSLs.
+
+## Counterexample formatting
+
+C# records print as `Point { X = 5, Y = 3 }`. F# records print as `{ X = 5; Y = 3 }`. F# unions print as `Circle 5.0`, not `Shape+Circle`. These differences aren't decorative — they're the syntax you'd type to reconstruct the value.
+
+`FSharpFormatter` detects F# records, unions, and tuples via `FSharpType` and routes them through `sprintf "%A"`. Everything else falls back to `ToString()`. `PropertyRunner` uses this formatter when building failure messages, so counterexamples come back in copy-pasteable F# syntax.
+
+## Why not just use Hedgehog or FsCheck?
+
+Both exist and are excellent. `Conjecture.FSharp` exists because:
+
+- **Single engine.** Conjecture's shrinker, replay database, and targeted-testing infrastructure all live in `Conjecture.Core`. The F# wrapper inherits every improvement to the core without a parallel F# port.
+- **Mixed-language projects.** A solution with C# production code and F# tests (or vice versa) can share a single strategy catalog and example database.
+- **Trim and AOT alignment.** As the core moves toward trim-safety, the wrapper tracks those annotations (see [the reference](../reference/fsharp-gen.md#trim-safety)).
+
+The wrapper doesn't compete with Hedgehog — it exposes the Conjecture engine to F# developers who are already in a Conjecture-adjacent codebase.
+
+## The Expecto integration
+
+`Conjecture.FSharp.Expecto` adds one function:
+
+```fsharp
+val property : string -> ('a -> 'r) -> Test
+```
+
+It's an Expecto-native alternative to the xUnit/NUnit/MSTest adapters. The function inspects `'r` at runtime, picks `PropertyRunner.runBool` or `PropertyRunner.runUnit`, runs the test synchronously via `Async.RunSynchronously`, and converts a failure into `failwith` so Expecto reports it. The name `property` was chosen to match the Expecto convention (`testCase`, `testList`, `testProperty`-style naming).
+
+## Trade-offs
+
+- **Reflection via `FSharp.Reflection`.** `Gen.auto` is convenient but not trim-safe. Use it when trimming isn't on; write generators by hand when it is.
+- **No built-in stateful DSL yet.** Commands-as-DU is the idiomatic pattern, but there's no equivalent of C#'s stateful-testing helpers in the F# module. This is tracked as future work.
+- **No `[<Property>]` attribute for xUnit-on-F#.** You can still reference `Conjecture.Xunit`'s `[<Property>]` from F# — it's the same attribute — but F#-specific attributes (Expecto-style) are the recommended path.
+
+## See also
+
+- [Reference: the `Gen` module](../reference/fsharp-gen.md)
+- [Tutorial: F# property tests](../tutorials/08-fsharp-property-tests.md)
+- [How-to: `Gen.auto` for records and unions](../how-to/use-fsharp-gen-auto.md)

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -9,3 +9,5 @@ items:
     href: targeted-testing.md
   - name: The example database
     href: example-database.md
+  - name: Why F# has its own package
+    href: fsharp-wrapper.md

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -29,6 +29,8 @@ items:
     href: use-cli-tool.md
   - name: Use time strategies
     href: use-time-strategies.md
+  - name: Use Gen.auto for F# records and unions
+    href: use-fsharp-gen-auto.md
   - name: Explore strategies interactively
     href: explore-strategies.md
   - name: Use the MCP server

--- a/docs/site/articles/how-to/use-fsharp-gen-auto.md
+++ b/docs/site/articles/how-to/use-fsharp-gen-auto.md
@@ -1,0 +1,115 @@
+# Use `Gen.auto` for F# records and unions
+
+`Gen.auto<'a> ()` derives a generator for any F# record, discriminated union, or primitive type using reflection. Use it when you don't need fine control over field values.
+
+## Records
+
+```fsharp
+open Conjecture
+
+type Customer = { Id: int; Name: string; IsActive: bool }
+
+let customerGen : Gen<Customer> = Gen.auto<Customer> ()
+```
+
+Every record field gets a default generator: `int` → `-1000..1000`, `string` → length `0..20`, `bool` → booleans, `float`/`float32` → `-1000.0..1000.0`.
+
+## Discriminated unions
+
+```fsharp
+type Shape =
+    | Circle of radius: float
+    | Rectangle of width: float * height: float
+    | Point
+
+let shapeGen : Gen<Shape> = Gen.auto<Shape> ()
+```
+
+`Gen.auto` picks a case uniformly, then recurses into its fields. Cases with no fields (like `Point`) are treated as base cases and prevent infinite recursion.
+
+## Nested and recursive types
+
+`Gen.auto` recurses up to a fixed depth (3 levels). Mutually recursive types terminate at a zero-field case:
+
+```fsharp
+type Tree =
+    | Leaf
+    | Node of int * Tree * Tree
+
+let treeGen : Gen<Tree> = Gen.auto<Tree> ()
+```
+
+At the depth limit, `Gen.auto` picks a zero-field case if one exists; otherwise it throws `NotSupportedException`. If your DU has no base case, write the generator by hand with `Gen.oneOf` and an explicit recursion depth.
+
+## Concurrent draws with `and!`
+
+The `gen { }` computation expression supports `and!` to express independent draws:
+
+```fsharp
+let pair =
+    gen {
+        let! x = Gen.int (0, 10)
+        and! y = Gen.int (100, 200)
+        return (x, y)
+    }
+```
+
+Compared to a chain of `let!`, `and!` signals that the two draws are independent — there's no data dependency between them. The compiler routes this through `GenBuilder.MergeSources` and the result is the same as `Gen.tuple2`.
+
+## Stateful tests via DU commands
+
+Conjecture.FSharp does not yet have a built-in stateful-testing DSL. The idiomatic F# pattern is to represent commands as a DU and generate a list:
+
+```fsharp
+type StackCmd<'a> =
+    | Push of 'a
+    | Pop
+    | Peek
+
+let cmdGen : Gen<StackCmd<int>> =
+    Gen.oneOf [
+        Gen.int (0, 100) |> Gen.map Push
+        Gen.constant Pop
+        Gen.constant Peek
+    ]
+
+let programGen : Gen<StackCmd<int> list> = Gen.list cmdGen
+```
+
+Run each generated program against a real implementation and a reference model, asserting they agree. When Conjecture finds a failing sequence, shrinking reduces both the command count and the values inside each command.
+
+## Use with Expecto
+
+```fsharp
+open Conjecture.FSharp.Expecto
+
+[<Tests>]
+let tests =
+    testList "customers" [
+        property "round-trip serialization preserves customer" (fun (c: Customer) ->
+            let serialized = Json.serialize c
+            let deserialized : Customer = Json.deserialize serialized
+            c = deserialized)
+    ]
+```
+
+`property` internally calls `Gen.auto<'a> ()`. For custom generators, drop to `PropertyRunner.runBool`/`runUnit` directly:
+
+```fsharp
+testCase "custom generator" <| fun () ->
+    let gen =
+        gen {
+            let! id = Gen.int (1, 1_000_000)
+            let! name = Gen.string (1, 50)
+            return { Id = id; Name = name; IsActive = true }
+        }
+    let result = PropertyRunner.runBool gen (fun c -> c.Id > 0) |> Async.AwaitTask |> Async.RunSynchronously
+    match result with
+    | PropertyResult.Passed -> ()
+    | PropertyResult.Failed msg -> failwith msg
+```
+
+## See also
+
+- [Reference: the `Gen` module](../reference/fsharp-gen.md)
+- [Why F# has its own package](../explanation/fsharp-wrapper.md)

--- a/docs/site/articles/reference/fsharp-gen.md
+++ b/docs/site/articles/reference/fsharp-gen.md
@@ -1,0 +1,124 @@
+# Reference: `Conjecture.FSharp`
+
+The `Conjecture.FSharp` package exposes a `Gen<'a>` type, a `Gen` module, a `gen { }` computation expression, and a `PropertyRunner` for executing properties.
+
+Namespace: `Conjecture`
+
+## `Gen<'a>`
+
+```fsharp
+[<Struct>]
+type Gen<'a> = internal Gen of Strategy: Strategy<'a>
+```
+
+An opaque struct wrapping `Conjecture.Core.Strategy<'a>`. Construct values via the `Gen` module, not the constructor. Use `Gen.unwrap` to access the underlying `Strategy<'a>` when interoperating with the C# API.
+
+## `Gen` module
+
+| Function | Signature | Notes |
+|---|---|---|
+| `constant` | `'a -> Gen<'a>` | Always produces the given value. |
+| `map` | `('a -> 'b) -> Gen<'a> -> Gen<'b>` | Projects generated values. |
+| `filter` | `('a -> bool) -> Gen<'a> -> Gen<'a>` | Discards values failing the predicate. Aggressive filters hurt performance. |
+| `bind` | `('a -> Gen<'b>) -> Gen<'a> -> Gen<'b>` | Monadic bind; enables dependent draws. |
+| `oneOf` | `Gen<'a> list -> Gen<'a>` | Uniformly picks one of the supplied generators. |
+| `int` | `int * int -> Gen<int>` | Integer in `[min, max]`. |
+| `float` | `float * float -> Gen<float>` | Double in `[min, max]`. |
+| `string` | `int * int -> Gen<string>` | String of length `[minLen, maxLen]`. |
+| `bool` | `Gen<bool>` | Value, not a function — booleans. |
+| `list` | `Gen<'a> -> Gen<'a list>` | F# `list`. |
+| `option` | `Gen<'a> -> Gen<'a option>` | 50/50 `Some` vs. `None`. |
+| `result` | `Gen<'ok> -> Gen<'err> -> Gen<Result<'ok, 'err>>` | 50/50 `Ok` vs. `Error`. |
+| `set` | `Gen<'a> -> Gen<Set<'a>>` | Deduplicated into an F# `Set`. |
+| `seq` | `Gen<'a> -> Gen<seq<'a>>` | Finite sequence. |
+| `tuple2` | `Gen<'a> -> Gen<'b> -> Gen<'a * 'b>` | Pair. |
+| `auto<'a>` | `unit -> Gen<'a>` | Reflection-driven generator. Trim-unsafe — see below. |
+| `unwrap` | `Gen<'a> -> Strategy<'a>` | Escape hatch to the C# core API. |
+
+## `GenBuilder` (the `gen { }` expression)
+
+| Operation | Signature | Syntax |
+|---|---|---|
+| `Bind` | `Gen<'a> * ('a -> Gen<'b>) -> Gen<'b>` | `let! x = genA` |
+| `Return` | `'a -> Gen<'a>` | `return value` |
+| `ReturnFrom` | `Gen<'a> -> Gen<'a>` | `return! gen` |
+| `MergeSources` | `Gen<'a> * Gen<'b> -> Gen<'a * 'b>` | `and!` |
+
+`gen` is auto-opened from the `GenBuilderValue` module, so `gen { ... }` is available wherever `Conjecture` is opened.
+
+## `PropertyRunner` module
+
+| Function | Signature | Notes |
+|---|---|---|
+| `runBool` | `Gen<'a> -> ('a -> bool) -> Task<PropertyResult>` | Property fails when the predicate returns `false`. |
+| `runUnit` | `Gen<'a> -> ('a -> unit) -> Task<PropertyResult>` | Property fails when the function throws. |
+
+```fsharp
+type PropertyResult =
+    | Passed
+    | Failed of message: string
+```
+
+Both functions use a default `ConjectureSettings()` and the standard test runner. For custom settings, drop into the C# API via `Gen.unwrap` and `TestRunner.Run` directly.
+
+The failure `message` includes: example count, shrink count, formatted counterexample, and a seed for reproduction.
+
+## `FSharpFormatter` module
+
+| Function | Signature |
+|---|---|
+| `format` | `obj -> string` |
+
+Formats F# records, unions, and tuples with `sprintf "%A"`. Falls back to `ToString()` for other types. Used internally by `PropertyRunner` to print counterexamples.
+
+## `Conjecture.FSharp.Expecto`
+
+Module (not a namespace): `Conjecture.FSharp.Expecto`.
+
+| Function | Signature |
+|---|---|
+| `property` | `string -> ('a -> 'r) -> Test` |
+
+Returns an Expecto `Test`. The return type `'r` must be `bool` or `unit` — anything else throws at runtime. Internally calls `Gen.auto<'a> ()`.
+
+## F# type coverage
+
+Types `Gen.auto<'a>` supports out of the box:
+
+| Type | Default generator |
+|---|---|
+| `int` | `Gen.int (-1000, 1000)` |
+| `float` | `Gen.float (-1000.0, 1000.0)` |
+| `float32` | same as `float`, cast down |
+| `string` | `Gen.string (0, 20)` |
+| `bool` | `Gen.bool` |
+| F# records | each field recursively |
+| F# discriminated unions | uniform over cases, each case recursively |
+
+Not supported by `Gen.auto`:
+
+- Collections (`list`, `option`, `Set`, arrays) — build with `Gen.list`, `Gen.option`, `Gen.set`
+- C# classes, structs, interfaces
+- Generic type parameters that remain unresolved
+- Tuples — use `Gen.tuple2` explicitly
+
+Anything unsupported throws `NotSupportedException` at call time.
+
+## Trim-safety
+
+`Gen.auto` is annotated `[<RequiresUnreferencedCode>]`. It uses `FSharp.Reflection` to walk types at runtime, which trimming and native AOT cannot statically verify. Two consequences:
+
+- Building with `<PublishTrimmed>true</PublishTrimmed>` or `<PublishAot>true</PublishAot>` emits an `IL2026`/`IL3050` warning at each `Gen.auto` call site.
+- At runtime under trimming, the reflected fields may have been removed, causing `Gen.auto` to throw.
+
+Mitigations:
+
+- Annotate calling functions with `[<RequiresUnreferencedCode>]` to propagate the warning.
+- For trim-safe tests, write generators by hand with the `gen { }` expression.
+- `Gen.auto` is intended for test code, which is normally not trimmed.
+
+## See also
+
+- [Tutorial: F# property tests](../tutorials/08-fsharp-property-tests.md)
+- [How-to: `Gen.auto` for records and unions](../how-to/use-fsharp-gen-auto.md)
+- [Explanation: why F# has its own package](../explanation/fsharp-wrapper.md)

--- a/docs/site/articles/reference/toc.yml
+++ b/docs/site/articles/reference/toc.yml
@@ -17,3 +17,5 @@ items:
     href: formatters.md
   - name: Telemetry
     href: telemetry.md
+  - name: Conjecture.FSharp
+    href: fsharp-gen.md

--- a/docs/site/articles/tutorials/08-fsharp-property-tests.md
+++ b/docs/site/articles/tutorials/08-fsharp-property-tests.md
@@ -1,0 +1,95 @@
+# Tutorial 8: Property Tests in F#
+
+This tutorial walks through writing your first property-based test in F# using the `Conjecture.FSharp` package and the Expecto integration. You'll install the packages, compose a generator with the `gen { }` computation expression, run a property test, and interpret a shrunk counterexample.
+
+## Prerequisites
+
+- .NET 10 SDK
+- A new or existing F# test project
+
+## Step 1: Install the packages
+
+Add `Conjecture.FSharp` and `Conjecture.FSharp.Expecto` to your test project:
+
+```bash
+dotnet add package Conjecture.FSharp
+dotnet add package Conjecture.FSharp.Expecto
+dotnet add package Expecto
+```
+
+`Conjecture.FSharp` provides the `Gen<'a>` type and `gen { }` computation expression. `Conjecture.FSharp.Expecto` wires those into Expecto as `testCase`-style properties.
+
+## Step 2: Write a generator
+
+Properties need values. In F#, you build generators in two ways:
+
+- Call module functions directly: `Gen.int (0, 100)`, `Gen.list (Gen.bool)`
+- Compose with the `gen { }` expression:
+
+```fsharp
+open Conjecture
+
+let pointGen : Gen<int * int> =
+    gen {
+        let! x = Gen.int (-100, 100)
+        let! y = Gen.int (-100, 100)
+        return (x, y)
+    }
+```
+
+`let!` draws a value from a generator — exactly like `let!` in `async { }`, but for random inputs.
+
+## Step 3: Run a property
+
+With Expecto, wrap a property in `property "name" (fun input -> ...)`. The function returns `bool` (pass/fail) or `unit` (any exception is a failure):
+
+```fsharp
+module Tests
+
+open Expecto
+open Conjecture.FSharp.Expecto
+
+[<Tests>]
+let tests =
+    testList "list reverse" [
+        property "reverse is self-inverse" (fun (xs: int list) ->
+            List.rev (List.rev xs) = xs)
+    ]
+
+[<EntryPoint>]
+let main argv =
+    runTestsInAssemblyWithCLIArgs [] argv
+```
+
+`property` uses `Gen.auto<'a>` to pick a generator based on the input type — here, `int list`.
+
+Run the test:
+
+```bash
+dotnet test
+```
+
+## Step 4: Read a shrunk counterexample
+
+Change the property to something that is *almost* true but breaks on a specific case:
+
+```fsharp
+property "sum is non-negative" (fun (xs: int list) ->
+    List.sum xs >= 0)
+```
+
+Run again. Expecto reports a failure with output similar to:
+
+```text
+Falsifying example found after 14 examples (shrunk 7 times)
+Counterexample: [-1]
+Reproduce with: [Property(Seed = 0xA4F3...)]
+```
+
+Conjecture ran 14 randomized examples, found a failure, then *shrank* it 7 times down to `[-1]` — the smallest list that falsifies the property. Values are formatted with F#'s `%A`, so records and unions print in idiomatic F# syntax, not their C# shape.
+
+## Next steps
+
+- [Generate records and unions with `Gen.auto`](../how-to/use-fsharp-gen-auto.md)
+- [Reference: the `Gen` module](../reference/fsharp-gen.md)
+- [Why F# has its own package](../explanation/fsharp-wrapper.md)

--- a/docs/site/articles/tutorials/toc.yml
+++ b/docs/site/articles/tutorials/toc.yml
@@ -13,3 +13,5 @@ items:
     href: 06-advanced-patterns.md
   - name: Data Generation Outside Tests
     href: 07-data-generation.md
+  - name: F# Property Tests
+    href: 08-fsharp-property-tests.md


### PR DESCRIPTION
## Description

Adds Diataxis-structured documentation for the `Conjecture.FSharp` and `Conjecture.FSharp.Expecto` packages:

- **Tutorial** (`tutorials/08-fsharp-property-tests.md`) — end-to-end: install packages, write a `gen { }` expression, run a property via Expecto's `property`, read a shrunk counterexample.
- **How-to** (`how-to/use-fsharp-gen-auto.md`) — generate records and DUs with `Gen.auto`, use `and!` for independent draws, stateful-testing via DU commands, composing with Expecto.
- **Reference** (`reference/fsharp-gen.md`) — `Gen` module table, `GenBuilder` operations, `PropertyRunner`/`FSharpFormatter`/`Conjecture.FSharp.Expecto`, F# type coverage, trim-safety notes.
- **Explanation** (`explanation/fsharp-wrapper.md`) — why F# gets its own package, how `Gen<'a>` wraps `Strategy<'a>`, `%A` formatting for counterexamples, trade-offs.

Each file is wired into the corresponding `toc.yml`. The issue description mentioned a `[<Property>]` attribute, but no such attribute exists today in `Conjecture.FSharp` — the docs describe the actual public API (`PropertyRunner.runBool`/`runUnit` and the Expecto `property` function).

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes (docs-only change, no code touched)
- [x] New behavior is covered by tests (N/A — docs)
- [x] Follows `.editorconfig` code style

Closes #269
Part of #65