### PR TITLE
[80.4] StrategyCompositionBenchmarks: wire allocation-budget regression gate

### DIFF
--- a/src/Conjecture.Benchmarks.Tests/AllocationBudgetValidatorTests.cs
+++ b/src/Conjecture.Benchmarks.Tests/AllocationBudgetValidatorTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Benchmarks.Tests;
+
+public sealed class AllocationBudgetValidatorTests
+{
+    [Fact]
+    public void Validate_ReturnsEmpty_WhenAllMethodsWithinBudget()
+    {
+        long baseline = 24;
+        IReadOnlyDictionary<string, (long Actual, long Budget)> methods = new Dictionary<string, (long Actual, long Budget)>
+        {
+            ["Select_Single"] = (24, 1),
+        };
+
+        List<(string Method, string Message)> failures = AllocationBudgetValidator.Validate(baseline, methods);
+
+        Assert.Empty(failures);
+    }
+
+    [Fact]
+    public void Validate_ReturnsFailure_WhenMethodExceedsBudget()
+    {
+        long baseline = 24;
+        IReadOnlyDictionary<string, (long Actual, long Budget)> methods = new Dictionary<string, (long Actual, long Budget)>
+        {
+            ["Select_Single"] = (50, 1),
+        };
+
+        List<(string Method, string Message)> failures = AllocationBudgetValidator.Validate(baseline, methods);
+
+        Assert.Single(failures);
+        Assert.Contains("Select_Single", failures[0].Method);
+        Assert.Contains("budget", failures[0].Message);
+    }
+
+    [Fact]
+    public void Validate_ReturnsMultipleFailures_WhenMultipleExceed()
+    {
+        long baseline = 24;
+        IReadOnlyDictionary<string, (long Actual, long Budget)> methods = new Dictionary<string, (long Actual, long Budget)>
+        {
+            ["MethodA"] = (100, 1),
+            ["MethodB"] = (200, 1),
+        };
+
+        List<(string Method, string Message)> failures = AllocationBudgetValidator.Validate(baseline, methods);
+
+        Assert.Equal(2, failures.Count);
+    }
+
+    [Fact]
+    public void Validate_ReturnsEmpty_WhenExactlyAtBudget()
+    {
+        long baseline = 24;
+        IReadOnlyDictionary<string, (long Actual, long Budget)> methods = new Dictionary<string, (long Actual, long Budget)>
+        {
+            ["Select_Single"] = (25, 1),
+        };
+
+        List<(string Method, string Message)> failures = AllocationBudgetValidator.Validate(baseline, methods);
+
+        Assert.Empty(failures);
+    }
+
+    [Fact]
+    public void Validate_ReturnsFailure_WhenOneByteOverBudget()
+    {
+        long baseline = 24;
+        IReadOnlyDictionary<string, (long Actual, long Budget)> methods = new Dictionary<string, (long Actual, long Budget)>
+        {
+            ["Select_Single"] = (26, 1),
+        };
+
+        List<(string Method, string Message)> failures = AllocationBudgetValidator.Validate(baseline, methods);
+
+        Assert.Single(failures);
+    }
+
+    [Fact]
+    public void Validate_ReturnsEmpty_WhenMethodsDictionaryIsEmpty()
+    {
+        long baseline = 24;
+        IReadOnlyDictionary<string, (long Actual, long Budget)> methods = new Dictionary<string, (long Actual, long Budget)>();
+
+        List<(string Method, string Message)> failures = AllocationBudgetValidator.Validate(baseline, methods);
+
+        Assert.Empty(failures);
+    }
+
+    [Fact]
+    public void Validate_HandlesNegativeBaseline()
+    {
+        long baseline = -10;
+        IReadOnlyDictionary<string, (long Actual, long Budget)> methods = new Dictionary<string, (long Actual, long Budget)>
+        {
+            ["Select_Single"] = (-5, 1),
+        };
+
+        List<(string Method, string Message)> failures = AllocationBudgetValidator.Validate(baseline, methods);
+
+        Assert.Single(failures);
+    }
+}

--- a/src/Conjecture.Benchmarks.Tests/Conjecture.Benchmarks.Tests.csproj
+++ b/src/Conjecture.Benchmarks.Tests/Conjecture.Benchmarks.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Benchmarks\Conjecture.Benchmarks.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/Conjecture.Benchmarks/AllocationBudgetValidator.cs
+++ b/src/Conjecture.Benchmarks/AllocationBudgetValidator.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Benchmarks;
+
+public static class AllocationBudgetValidator
+{
+    public static List<(string Method, string Message)> Validate(
+        long baseline,
+        IReadOnlyDictionary<string, (long Actual, long Budget)> methods)
+    {
+        List<(string Method, string Message)> failures = [];
+        foreach (KeyValuePair<string, (long Actual, long Budget)> entry in methods)
+        {
+            long limit = baseline + entry.Value.Budget;
+            if (entry.Value.Actual > limit)
+            {
+                failures.Add((entry.Key, $"{entry.Key} exceeded allocation budget: actual={entry.Value.Actual}, limit={limit}"));
+            }
+        }
+
+        return failures;
+    }
+}

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -3,6 +3,7 @@
   <Project Path="Conjecture.Xunit/Conjecture.Xunit.csproj" />
   <Project Path="Conjecture.Core.Tests/Conjecture.Core.Tests.csproj" />
   <Project Path="Conjecture.Xunit.Tests/Conjecture.Xunit.Tests.csproj" />
+  <Project Path="Conjecture.Benchmarks.Tests/Conjecture.Benchmarks.Tests.csproj" />
   <Project Path="Conjecture.Benchmarks/Conjecture.Benchmarks.csproj" />
   <Project Path="Conjecture.Generators/Conjecture.Generators.csproj" />
   <Project Path="Conjecture.Generators.Tests/Conjecture.Generators.Tests.csproj" />


### PR DESCRIPTION
## Description

Adds `AllocationBudgetValidator` — a pure static utility that checks per-method measured allocations against a budget ceiling (baseline + N bytes). Also introduces `Conjecture.Benchmarks.Tests`, a new xUnit test project for benchmark-adjacent code.

The validator accepts the baseline allocation and a dictionary of (method → actual, budget-above-baseline), returning named failure tuples for any method that exceeds its ceiling. This is the testable core of the allocation-budget regression gate described in #80 DD4.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #324
Part of #80