### PR TITLE
[317.6] Docs: MTP framework how-to and reference for Conjecture.TestingPlatform

### DIFF
--- a/docs/site/articles/explanation/mtp-model.md
+++ b/docs/site/articles/explanation/mtp-model.md
@@ -1,0 +1,34 @@
+# Why MTP tests are executables
+
+Microsoft Testing Platform (MTP) uses a different execution model from xUnit, NUnit, and MSTest. Understanding the difference explains why `Conjecture.TestingPlatform` projects require `OutputType=Exe` and why there is no runner to install.
+
+## The traditional model
+
+With xUnit, NUnit, or MSTest, the test project compiles to a class library (`.dll`). A separate runner — `dotnet test`, the vstest host, or an IDE adapter — loads that DLL as a plugin and calls into it via a well-known interface. The runner owns the process; the test framework is a guest.
+
+This model requires:
+- A test host binary that knows how to load framework DLLs
+- Adapter packages that wire the framework to the vstest protocol
+- `.runsettings` files or environment variables to pass configuration through the host
+
+## The MTP model
+
+MTP inverts the relationship. The test project compiles to an executable (`.exe`). The framework — `Conjecture.TestingPlatform` — is a library statically linked into that executable. When you run `dotnet test` or execute the binary directly, your code is the host.
+
+The package supplies an entry point via MSBuild props, so you do not write `Program.cs`. Your test classes and `[Property]` methods are discovered by the framework at startup.
+
+Consequences:
+- No adapter DLLs, no `.runsettings`, no runner installation
+- `dotnet test` and `dotnet run` both work — the binary is self-contained
+- The executable can be invoked directly in CI without the .NET SDK test infrastructure
+
+## Alignment with .NET's direction
+
+MTP's executable model fits naturally with native AOT and single-file trimmed binaries, where reflection-based plugin loading is problematic. A statically linked binary can be inspected by the trimmer at publish time.
+
+`Conjecture.TestingPlatform` uses reflection for test discovery (`[RequiresUnreferencedCode]`, `[RequiresDynamicCode]`), so it does not currently support native AOT publishing. Trim warnings are suppressed in the package. If AOT support is required, stay with an xUnit or NUnit adapter and a source-generated test runner.
+
+## Further reading
+
+- [Microsoft Testing Platform introduction](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro)
+- [How to use the MTP adapter](../how-to/use-mtp-adapter.md)

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -13,3 +13,5 @@ items:
     href: fsharp-wrapper.md
   - name: Allocation model
     href: allocation-model.md
+  - name: Why MTP tests are executables
+    href: mtp-model.md

--- a/docs/site/articles/how-to/use-mtp-adapter.md
+++ b/docs/site/articles/how-to/use-mtp-adapter.md
@@ -68,6 +68,37 @@ dotnet test
 
 Each `[Property]` method runs against 100 randomly generated inputs by default. A failure shows the shrunk counterexample.
 
+## Configure per-test behaviour
+
+Set `[Property]` attribute properties to control individual test runs:
+
+```csharp
+[Property(MaxExamples = 500, DeadlineMs = 200)]
+public bool Reverse_preserves_length(List<int> xs) =>
+    xs.AsEnumerable().Reverse().Count() == xs.Count;
+
+[Property(Seed = 42UL, UseDatabase = false)]
+public void Deterministic_property(int value)
+{
+    Assert.True(value < int.MaxValue);
+}
+
+[Property(ExportReproOnFailure = true, ReproOutputPath = "failures/")]
+public bool Serialisation_roundtrips(string input) =>
+    Deserialise(Serialise(input)) == input;
+```
+
+For the full list of properties and their defaults, see [Attributes reference](../reference/attributes.md#property).
+
+To apply defaults across the whole assembly, use `[assembly: ConjectureSettings(...)]`:
+
+```csharp
+[assembly: ConjectureSettings(MaxExamples = 500, UseDatabase = false)]
+```
+
+> [!NOTE]
+> The `--conjecture-seed` and `--conjecture-max-examples` CLI flags override the corresponding attribute values for every property in the run. See [CLI options](#cli-options) below.
+
 ## CLI options
 
 Two CLI flags override settings globally for all properties in the run:

--- a/docs/site/articles/reference/attributes.md
+++ b/docs/site/articles/reference/attributes.md
@@ -41,6 +41,26 @@ public async Task<bool> Api_returns_200(int id)
 | `ExportReproOnFailure` | `bool` | `false` | Write shrunk counterexample to file on failure |
 | `ReproOutputPath` | `string` | `".conjecture/repros/"` | Output directory for repro files |
 
+### MTP-specific notes
+
+When using `Conjecture.TestingPlatform`, `[Property]` is defined in that package rather than in the framework adapter. Two differences apply:
+
+**`Seed` type is `ulong?`.** A `null` value means random (the default). In xUnit, NUnit, and MSTest adapters, `Seed` is `ulong` and `0` means random.
+
+```csharp
+// Conjecture.TestingPlatform — pin with a non-null value
+[Property(Seed = 42UL)]
+public bool My_property(int value) => ...;
+
+// Other adapters — 0 means random, any other value pins
+[Property(Seed = 42UL)]
+public bool My_property(int value) => ...;
+```
+
+**CLI overrides take precedence.** The `--conjecture-seed` and `--conjecture-max-examples` options (passed after `--` to `dotnet test`) override the corresponding attribute values for every property in the run. See [How to use the MTP adapter](../how-to/use-mtp-adapter.md#cli-options).
+
+For runner-level configuration options provided by Microsoft Testing Platform itself, see the [MTP documentation](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro).
+
 ## `[ConjectureSettings]`
 
 Applies settings to a test method, or at assembly level to all tests in the assembly.


### PR DESCRIPTION
## Description

Adds Diataxis-structured documentation for `Conjecture.TestingPlatform`:

- **How-to** (`use-mtp-adapter.md`): new "Configure per-test behaviour" section covering `[Property]` attribute properties and `[assembly: ConjectureSettings]`, with a callout linking to the CLI flags
- **Reference** (`attributes.md`): MTP-specific notes after the `[Property]` table — `Seed` nullability difference (`ulong?` vs `ulong`), CLI override precedence, and link to MTP docs
- **Explanation** (`mtp-model.md`): new page explaining why MTP test projects compile to executables, alignment with .NET's direction, and current AOT limitations

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #338
Part of #317