### PR TITLE
[294.1] Conjecture.Regex scaffold + RegexParser

### DIFF
--- a/src/Conjecture.Regex.Tests/Conjecture.Regex.Tests.csproj
+++ b/src/Conjecture.Regex.Tests/Conjecture.Regex.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);xUnit2013</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Regex\Conjecture.Regex.csproj" />
+    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.Regex.Tests/RegexParserTests.cs
+++ b/src/Conjecture.Regex.Tests/RegexParserTests.cs
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using RegexUnicodeCategory = Conjecture.Regex.UnicodeCategory;
+
+namespace Conjecture.Regex.Tests;
+
+public class RegexParserTests
+{
+    // ── Literal ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_LiteralString_ReturnsSequenceOfLiterals()
+    {
+        RegexNode result = RegexParser.Parse("abc", RegexOptions.None);
+
+        Sequence seq = Assert.IsType<Sequence>(result);
+        Assert.Equal(3, seq.Items.Count);
+        Literal a = Assert.IsType<Literal>(seq.Items[0]);
+        Literal b = Assert.IsType<Literal>(seq.Items[1]);
+        Literal c = Assert.IsType<Literal>(seq.Items[2]);
+        Assert.Equal('a', a.Ch);
+        Assert.Equal('b', b.Ch);
+        Assert.Equal('c', c.Ch);
+    }
+
+    [Fact]
+    public void Parse_SingleLiteral_ReturnsLiteralNode()
+    {
+        RegexNode result = RegexParser.Parse("x", RegexOptions.None);
+
+        Literal lit = Assert.IsType<Literal>(result);
+        Assert.Equal('x', lit.Ch);
+    }
+
+    // ── CharClass ─────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("[a-z]", false)]
+    [InlineData("[^0-9]", true)]
+    public void Parse_CharClass_ReturnsCharClassWithCorrectNegation(string pattern, bool expectedNegated)
+    {
+        RegexNode result = RegexParser.Parse(pattern, RegexOptions.None);
+
+        CharClass cc = Assert.IsType<CharClass>(result);
+        Assert.Equal(expectedNegated, cc.Negated);
+        Assert.NotEmpty(cc.Ranges);
+    }
+
+    [Fact]
+    public void Parse_CharClassAtoZ_HasCorrectRange()
+    {
+        RegexNode result = RegexParser.Parse("[a-z]", RegexOptions.None);
+
+        CharClass cc = Assert.IsType<CharClass>(result);
+        Assert.False(cc.Negated);
+        Assert.Equal(1, cc.Ranges.Count);
+        Assert.Equal('a', cc.Ranges[0].Low);
+        Assert.Equal('z', cc.Ranges[0].High);
+    }
+
+    [Fact]
+    public void Parse_CharClassNegatedDigits_HasCorrectRangeAndNegated()
+    {
+        RegexNode result = RegexParser.Parse("[^0-9]", RegexOptions.None);
+
+        CharClass cc = Assert.IsType<CharClass>(result);
+        Assert.True(cc.Negated);
+        Assert.Equal('0', cc.Ranges[0].Low);
+        Assert.Equal('9', cc.Ranges[0].High);
+    }
+
+    [Fact]
+    public void Parse_CharClassWordShorthand_ReturnsCharClassNode()
+    {
+        // [\w] is a shorthand char class
+        RegexNode result = RegexParser.Parse(@"[\w]", RegexOptions.None);
+
+        Assert.IsType<CharClass>(result);
+    }
+
+    // ── Quantifiers ───────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("a*", 0, null, false)]
+    [InlineData("a+", 1, null, false)]
+    [InlineData("a?", 0, 1, false)]
+    [InlineData("a{3}", 3, 3, false)]
+    [InlineData("a{2,5}", 2, 5, false)]
+    [InlineData("a*?", 0, null, true)]
+    public void Parse_Quantifier_ReturnsCorrectMinMaxLazy(
+        string pattern,
+        int expectedMin,
+        int? expectedMax,
+        bool expectedLazy)
+    {
+        RegexNode result = RegexParser.Parse(pattern, RegexOptions.None);
+
+        Quantifier q = Assert.IsType<Quantifier>(result);
+        Assert.Equal(expectedMin, q.Min);
+        Assert.Equal(expectedMax, q.Max);
+        Assert.Equal(expectedLazy, q.Lazy);
+        Assert.IsType<Literal>(q.Inner);
+    }
+
+    // ── Alternation ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_Alternation_ReturnsTwoArmAlternation()
+    {
+        RegexNode result = RegexParser.Parse("cat|dog", RegexOptions.None);
+
+        Alternation alt = Assert.IsType<Alternation>(result);
+        Assert.Equal(2, alt.Arms.Count);
+    }
+
+    // ── Groups ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_CapturingGroup_ReturnsCaptureIndexOne()
+    {
+        RegexNode result = RegexParser.Parse("(foo)", RegexOptions.None);
+
+        Group grp = Assert.IsType<Group>(result);
+        Assert.Equal(1, grp.CaptureIndex);
+        Assert.Null(grp.Name);
+    }
+
+    [Fact]
+    public void Parse_NamedGroup_ReturnsGroupWithName()
+    {
+        RegexNode result = RegexParser.Parse(@"(?<year>\d{4})", RegexOptions.None);
+
+        Group grp = Assert.IsType<Group>(result);
+        Assert.Equal("year", grp.Name);
+        Assert.NotNull(grp.CaptureIndex);
+    }
+
+    // ── Anchors ───────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("^", 0)]
+    [InlineData("$", 1)]
+    [InlineData(@"\b", 2)]
+    public void Parse_Anchor_ReturnsCorrectAnchorKind(string pattern, int expectedKind)
+    {
+        RegexNode result = RegexParser.Parse(pattern, RegexOptions.None);
+
+        Anchor anchor = Assert.IsType<Anchor>(result);
+        Assert.Equal((AnchorKind)expectedKind, anchor.Kind);
+    }
+
+    // ── Dot ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_Dot_WithoutSingleline_ReturnsDotNode()
+    {
+        // Without Singleline, dot matches any char except newline.
+        // The AST shape is Dot regardless; Singleline is carried by RegexOptions at
+        // evaluation time, not encoded in the node.
+        RegexNode result = RegexParser.Parse(".", RegexOptions.None);
+
+        Assert.IsType<Dot>(result);
+    }
+
+    [Fact]
+    public void Parse_Dot_WithSingleline_ReturnsDotNode()
+    {
+        // With Singleline, dot matches newlines too. AST shape remains Dot.
+        RegexNode result = RegexParser.Parse(".", RegexOptions.Singleline);
+
+        Assert.IsType<Dot>(result);
+    }
+
+    // ── Unicode categories ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_UnicodeCategoryPositive_ReturnsCategoryNode()
+    {
+        RegexNode result = RegexParser.Parse(@"\p{L}", RegexOptions.None);
+
+        RegexUnicodeCategory cat = Assert.IsType<RegexUnicodeCategory>(result);
+        Assert.Equal("L", cat.Category);
+        Assert.False(cat.Negated);
+    }
+
+    [Fact]
+    public void Parse_UnicodeCategoryNegated_ReturnsCategoryNodeWithNegatedTrue()
+    {
+        RegexNode result = RegexParser.Parse(@"\P{Nd}", RegexOptions.None);
+
+        RegexUnicodeCategory cat = Assert.IsType<RegexUnicodeCategory>(result);
+        Assert.Equal("Nd", cat.Category);
+        Assert.True(cat.Negated);
+    }
+
+    // ── Lookaround ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_PositiveLookahead_ReturnsLookaroundAheadPositive()
+    {
+        RegexNode result = RegexParser.Parse(@"(?=\d)", RegexOptions.None);
+
+        LookaroundAssertion la = Assert.IsType<LookaroundAssertion>(result);
+        Assert.True(la.IsAhead);
+        Assert.True(la.IsPositive);
+    }
+
+    [Fact]
+    public void Parse_NegativeLookahead_ReturnsLookaroundAheadNegative()
+    {
+        RegexNode result = RegexParser.Parse(@"(?!\d)", RegexOptions.None);
+
+        LookaroundAssertion la = Assert.IsType<LookaroundAssertion>(result);
+        Assert.True(la.IsAhead);
+        Assert.False(la.IsPositive);
+    }
+
+    [Fact]
+    public void Parse_PositiveLookbehind_ReturnsLookaroundBehindPositive()
+    {
+        RegexNode result = RegexParser.Parse(@"(?<=\s)", RegexOptions.None);
+
+        LookaroundAssertion la = Assert.IsType<LookaroundAssertion>(result);
+        Assert.False(la.IsAhead);
+        Assert.True(la.IsPositive);
+    }
+
+    [Fact]
+    public void Parse_NegativeLookbehind_ReturnsLookaroundBehindNegative()
+    {
+        RegexNode result = RegexParser.Parse(@"(?<!\s)", RegexOptions.None);
+
+        LookaroundAssertion la = Assert.IsType<LookaroundAssertion>(result);
+        Assert.False(la.IsAhead);
+        Assert.False(la.IsPositive);
+    }
+
+    // ── Backreferences ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Parse_NumericBackreference_ReturnsBackreferenceWithIndex()
+    {
+        // (a)\1 — group 1 then backreference to group 1
+        RegexNode result = RegexParser.Parse(@"(a)\1", RegexOptions.None);
+
+        Sequence seq = Assert.IsType<Sequence>(result);
+        Assert.Equal(2, seq.Items.Count);
+        Assert.IsType<Group>(seq.Items[0]);
+        Backreference bref = Assert.IsType<Backreference>(seq.Items[1]);
+        Assert.Equal(1, bref.Index);
+    }
+
+    [Fact]
+    public void Parse_NamedBackreference_ReturnsNamedBackreferenceWithName()
+    {
+        // (?<w>\w+)\k<w>
+        RegexNode result = RegexParser.Parse(@"(?<w>\w+)\k<w>", RegexOptions.None);
+
+        Sequence seq = Assert.IsType<Sequence>(result);
+        Assert.Equal(2, seq.Items.Count);
+        Assert.IsType<Group>(seq.Items[0]);
+        NamedBackreference nbref = Assert.IsType<NamedBackreference>(seq.Items[1]);
+        Assert.Equal("w", nbref.Name);
+    }
+
+    // ── CharRange struct ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void CharRange_LowAndHighProperties_RoundTrip()
+    {
+        CharRange range = new('a', 'z');
+
+        Assert.Equal('a', range.Low);
+        Assert.Equal('z', range.High);
+    }
+}

