### PR TITLE
[210.2] Migrate Conjecture.SelfTests to Conjecture.TestingPlatform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # Claude Code local settings (user-specific tool permissions)
 .claude/settings.local.json
 
+# Conjecture example database (local shrink cache)
+.conjecture/
+
 # dotenv files
 .env
 

--- a/src/Conjecture.SelfTests/Conjecture.SelfTests.csproj
+++ b/src/Conjecture.SelfTests/Conjecture.SelfTests.csproj
@@ -4,18 +4,18 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <OutputType>Exe</OutputType>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.assert" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
-    <ProjectReference Include="..\Conjecture.Xunit.V3\Conjecture.Xunit.V3.csproj" />
+    <ProjectReference Include="..\Conjecture.TestingPlatform\Conjecture.TestingPlatform.csproj" />
     <ProjectReference Include="..\Conjecture.Generators\Conjecture.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />

--- a/src/Conjecture.SelfTests/GeneratorSelfTests.cs
+++ b/src/Conjecture.SelfTests/GeneratorSelfTests.cs
@@ -3,7 +3,7 @@
 
 using Conjecture.Core;
 using Conjecture.Core.Internal;
-using Conjecture.Xunit.V3;
+using Conjecture.TestingPlatform;
 
 using Xunit;
 
@@ -26,7 +26,7 @@ public class GeneratorSelfTests
         Assert.NotNull(p);
     }
 
-    [Fact]
+    [Property]
     public async Task GeneratedStrategy_Select_TransformsValues()
     {
         Strategy<int> xStrategy = new SelfPointArbitrary().Create().Select(p => p.X);
@@ -37,7 +37,7 @@ public class GeneratorSelfTests
         Assert.True(result.Passed);
     }
 
-    [Fact]
+    [Property]
     public async Task GeneratedStrategy_Where_FiltersValues()
     {
         Strategy<SelfPoint> positivePoints = new SelfPointArbitrary().Create()
@@ -64,7 +64,7 @@ public class GeneratorSelfTests
         Assert.NotNull(e.Label.Text);
     }
 
-    [Fact]
+    [Property]
     public async Task GeneratedStrategy_SelectMany_ComposesCorrectly()
     {
         Strategy<SelfLabel> labelStrategy = new SelfLabelArbitrary().Create();

--- a/src/Conjecture.SelfTests/InfrastructureSelfTests.cs
+++ b/src/Conjecture.SelfTests/InfrastructureSelfTests.cs
@@ -3,7 +3,7 @@
 
 using Conjecture.Core;
 using Conjecture.Core.Internal;
-using Conjecture.Xunit.V3;
+using Conjecture.TestingPlatform;
 
 using Xunit;
 
@@ -64,7 +64,7 @@ public class InfrastructureSelfTests
 
     // Verifies ShrinkCount in TestRunResult matches actual shrink iterations produced by
     // running Shrinker.ShrinkAsync independently on the same original counterexample.
-    [Fact]
+    [Property]
     public async Task ReportingAccuracy_ShrinkCount_MatchesActualShrinkIterations()
     {
         ConjectureSettings settings = new() { Seed = 42ul, MaxExamples = 20, UseDatabase = false };

--- a/src/Conjecture.SelfTests/Program.cs
+++ b/src/Conjecture.SelfTests/Program.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.TestingPlatform;
+
+using Microsoft.Testing.Platform.Builder;
+
+ITestApplicationBuilder builder = await TestApplication.CreateBuilderAsync(args);
+builder.RegisterConjectureFramework();
+using ITestApplication app = await builder.BuildAsync();
+return await app.RunAsync();

--- a/src/Conjecture.SelfTests/RecursiveStrategySelfTests.cs
+++ b/src/Conjecture.SelfTests/RecursiveStrategySelfTests.cs
@@ -3,6 +3,7 @@
 
 using Conjecture.Core;
 using Conjecture.Core.Internal;
+using Conjecture.TestingPlatform;
 
 using Xunit;
 
@@ -27,7 +28,7 @@ public class RecursiveStrategySelfTests
         return depth;
     }
 
-    [Fact]
+    [Property]
     public async Task RecursiveStrategy_SameIRNodes_ProduceSameValue()
     {
         ConjectureSettings settings = new() { Seed = 7UL, MaxExamples = 50, UseDatabase = false };
@@ -46,7 +47,7 @@ public class RecursiveStrategySelfTests
         Assert.Equal(first, second);
     }
 
-    [Fact]
+    [Property]
     public async Task RecursiveStrategy_ShrunkValue_HasDepthAtMostOriginal()
     {
         ConjectureSettings settings = new() { Seed = 42UL, MaxExamples = 50, UseDatabase = false };

--- a/src/Conjecture.SelfTests/ShrinkerInvariantTests.cs
+++ b/src/Conjecture.SelfTests/ShrinkerInvariantTests.cs
@@ -3,6 +3,7 @@
 
 using Conjecture.Core;
 using Conjecture.Core.Internal;
+using Conjecture.TestingPlatform;
 
 using Xunit;
 
@@ -30,7 +31,7 @@ public class ShrinkerInvariantTests
         }
     }
 
