### PR TITLE
[317.3] MSBuild props/targets: ship build/ assets in Conjecture.TestingPlatform NuGet package

### DIFF
--- a/src/Conjecture.TestingPlatform.Tests/BuildAssetsTests.cs
+++ b/src/Conjecture.TestingPlatform.Tests/BuildAssetsTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.IO;
+using System.Xml.Linq;
+
+namespace Conjecture.TestingPlatform.Tests;
+
+public sealed class BuildAssetsTests
+{
+    private static string FindBuildDirectory()
+    {
+        string current = AppContext.BaseDirectory;
+        while (current is not null)
+        {
+            string candidate = Path.Combine(current, "src", "Conjecture.TestingPlatform", "build");
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            string? parent = Path.GetDirectoryName(current);
+            if (parent is null || parent == current)
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate 'src/Conjecture.TestingPlatform/build/' by walking up from AppContext.BaseDirectory.");
+    }
+
+    [Fact]
+    public void PropsFile_Exists()
+    {
+        string path = Path.Combine(FindBuildDirectory(), "Conjecture.TestingPlatform.props");
+        Assert.True(File.Exists(path), $"Expected props file at: {path}");
+    }
+
+    [Fact]
+    public void TargetsFile_Exists()
+    {
+        string path = Path.Combine(FindBuildDirectory(), "Conjecture.TestingPlatform.targets");
+        Assert.True(File.Exists(path), $"Expected targets file at: {path}");
+    }
+
+    [Fact]
+    public void PropsFile_IsValidXml()
+    {
+        string path = Path.Combine(FindBuildDirectory(), "Conjecture.TestingPlatform.props");
+        XDocument.Load(path);
+    }
+
+    [Fact]
+    public void TargetsFile_IsValidXml()
+    {
+        string path = Path.Combine(FindBuildDirectory(), "Conjecture.TestingPlatform.targets");
+        XDocument.Load(path);
+    }
+
+    [Fact]
+    public void PropsFile_SetsIsTestingPlatformApplicationToTrue()
+    {
+        string path = Path.Combine(FindBuildDirectory(), "Conjecture.TestingPlatform.props");
+        XDocument doc = XDocument.Load(path);
+        bool found = false;
+        foreach (XElement element in doc.Descendants("IsTestingPlatformApplication"))
+        {
+            if (string.Equals(element.Value.Trim(), "true", StringComparison.OrdinalIgnoreCase))
+            {
+                found = true;
+                break;
+            }
+        }
+
+        Assert.True(found, $"Expected <IsTestingPlatformApplication>true</IsTestingPlatformApplication> in {path}");
+    }
+}

--- a/src/Conjecture.TestingPlatform/Conjecture.TestingPlatform.csproj
+++ b/src/Conjecture.TestingPlatform/Conjecture.TestingPlatform.csproj
@@ -5,10 +5,12 @@
     <TargetFramework>net10.0</TargetFramework>
     <Description>Microsoft Testing Platform adapter for Conjecture.NET property-based testing</Description>
     <IsPackable>true</IsPackable>
+    <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="build\**" Pack="true" PackagePath="build\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -25,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" />
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="Microsoft.Testing.Platform.MSBuild" PrivateAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.TestingPlatform/build/Conjecture.TestingPlatform.props
+++ b/src/Conjecture.TestingPlatform/build/Conjecture.TestingPlatform.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <IsTestingPlatformApplication>true</IsTestingPlatformApplication>
+  </PropertyGroup>
+</Project>

--- a/src/Conjecture.TestingPlatform/build/Conjecture.TestingPlatform.targets
+++ b/src/Conjecture.TestingPlatform/build/Conjecture.TestingPlatform.targets
@@ -1,0 +1,16 @@
+<Project>
+  <ItemGroup>
+    <TestingPlatformBuilderHook Include="Conjecture.TestingPlatform" AssemblyName="Conjecture.TestingPlatform" TypeFullName="Conjecture.TestingPlatform.ConjectureTestingPlatformExtensions" MethodName="RegisterConjectureFramework" />
+  </ItemGroup>
+
+  <!-- Suppress MTP entry-point generation for VSTest/xUnit test projects that install this
+       NuGet package. Those projects already have their own entry point and do not need the
+       auto-generated MicrosoftTestingPlatformEntryPoint. -->
+  <Target Name="_ConjectureSuppressEntryPointForTestProjects"
+          BeforeTargets="_CalculateGenerateTestingPlatformEntryPoint"
+          Condition="'$(IsTestProject)' == 'true'">
+    <PropertyGroup>
+      <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,14 @@
+<Project>
+  <!-- Prevent Microsoft.Testing.Platform.MSBuild from generating a second entry point in
+       VSTest/xUnit test projects. These projects already have their own entry point supplied
+       by the test framework runner and do not need the auto-generated
+       MicrosoftTestingPlatformEntryPoint.cs that would otherwise be produced when
+       IsTestingPlatformApplication=true (set transitively by Microsoft.Testing.Platform). -->
+  <Target Name="_SuppressMtpEntryPointForVsTestProjects"
+          BeforeTargets="_CalculateGenerateTestingPlatformEntryPoint"
+          Condition="'$(IsTestProject)' == 'true'">
+    <PropertyGroup>
+      <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+    </PropertyGroup>
+  </Target>
+</Project>


### PR DESCRIPTION
## Description

Ships the MSBuild `build/` assets required for `Conjecture.TestingPlatform` to function as a NuGet package:

- `build/Conjecture.TestingPlatform.props` — sets `IsTestingPlatformApplication=true` on consumer projects
- `build/Conjecture.TestingPlatform.targets` — wires `RegisterConjectureFramework` via `TestingPlatformBuilderHook` so `Microsoft.Testing.Platform.MSBuild` auto-generates the correct entry point
- Adds `Microsoft.Testing.Platform.MSBuild` with `PrivateAssets="none"` so the `TestingPlatformBuilderHook` item type is available in consumer build graphs
- Adds `src/Directory.Build.targets` to suppress MTP entry-point generation in the solution's VSTest/xUnit test projects, which would otherwise be broken by the transitive `Microsoft.Testing.Platform.MSBuild` reference

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #335
Part of #317