--- a/src/Conjecture.Regex/Conjecture.Regex.csproj
+++ b/src/Conjecture.Regex/Conjecture.Regex.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Conjecture.Regex.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.Regex/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Regex/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.Regex/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Regex/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.Regex/RegexNode.cs
+++ b/src/Conjecture.Regex/RegexNode.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+
+namespace Conjecture.Regex;
+
+internal abstract record RegexNode;
+
+internal record Literal(char Ch) : RegexNode;
+
+internal record CharClass(IReadOnlyList<CharRange> Ranges, bool Negated) : RegexNode;
+
+internal record Quantifier(RegexNode Inner, int Min, int? Max, bool Lazy) : RegexNode;
+
+internal record Alternation(IReadOnlyList<RegexNode> Arms) : RegexNode;
+
+internal record Sequence(IReadOnlyList<RegexNode> Items) : RegexNode;
+
+internal record Group(RegexNode Inner, int? CaptureIndex, string? Name) : RegexNode;
+
+internal record Anchor(AnchorKind Kind) : RegexNode;
+
+internal record Backreference(int Index) : RegexNode;
+
+internal record NamedBackreference(string Name) : RegexNode;
+
+internal record LookaroundAssertion(RegexNode Inner, bool IsAhead, bool IsPositive) : RegexNode;
+
+internal record UnicodeCategory(string Category, bool Negated) : RegexNode;
+
+internal record Dot : RegexNode;
+
+internal readonly record struct CharRange(char Low, char High);
+
+internal enum AnchorKind
+{
+    Start,
+    End,
+    WordBoundary,
+    NonWordBoundary,
+}

