### PR TITLE
[80.3] WhereStrategy: reduce IRNode allocation on rejection retries

### DIFF
--- a/src/Conjecture.Core.Tests/Strategies/WhereStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/WhereStrategyTests.cs
@@ -14,9 +14,9 @@ public class WhereStrategyTests
     [Fact]
     public void Where_FiltersOutput()
     {
-        var strategy = Generate.Integers<int>(0, 10).Where(x => x % 2 == 0);
-        var data = MakeData();
-        for (var i = 0; i < 50; i++)
+        Strategy<int> strategy = Generate.Integers<int>(0, 10).Where(x => x % 2 == 0);
+        ConjectureData data = MakeData();
+        for (int i = 0; i < 50; i++)
         {
             Assert.True(strategy.Generate(data) % 2 == 0, "Where() returned a value that didn't satisfy the predicate");
         }
@@ -25,9 +25,9 @@ public class WhereStrategyTests
     [Fact]
     public void Where_AllowsValuesMatchingPredicate()
     {
-        var strategy = Generate.Booleans().Where(x => x);
-        var data = MakeData();
-        for (var i = 0; i < 20; i++)
+        Strategy<bool> strategy = Generate.Booleans().Where(x => x);
+        ConjectureData data = MakeData();
+        for (int i = 0; i < 20; i++)
         {
             Assert.True(strategy.Generate(data));
         }
@@ -36,9 +36,53 @@ public class WhereStrategyTests
     [Fact]
     public void Where_ExhaustedBudget_MarksInvalid()
     {
-        var data = MakeData();
-        var strategy = Generate.Integers<int>(0, 10).Where(_ => false);
+        ConjectureData data = MakeData();
+        Strategy<int> strategy = Generate.Integers<int>(0, 10).Where(_ => false);
         Assert.ThrowsAny<Exception>((Action)(() => strategy.Generate(data)));
         Assert.Equal(Status.Invalid, data.Status);
+    }
+
+    [Fact]
+    public void Where_RejectedAttempts_RolledBackFromIRNodes()
+    {
+        ConjectureData data = ConjectureData.ForRecord(
+        [
+            IRNode.ForInteger(0UL, 0UL, 1UL),
+            IRNode.ForInteger(1UL, 0UL, 1UL),
+        ]);
+
+        Strategy<int> strategy = Generate.Integers<int>(0, 1).Where(x => x == 1);
+        int result = strategy.Generate(data);
+
+        Assert.Equal(1, result);
+        Assert.Single(data.IRNodes);
+    }
+
+    [Fact]
+    public void Where_SingleAcceptedDraw_AllocatesAtMostBaselinePlus16Bytes()
+    {
+        Strategy<int> baseline = Generate.Integers<int>(0, 100);
+        Strategy<int> where = Generate.Integers<int>(0, 100).Where(_ => true);
+
+        ConjectureData warmupData = ConjectureData.ForRecord([IRNode.ForInteger(42UL, 0UL, 100UL)]);
+        baseline.Generate(warmupData);
+        ConjectureData warmupData2 = ConjectureData.ForRecord([IRNode.ForInteger(42UL, 0UL, 100UL)]);
+        where.Generate(warmupData2);
+
+        ConjectureData baselineData = ConjectureData.ForRecord([IRNode.ForInteger(42UL, 0UL, 100UL)]);
+        long beforeBaseline = GC.GetAllocatedBytesForCurrentThread();
+        baseline.Generate(baselineData);
+        long afterBaseline = GC.GetAllocatedBytesForCurrentThread();
+        long baselineAlloc = afterBaseline - beforeBaseline;
+
+        ConjectureData whereData = ConjectureData.ForRecord([IRNode.ForInteger(42UL, 0UL, 100UL)]);
+        long beforeWhere = GC.GetAllocatedBytesForCurrentThread();
+        where.Generate(whereData);
+        long afterWhere = GC.GetAllocatedBytesForCurrentThread();
+        long whereAlloc = afterWhere - beforeWhere;
+
+        Assert.True(
+            whereAlloc <= baselineAlloc + 16,
+            $"Expected where alloc ({whereAlloc}) <= baseline alloc ({baselineAlloc}) + 16");
     }
 }

--- a/src/Conjecture.Core/Internal/ConjectureData.cs
+++ b/src/Conjecture.Core/Internal/ConjectureData.cs
@@ -143,6 +143,18 @@ internal sealed class ConjectureData
         observations[label] = value;
     }
 
+    internal int NodeCount => nodes.Count;
+
+    internal void TruncateNodes(int length)
+    {
+        if (length < 0 || length > nodes.Count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), length,
+                $"Cannot truncate to {length}; current node count is {nodes.Count}.");
+        }
+        nodes.RemoveRange(length, nodes.Count - length);
+    }
+
     internal void MarkInvalid() => Status = Status.Invalid;
     internal void MarkInteresting() => Status = Status.Interesting;
     internal void Freeze() => frozen = true;

--- a/src/Conjecture.Core/WhereStrategy.cs
+++ b/src/Conjecture.Core/WhereStrategy.cs
@@ -14,14 +14,15 @@ internal sealed class WhereStrategy<T>(Strategy<T> source, Func<T, bool> predica
 
     internal override T Generate(ConjectureData data)
     {
-        for (var i = 0; i < MaxAttempts; i++)
+        for (int i = 0; i < MaxAttempts; i++)
         {
-            var value = source.Generate(data);
+            int snapshot = data.NodeCount;
+            T value = source.Generate(data);
             if (predicate(value))
             {
                 return value;
             }
-
+            data.TruncateNodes(snapshot);
         }
         data.MarkInvalid();
         throw new UnsatisfiedAssumptionException();


### PR DESCRIPTION
## Description

Implements speculative-record rollback in `WhereStrategy<T>`: before each rejection-loop attempt, snapshots `ConjectureData.NodeCount`, and on rejection calls `TruncateNodes(snapshot)` to remove the rejected draw's IR entries. Only the accepted attempt's nodes remain in the IR, reducing allocation on the rejection path and improving shrinker signal quality.

Adds `NodeCount` property and `TruncateNodes(int length)` to `ConjectureData` with an out-of-range guard.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #323
Part of #80