-    [Fact]
+    [Property]
     public async Task Idempotent_ReshrinkingFullyShrunkResult_MakesNoProgress()
     {
         ConjectureSettings settings = new() { Seed = 42ul, MaxExamples = 20, UseDatabase = false };
@@ -46,7 +47,7 @@ public class ShrinkerInvariantTests
         Assert.Equal(0, additionalShrinks);
     }
 
-    [Fact]
+    [Property]
     public async Task PreservesFailure_ShrunkCounterexample_StillInteresting()
     {
         ConjectureSettings settings = new() { Seed = 1ul, MaxExamples = 20, UseDatabase = false };
@@ -57,7 +58,7 @@ public class ShrinkerInvariantTests
         Assert.Equal(Status.Interesting, SelfTestHelpers.Replay(result.Counterexample!, FailIfOver5));
     }
 
-    [Fact]
+    [Property]
     public async Task Reduces_ShrunkCounterexample_IsLexicographicallyLeqOriginal()
     {
         ConjectureSettings settings = new() { Seed = 99ul, MaxExamples = 20, UseDatabase = false };
@@ -77,7 +78,7 @@ public class ShrinkerInvariantTests
             "Shrunk counterexample must be lexicographically <= the original failing example.");
     }
 
-    [Fact]
+    [Property]
     public async Task BoundsRespected_ShrunkNodes_AllWithinStrategyBounds()
     {
         ConjectureSettings settings = new() { Seed = 7ul, MaxExamples = 20, UseDatabase = false };

--- a/src/Conjecture.SelfTests/StateMachineSelfTests.cs
+++ b/src/Conjecture.SelfTests/StateMachineSelfTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 
 using Conjecture.Core;
 using Conjecture.Core.Internal;
+using Conjecture.TestingPlatform;
 
 using Xunit;
 
@@ -78,7 +79,7 @@ public class StateMachineSelfTests
 
     // ─── Tests ────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [Property]
     public async Task MonotoneShrinking_CommandSequence_ShrunkStepCountLeqOriginal()
     {
         ConjectureSettings settings = new() { Seed = 1UL, MaxExamples = 100, UseDatabase = false };
@@ -92,7 +93,7 @@ public class StateMachineSelfTests
             $"Shrinking increased step count from {originalSteps} to {shrunkSteps}");
     }
 
-    [Fact]
+    [Property]
     public async Task ShrinkingPreservesFailure_ShrunkCounterexample_ReplaysAsInteresting()
     {
         ConjectureSettings settings = new() { Seed = 1UL, MaxExamples = 100, UseDatabase = false };
@@ -105,7 +106,7 @@ public class StateMachineSelfTests
         Assert.Equal(Status.Interesting, status);
     }
 