--- a/src/Conjecture.Regex/RegexParser.cs
+++ b/src/Conjecture.Regex/RegexParser.cs
@@ -1,0 +1,438 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Conjecture.Regex;
+
+internal static class RegexParser
+{
+    internal static RegexNode Parse(string pattern, RegexOptions options)
+    {
+        _ = options;
+        Parser parser = new(pattern);
+        return parser.ParseAlternation();
+    }
+
+    private sealed class Parser(string pattern)
+    {
+        private static readonly IReadOnlyList<CharRange> WordRanges =
+            [new('a', 'z'), new('A', 'Z'), new('0', '9'), new('_', '_')];
+
+        private static readonly IReadOnlyList<CharRange> SpaceRanges =
+            [new(' ', ' '), new('\t', '\t'), new('\n', '\n'), new('\r', '\r'), new('\f', '\f')];
+
+        private static readonly IReadOnlyList<CharRange> DigitRanges =
+            [new('0', '9')];
+
+        private readonly string pat = pattern;
+        private int pos = 0;
+        private int captureCounter = 0;
+
+        private bool AtEnd => pos >= pat.Length;
+
+        private char Current => pat[pos];
+
+        private char Consume()
+        {
+            char ch = pat[pos];
+            pos++;
+            return ch;
+        }
+
+        internal RegexNode ParseAlternation()
+        {
+            List<RegexNode> arms = [];
+            arms.Add(ParseSequence());
+
+            while (!AtEnd && Current == '|')
+            {
+                pos++;
+                arms.Add(ParseSequence());
+            }
+
+            return arms.Count == 1 ? arms[0] : new Alternation(arms);
+        }
+
+        private RegexNode ParseSequence()
+        {
+            List<RegexNode> items = [];
+
+            while (!AtEnd && Current != '|' && Current != ')')
+            {
+                RegexNode atom = ParseAtomWithQuantifier();
+                items.Add(atom);
+            }
+
+            return items.Count == 1 ? items[0] : new Sequence(items);
+        }
+
+        private RegexNode ParseAtomWithQuantifier()
+        {
+            RegexNode atom = ParseAtom();
+            return TryParseQuantifier(atom);
+        }
+
+        private RegexNode TryParseQuantifier(RegexNode inner)
+        {
+            if (AtEnd)
+            {
+                return inner;
+            }
+
+            int min;
+            int? max;
+
+            switch (Current)
+            {
+                case '*':
+                    pos++;
+                    min = 0;
+                    max = null;
+                    break;
+                case '+':
+                    pos++;
+                    min = 1;
+                    max = null;
+                    break;
+                case '?':
+                    pos++;
+                    min = 0;
+                    max = 1;
+                    break;
+                case '{':
+                    (min, max) = ParseBraceQuantifier();
+                    break;
+                default:
+                    return inner;
+            }
+
+            bool lazy = !AtEnd && Current == '?';
+            if (lazy)
+            {
+                pos++;
+            }
+
+            return new Quantifier(inner, min, max, lazy);
+        }
+
+        private (int min, int? max) ParseBraceQuantifier()
+        {
+            pos++;
+            int min = ParseInt();
+
+            if (!AtEnd && Current == '}')
+            {
+                pos++;
+                return (min, min);
+            }
+
+            pos++;
+
+            if (!AtEnd && Current == '}')
+            {
+                pos++;
+                return (min, null);
+            }
+
+            int max = ParseInt();
+            pos++;
+            return (min, max);
+        }
+
+        private int ParseInt()
+        {
+            int start = pos;
+            while (!AtEnd && char.IsDigit(Current))
+            {
+                pos++;
+            }
+
+            return int.Parse(pat.AsSpan(start, pos - start));
+        }
+
+        private RegexNode ParseAtom()
+        {
+            if (AtEnd)
+            {
+                throw new InvalidOperationException("Unexpected end of pattern");
+            }
+
+            char ch = Current;
+
+            if (ch == '(')
+            {
+                return ParseGroup();
+            }
+
+            if (ch == '[')
+            {
+                return ParseCharClass();
+            }
+
+            if (ch == '\\')
+            {
+                return ParseEscape();
+            }
+
+            if (ch == '^')
+            {
+                pos++;
+                return new Anchor(AnchorKind.Start);
+            }
+
+            if (ch == '$')
+            {
+                pos++;
+                return new Anchor(AnchorKind.End);
+            }
+
+            if (ch == '.')
+            {
+                pos++;
+                return new Dot();
+            }
+
+            pos++;
+            return new Literal(ch);
+        }
+
+        private RegexNode ParseGroup()
+        {
+            pos++;
+
+            if (!AtEnd && Current == '?')
+            {
+                pos++;
+
+                if (!AtEnd && Current == '<')
+                {
+                    pos++;
+                    if (!AtEnd && (Current == '=' || Current == '!'))
+                    {
+                        bool isPositive = Current == '=';
+                        pos++;
+                        RegexNode inner = ParseAlternation();
+                        pos++;
+                        return new LookaroundAssertion(inner, false, isPositive);
+                    }
+                    else
+                    {
+                        string name = ParseGroupName('>');
+                        captureCounter++;
+                        int captureIdx = captureCounter;
+                        RegexNode inner = ParseAlternation();
+                        pos++;
+                        return new Group(inner, captureIdx, name);
+                    }
+                }
+
+                if (!AtEnd && Current == '=')
+                {
+                    pos++;
+                    RegexNode inner = ParseAlternation();
+                    pos++;
+                    return new LookaroundAssertion(inner, true, true);
+                }
+
+                if (!AtEnd && Current == '!')
+                {
+                    pos++;
+                    RegexNode inner = ParseAlternation();
+                    pos++;
+                    return new LookaroundAssertion(inner, true, false);
+                }
+
+                if (!AtEnd && Current == ':')
+                {
+                    pos++;
+                }
+
+                RegexNode ncInner = ParseAlternation();
+                pos++;
+                return ncInner;
+            }
+
+            captureCounter++;
+            int idx = captureCounter;
+            RegexNode groupInner = ParseAlternation();
+            pos++;
+            return new Group(groupInner, idx, null);
+        }
+
+        private string ParseGroupName(char terminator)
+        {
+            int start = pos;
+            while (!AtEnd && Current != terminator)
+            {
+                pos++;
+            }
+
+            string name = pat[start..pos];
+            pos++;
+            return name;
+        }
+
+        private RegexNode ParseCharClass()
+        {
+            pos++;
+
+            bool negated = !AtEnd && Current == '^';
+            if (negated)
+            {
+                pos++;
+            }
+
+            List<CharRange> ranges = [];
+
+            while (!AtEnd && Current != ']')
+            {
+                if (Current == '\\')
+                {
+                    pos++;
+                    char escaped = Consume();
+                    IReadOnlyList<CharRange>? shorthandRanges = GetShorthandRanges(escaped);
+                    if (shorthandRanges is not null)
+                    {
+                        foreach (CharRange r in shorthandRanges)
+                        {
+                            ranges.Add(r);
+                        }
+                    }
+                    else
+                    {
+                        char low = UnescapeChar(escaped);
+                        if (!AtEnd && Current == '-' && pos + 1 < pat.Length && pat[pos + 1] != ']')
+                        {
+                            pos++;
+                            char next = Consume();
+                            ranges.Add(new CharRange(low, next));
+                        }
+                        else
+                        {
+                            ranges.Add(new CharRange(low, low));
+                        }
+                    }
+                }
+                else
+                {
+                    char low = Consume();
+                    if (!AtEnd && Current == '-' && pos + 1 < pat.Length && pat[pos + 1] != ']')
+                    {
+                        pos++;
+                        char high = Consume();
+                        ranges.Add(new CharRange(low, high));
+                    }
+                    else
+                    {
+                        ranges.Add(new CharRange(low, low));
+                    }
+                }
+            }
+
+            pos++;
+
+            return new CharClass(ranges, negated);
+        }
+
+        private RegexNode ParseEscape()
+        {
+            pos++;
+            if (AtEnd)
+            {
+                throw new InvalidOperationException("Unexpected end after backslash");
+            }
+
+            char ch = Consume();
+
+            if (ch == 'b')
+            {
+                return new Anchor(AnchorKind.WordBoundary);
+            }
+
+            if (ch == 'B')
+            {
+                return new Anchor(AnchorKind.NonWordBoundary);
+            }
+
+            if (ch == 'd')
+            {
+                return new CharClass(DigitRanges, false);
+            }
+
+            if (ch == 'D')
+            {
+                return new CharClass(DigitRanges, true);
+            }
+
+            if (ch == 'w')
+            {
+                return new CharClass(WordRanges, false);
+            }
+
+            if (ch == 'W')
+            {
+                return new CharClass(WordRanges, true);
+            }
+
+            if (ch == 's')
+            {
+                return new CharClass(SpaceRanges, false);
+            }
+
+            if (ch == 'S')
+            {
+                return new CharClass(SpaceRanges, true);
+            }
+
+            if (ch == 'p' || ch == 'P')
+            {
+                bool negated = ch == 'P';
+                pos++;
+                int start = pos;
+                while (!AtEnd && Current != '}')
+                {
+                    pos++;
+                }
+
+                string category = pat[start..pos];
+                pos++;
+                return new UnicodeCategory(category, negated);
+            }
+
+            if (ch == 'k')
+            {
+                pos++;
+                string name = ParseGroupName('>');
+                return new NamedBackreference(name);
+            }
+
+            if (char.IsDigit(ch))
+            {
+                int index = ch - '0';
+                return new Backreference(index);
+            }
+
+            return new Literal(UnescapeChar(ch));
+        }
+
+        private static char UnescapeChar(char ch)
+        {
+            return ch switch
+            {
+                'n' => '\n',
+                'r' => '\r',
+                't' => '\t',
+                'f' => '\f',
+                _ => ch,
+            };
+        }
+
+        private static IReadOnlyList<CharRange>? GetShorthandRanges(char ch)
+        {
+            return ch == 'd' ? DigitRanges : ch == 'w' ? WordRanges : ch == 's' ? SpaceRanges : null;
+        }
+    }
+}

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -25,6 +25,8 @@
   <Project Path="Conjecture.Tool.Tests/Conjecture.Tool.Tests.csproj" />
   <Project Path="Conjecture.Time/Conjecture.Time.csproj" />
   <Project Path="Conjecture.Time.Tests/Conjecture.Time.Tests.csproj" />
