### PR TITLE
[317.2] ConjectureTestingPlatformExtensions: expose public registration helper

### DIFF
--- a/src/Conjecture.TestingPlatform.Tests/ConjectureTestingPlatformExtensionsTests.cs
+++ b/src/Conjecture.TestingPlatform.Tests/ConjectureTestingPlatformExtensionsTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Threading.Tasks;
+
+using Microsoft.Testing.Platform.Builder;
+using Microsoft.Testing.Platform.Capabilities.TestFramework;
+using Microsoft.Testing.Platform.CommandLine;
+using Microsoft.Testing.Platform.Configurations;
+using Microsoft.Testing.Platform.Extensions.CommandLine;
+using Microsoft.Testing.Platform.Extensions.TestFramework;
+using Microsoft.Testing.Platform.Logging;
+using Microsoft.Testing.Platform.TestHost;
+using Microsoft.Testing.Platform.TestHostControllers;
+
+namespace Conjecture.TestingPlatform.Tests;
+
+public class ConjectureTestingPlatformExtensionsTests
+{
+    // ---- fakes ---------------------------------------------------------------
+
+    private sealed class FakeCommandLineManager : ICommandLineManager
+    {
+        public int AddProviderCallCount { get; private set; }
+
+        public void AddProvider(Func<ICommandLineOptionsProvider> providerFactory)
+        {
+            AddProviderCallCount++;
+        }
+
+        public void AddProvider(Func<IServiceProvider, ICommandLineOptionsProvider> providerFactory)
+        {
+            AddProviderCallCount++;
+        }
+    }
+
+    private sealed class FakeTestApplicationBuilder : ITestApplicationBuilder
+    {
+        private readonly FakeCommandLineManager commandLineManager = new();
+
+        public int RegisterTestFrameworkCallCount { get; private set; }
+
+        public ICommandLineManager CommandLine => commandLineManager;
+
+        public int CommandLineAddProviderCallCount => commandLineManager.AddProviderCallCount;
+
+        public ITestHostManager TestHost => throw new NotSupportedException();
+
+        public ITestHostControllersManager TestHostControllers => throw new NotSupportedException();
+
+#pragma warning disable TPEXP
+        public IConfigurationManager Configuration => throw new NotSupportedException();
+
+        public ILoggingManager Logging => throw new NotSupportedException();
+#pragma warning restore TPEXP
+
+        public ITestApplicationBuilder RegisterTestFramework(
+            Func<IServiceProvider, ITestFrameworkCapabilities> capabilitiesFactory,
+            Func<ITestFrameworkCapabilities, IServiceProvider, ITestFramework> frameworkFactory)
+        {
+            RegisterTestFrameworkCallCount++;
+            return this;
+        }
+
+        public Task<ITestApplication> BuildAsync()
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    // ---- tests ---------------------------------------------------------------
+
+    [Fact]
+    public void RegisterConjectureFramework_ReturnsSameBuilderInstance()
+    {
+        FakeTestApplicationBuilder builder = new();
+
+        ITestApplicationBuilder returned = builder.RegisterConjectureFramework();
+
+        Assert.Same(builder, returned);
+    }
+
+    [Fact]
+    public void RegisterConjectureFramework_CallsAddProviderOnCommandLine()
+    {
+        FakeTestApplicationBuilder builder = new();
+
+        builder.RegisterConjectureFramework();
+
+        Assert.Equal(1, builder.CommandLineAddProviderCallCount);
+    }
+
+    [Fact]
+    public void RegisterConjectureFramework_CallsRegisterTestFramework()
+    {
+        FakeTestApplicationBuilder builder = new();
+
+        builder.RegisterConjectureFramework();
+
+        Assert.Equal(1, builder.RegisterTestFrameworkCallCount);
+    }
+}

--- a/src/Conjecture.TestingPlatform/ConjectureTestingPlatformExtensions.cs
+++ b/src/Conjecture.TestingPlatform/ConjectureTestingPlatformExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.TestingPlatform.Internal;
+
+using Microsoft.Testing.Platform.Builder;
+
+namespace Conjecture.TestingPlatform;
+
+/// <summary>Extension methods for registering Conjecture with the Microsoft Testing Platform.</summary>
+public static class ConjectureTestingPlatformExtensions
+{
+    /// <summary>Registers the Conjecture property-based test framework with the test application builder.</summary>
+    /// <param name="builder">The test application builder.</param>
+    /// <returns>The same <paramref name="builder"/> instance for chaining.</returns>
+    public static ITestApplicationBuilder RegisterConjectureFramework(
+        this ITestApplicationBuilder builder)
+    {
+        builder.CommandLine.AddProvider(static () => new ConjectureCommandLineOptions());
+        builder.RegisterTestFramework(
+            _ => new PropertyTestFrameworkCapabilities(),
+            (_, services) => new PropertyTestFramework(services));
+        return builder;
+    }
+}

--- a/src/Conjecture.TestingPlatform/Program.cs
+++ b/src/Conjecture.TestingPlatform/Program.cs
@@ -1,14 +1,11 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using Conjecture.TestingPlatform.Internal;
+using Conjecture.TestingPlatform;
 
 using Microsoft.Testing.Platform.Builder;
 
 ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
-builder.CommandLine.AddProvider(static () => new ConjectureCommandLineOptions());
-builder.RegisterTestFramework(
-    _ => new PropertyTestFrameworkCapabilities(),
-    (_, services) => new PropertyTestFramework(services));
+builder.RegisterConjectureFramework();
 using ITestApplication app = await builder.BuildAsync();
 return await app.RunAsync();

--- a/src/Conjecture.TestingPlatform/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.TestingPlatform/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Conjecture.TestingPlatform.ConjectureTestingPlatformExtensions
+static Conjecture.TestingPlatform.ConjectureTestingPlatformExtensions.RegisterConjectureFramework(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!


### PR DESCRIPTION
## Description

Adds `ConjectureTestingPlatformExtensions` with a `RegisterConjectureFramework(this ITestApplicationBuilder)` extension method that encapsulates Conjecture framework registration. Updates `Program.cs` to use it. Exposes the method as public API so consumers can wire up the framework without copying internal types.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #334
Part of #317