-    [Fact]
+    [Property]
     public async Task CommandSequenceShrinkPass_Idempotent_NoFurtherProgressAfterShrink()
     {
         ConjectureSettings settings = new() { Seed = 1UL, MaxExamples = 100, UseDatabase = false };

--- a/src/Conjecture.SelfTests/StrategyLawTests.cs
+++ b/src/Conjecture.SelfTests/StrategyLawTests.cs
@@ -3,7 +3,7 @@
 
 using Conjecture.Core;
 using Conjecture.Core.Internal;
-using Conjecture.Xunit.V3;
+using Conjecture.TestingPlatform;
 
 using Xunit;
 
@@ -11,7 +11,7 @@ namespace Conjecture.SelfTests;
 
 public class StrategyLawTests
 {
-    [Fact]
+    [Property]
     public async Task FunctorIdentity_SelectIdentity_ProducesSameValue()
     {
         ConjectureSettings settings = new() { Seed = 0xC0FFEEul, MaxExamples = 1, UseDatabase = false };
@@ -25,7 +25,7 @@ public class StrategyLawTests
         Assert.Equal(baseline, mapped);
     }
 
-    [Fact]
+    [Property]
     public async Task FilterTrue_WhereAlwaysTrue_ProducesSameValue()
     {
         ConjectureSettings settings = new() { Seed = 0xDEADBEEFul, MaxExamples = 1, UseDatabase = false };
@@ -39,7 +39,7 @@ public class StrategyLawTests
         Assert.Equal(baseline, filtered);
     }
 
-    [Fact]
+    [Property]
     public async Task FilterFalse_WhereNeverTrue_NoValidExamplesProduced()
     {
         // MaxExamples = 1 keeps the test fast; all attempts are filtered so no valid examples run.
@@ -51,7 +51,7 @@ public class StrategyLawTests
         Assert.Equal(0, result.ExampleCount);
     }
 
-    [Fact]
+    [Property]
     public async Task SelectManyAssociativity_ConstantStrategies_BothSidesEqual()
     {
         ConjectureSettings settings = new() { Seed = 777ul, MaxExamples = 1, UseDatabase = false };

--- a/src/Conjecture.SelfTests/TargetingSelfTests.cs
+++ b/src/Conjecture.SelfTests/TargetingSelfTests.cs
@@ -3,6 +3,7 @@
 
 using Conjecture.Core;
 using Conjecture.Core.Internal;
+using Conjecture.TestingPlatform;
 
 using Xunit;
 
@@ -15,7 +16,7 @@ public class TargetingSelfTests
     private static readonly Strategy<List<int>> ListStrategy =
         Generate.Lists(Generate.Just(0), 0, 100);
 
-    [Fact]
+    [Property]
     public async Task HillClimbing_MonotoneScoredProperty_ScoreNeverRegressesBelowGenerationBest()
     {
         const ulong seed = 99UL;
@@ -63,7 +64,7 @@ public class TargetingSelfTests
             $"Targeting score {targetedScore} regressed below generation best {generationBest}");
     }
 
-    [Fact]
+    [Property]
     public async Task TargetingPhase_ExampleCount_NeverExceedsBudget()
     {
         ConjectureSettings settings = new()
@@ -85,7 +86,7 @@ public class TargetingSelfTests
             $"ExampleCount {result.ExampleCount} exceeds MaxExamples {settings.MaxExamples}");
     }
 
-    [Fact]
+    [Property]
     public async Task TargetingPhase_RecordedScores_AreAllFinite()
     {
         ConjectureSettings settings = new()

--- a/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
+++ b/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
@@ -126,6 +126,7 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
         TestNodeUid parentNodeUid = new(uid);
         ParameterInfo[] parameters = method.GetParameters();
         bool exampleFailed = false;
+        object? instance = method.IsStatic ? null : Activator.CreateInstance(method.DeclaringType!);
 
         ExampleAttribute[] examples = method.GetCustomAttributes<ExampleAttribute>().ToArray();
         for (int i = 0; i < examples.Length; i++)
@@ -144,11 +145,11 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
                 TestCaseHelper.ValidateExampleArgs(example, parameters);
                 if (TestCaseHelper.IsAsyncReturnType(method.ReturnType))
                 {
-                    await TestCaseHelper.InvokeAsync(method, null, example.Arguments!);
+                    await TestCaseHelper.InvokeAsync(method, instance, example.Arguments!);
                 }
                 else
                 {
-                    TestCaseHelper.InvokeSync(method, null, example.Arguments!);
+                    TestCaseHelper.InvokeSync(method, instance, example.Arguments!);
                 }
 
                 childNode.Properties.Add(PassedTestNodeStateProperty.CachedInstance);
@@ -194,11 +195,11 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
             {
                 if (TestCaseHelper.IsAsyncReturnType(method.ReturnType))
                 {
-                    await TestCaseHelper.InvokeAsync(method, null, []);
+                    await TestCaseHelper.InvokeAsync(method, instance, []);
                 }
                 else
                 {
-                    TestCaseHelper.InvokeSync(method, null, []);
+                    TestCaseHelper.InvokeSync(method, instance, []);
                 }
 
                 node.Properties.Add(PassedTestNodeStateProperty.CachedInstance);
@@ -243,10 +244,10 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
             object[] args = SharedParameterStrategyResolver.Resolve(parameters, data);
             if (TestCaseHelper.IsAsyncReturnType(method.ReturnType))
             {
-                return TestCaseHelper.InvokeAsync(method, null, args);
+                return TestCaseHelper.InvokeAsync(method, instance, args);
             }
 
-            TestCaseHelper.InvokeSync(method, null, args);
+            TestCaseHelper.InvokeSync(method, instance, args);
             return Task.CompletedTask;
         }
 
@@ -264,7 +265,18 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
         }
         else
         {
-            string failureMessage = TestCaseHelper.BuildFailureMessage(result, parameters);
+            string failureMessage;
+            try
+            {
+                failureMessage = TestCaseHelper.BuildFailureMessage(result, parameters);
+            }
+            catch (Exception)
+            {
+                failureMessage = result.FailureStackTrace is not null
+                    ? $"Property failed.{Environment.NewLine}{result.FailureStackTrace}"
+                    : "Property failed.";
+            }
+
             resultNode.Properties.Add(new FailedTestNodeStateProperty(failureMessage));
             if (capabilities?.TrxEnabled == true)
             {

--- a/src/Conjecture.TestingPlatform/PropertyAttribute.cs
+++ b/src/Conjecture.TestingPlatform/PropertyAttribute.cs
@@ -9,12 +9,11 @@ namespace Conjecture.TestingPlatform;
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class PropertyAttribute : Attribute, IPropertyTest, IReproductionExport
 {
-    ulong IPropertyTest.Seed => Seed ?? 0;
     /// <summary>Maximum number of examples to generate. Defaults to 100.</summary>
     public int MaxExamples { get; set; } = 100;
 
-    /// <summary>Optional fixed seed for deterministic runs. Null means use a random seed.</summary>
-    public ulong? Seed { get; set; }
+    /// <summary>Optional fixed seed for deterministic runs. 0 means use a random seed.</summary>
+    public ulong Seed { get; set; }
 
     /// <summary>Whether to use the example database. Defaults to <see langword="true"/>.</summary>
     public bool UseDatabase { get; set; } = true;

--- a/src/Conjecture.TestingPlatform/PublicAPI.Shipped.txt
+++ b/src/Conjecture.TestingPlatform/PublicAPI.Shipped.txt
@@ -11,7 +11,7 @@ Conjecture.TestingPlatform.PropertyAttribute.MaxStrategyRejections.get -> int
 Conjecture.TestingPlatform.PropertyAttribute.MaxStrategyRejections.set -> void
 Conjecture.TestingPlatform.PropertyAttribute.ReproOutputPath.get -> string!
 Conjecture.TestingPlatform.PropertyAttribute.ReproOutputPath.set -> void
-Conjecture.TestingPlatform.PropertyAttribute.Seed.get -> ulong?
+Conjecture.TestingPlatform.PropertyAttribute.Seed.get -> ulong
 Conjecture.TestingPlatform.PropertyAttribute.Seed.set -> void
 Conjecture.TestingPlatform.PropertyAttribute.Targeting.get -> bool
 Conjecture.TestingPlatform.PropertyAttribute.Targeting.set -> void

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -68,6 +68,9 @@
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="1.9.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="1.9.1" />
 
+    <!-- xunit assertions (standalone, no runner) -->
+    <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
+
     <!-- F# -->
     <PackageVersion Include="FSharp.Core" Version="10.1.201" />
     <PackageVersion Include="Expecto" Version="10.2.3" />


### PR DESCRIPTION
## Description

Migrates `Conjecture.SelfTests` from the xunit v3 runner to `Conjecture.TestingPlatform` (MTP adapter). The self-tests now run as a standalone executable via `dotnet run`, discovering and executing `[Property]`-attributed methods through the same framework NuGet consumers use.

Along the way, three latent bugs in `PropertyTestFramework` were uncovered and fixed:

- **Null instance crash**: all `method.Invoke` calls used `null` as the instance; non-static test classes now get an instance via `Activator.CreateInstance`
- **BuildFailureMessage crash on database replay**: the database-replay path can produce IR nodes that exhaust the buffer during message construction; wrapped in try-catch with a fallback message
- **`PropertyAttribute.Seed` was `ulong?`**: nullable types are not valid C# attribute parameter types (CS0655); changed to `ulong` with `0` meaning "random seed", matching all other adapters

Also adds `.conjecture/` to `.gitignore` (the local shrink cache directory created at runtime).

## Type of change

- [x] Bug fix
- [x] Refactor (no behavior change)

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #212
Part of #210