+  <Project Path="Conjecture.Regex/Conjecture.Regex.csproj" />
+  <Project Path="Conjecture.Regex.Tests/Conjecture.Regex.Tests.csproj" />
   <Project Path="Conjecture.Interactive/Conjecture.Interactive.csproj" />
   <Project Path="Conjecture.Interactive.Tests/Conjecture.Interactive.Tests.csproj" />
   <Project Path="Conjecture.TestingPlatform/Conjecture.TestingPlatform.csproj" />


### PR DESCRIPTION
## Description

Scaffolds the `Conjecture.Regex` satellite package and its paired test project, wires both into `Conjecture.slnx`, and lands the internal recursive-descent `RegexParser` with a full `RegexNode` AST.

Parser covers every construct named in the cycle's test contract: literals, char classes (`[a-z]`, `[^0-9]`, `[\w]`), shorthand escapes (`\d`/`\w`/`\s`), quantifiers (`*`, `+`, `?`, `{n}`, `{n,m}`, lazy variants), alternation, capturing and named groups, anchors (`^`, `$`, `\b`, `\B`), `.`, Unicode categories (`\p{X}` / `\P{X}`), lookahead and lookbehind (positive and negative), and numeric / named backreferences. All AST types and the parser itself are `internal` — the tests access them via `InternalsVisibleTo`.

Shorthand char-class ranges are cached in static readonly fields to avoid per-parse allocation. `RegexOptions` flows through the API surface but is not yet consumed — intentional: later cycles (IgnoreCase/Singleline/Multiline handling) will wire it in.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes (30/30 `RegexParserTests` green; full suite unaffected)
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #349
Part of #294