### PR TITLE
[294.3] LookaroundStrategy: proper lookahead/lookbehind generation

### DIFF
--- a/src/Conjecture.Regex.Tests/LookaroundStrategyTests.cs
+++ b/src/Conjecture.Regex.Tests/LookaroundStrategyTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Linq;
+
+using Conjecture.Core;
+using Conjecture.Regex;
+
+using DotNetRegex = System.Text.RegularExpressions.Regex;
+
+namespace Conjecture.Regex.Tests;
+
+public class LookaroundStrategyTests
+{
+    // ── 1. Positive lookahead chain: length >= 8, has digit, has lowercase ────
+
+    [Fact]
+    public void Matching_PositiveLookaheadChain_GeneratesStringWithRequiredClasses()
+    {
+        string pattern = @"(?=.*\d)(?=.*[a-z]).{8,}";
+        DotNetRegex regex = new(pattern);
+        ulong seed = 1UL;
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.Matching(pattern), 50, seed);
+
+        Assert.All(samples, s =>
+        {
+            Assert.True(s.Length >= 8, $"Expected length >= 8, got {s.Length}: '{s}'");
+            Assert.True(s.Any(char.IsDigit), $"Expected at least one digit in '{s}'");
+            Assert.True(s.Any(c => c >= 'a' && c <= 'z'), $"Expected at least one lowercase letter in '{s}'");
+            Assert.True(regex.IsMatch(s), s);
+        });
+    }
+
+    // ── 2. Negative lookahead: no sample starts with a digit ─────────────────
+
+    [Fact]
+    public void Matching_NegativeLookaheadBeforeWordChars_NoSampleStartsWithDigit()
+    {
+        string pattern = @"(?!\d)\w+";
+        DotNetRegex regex = new(pattern);
+        ulong seed = 2UL;
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.Matching(pattern), 50, seed);
+
+        Assert.All(samples, s =>
+        {
+            Assert.True(regex.IsMatch(s), s);
+            Assert.True(!char.IsDigit(s[0]), $"Expected first char not to be digit in '{s}'");
+        });
+    }
+
+    // ── 3. Positive lookbehind: generation does not throw; every sample matches
+
+    [Fact]
+    public void Matching_PositiveLookbehindAfterWhitespace_DoesNotThrowAndMatches()
+    {
+        string pattern = @"(?<=\s)\w+";
+        DotNetRegex regex = new(pattern);
+        ulong seed = 3UL;
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.Matching(pattern), 50, seed);
+
+        Assert.All(samples, s => Assert.True(regex.IsMatch(s), s));
+    }
+
+    // ── 4. Negative lookbehind: every sample matches ──────────────────────────
+
+    [Fact]
+    public void Matching_NegativeLookbehindExcludingWhitespace_DoesNotFollowWhitespace()
+    {
+        string pattern = @"(?<!\s)\w+";
+        DotNetRegex regex = new(pattern);
+        ulong seed = 4UL;
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.Matching(pattern), 50, seed);
+
+        Assert.All(samples, s => Assert.True(regex.IsMatch(s), s));
+    }
+
+    // ── 5. Impossible negative lookahead: falls back, produces empty strings ──
+
+    [Fact]
+    public void Matching_NegativeLookaheadOverFullAlphabet_FallsBackToFilterAndCompletes()
+    {
+        string pattern = @"(?![\s\S]).*";
+        DotNetRegex regex = new(pattern);
+        ulong seed = 5UL;
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.Matching(pattern), 20, seed);
+
+        Assert.All(samples, s => Assert.True(regex.IsMatch(s), s));
+    }
+}

--- a/src/Conjecture.Regex/CharRangeHelpers.cs
+++ b/src/Conjecture.Regex/CharRangeHelpers.cs
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+
+using Conjecture.Core;
+
+namespace Conjecture.Regex;
+
+internal static class CharRangeHelpers
+{
+    internal static IReadOnlyList<CharRange> ComplementRanges(
+        IReadOnlyList<CharRange> ranges,
+        char low,
+        char high)
+    {
+        List<(int Lo, int Hi)> sorted = [];
+        foreach (CharRange r in ranges)
+        {
+            sorted.Add((r.Low, r.High));
+        }
+
+        sorted.Sort(static (a, b) => a.Lo.CompareTo(b.Lo));
+
+        List<CharRange> result = [];
+        int cursor = low;
+        foreach ((int rLo, int rHi) in sorted)
+        {
+            if (rLo > cursor)
+            {
+                result.Add(new CharRange((char)cursor, (char)(rLo - 1)));
+            }
+
+            int next = rHi + 1;
+            if (next > cursor)
+            {
+                cursor = next;
+            }
+
+            if (cursor > high)
+            {
+                break;
+            }
+        }
+
+        if (cursor <= high)
+        {
+            result.Add(new CharRange((char)cursor, high));
+        }
+
+        return result;
+    }
+
+    internal static IReadOnlyList<CharRange> IntersectRangeLists(
+        IReadOnlyList<CharRange> a,
+        IReadOnlyList<CharRange> b)
+    {
+        List<CharRange> result = [];
+        foreach (CharRange ra in a)
+        {
+            foreach (CharRange rb in b)
+            {
+                int lo = ra.Low > rb.Low ? ra.Low : rb.Low;
+                int hi = ra.High < rb.High ? ra.High : rb.High;
+                if (lo <= hi)
+                {
+                    result.Add(new CharRange((char)lo, (char)hi));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    internal static char SampleFromRanges(IReadOnlyList<CharRange> ranges, IGeneratorContext ctx)
+    {
+        int total = 0;
+        foreach (CharRange r in ranges)
+        {
+            total += r.High - r.Low + 1;
+        }
+
+        if (total == 0)
+        {
+            return '\0';
+        }
+
+        int pick = ctx.Generate(Conjecture.Core.Generate.Integers<int>(0, total - 1));
+        foreach (CharRange r in ranges)
+        {
+            int size = r.High - r.Low + 1;
+            if (pick < size)
+            {
+                return (char)(r.Low + pick);
+            }
+
+            pick -= size;
+        }
+
+        return ranges[0].Low;
+    }
+
+    internal static bool CharInRanges(char ch, IReadOnlyList<CharRange> ranges)
+    {
+        foreach (CharRange r in ranges)
+        {
+            if (ch >= r.Low && ch <= r.High)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Conjecture.Regex/CharRequirementExtractor.cs
+++ b/src/Conjecture.Regex/CharRequirementExtractor.cs
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+
+namespace Conjecture.Regex;
+
+/// <summary>
+/// Extracts the char ranges that MUST appear somewhere in a string for a given node to match.
+/// Used by lookaround handling to post-process generated strings.
+/// </summary>
+internal static class CharRequirementExtractor
+{
+    private static readonly CharRange FullRange = new('\u0000', '\uFFFF');
+
+    /// <summary>
+    /// Returns the char ranges that must appear in a string for the given node to match.
+    /// An empty list means no chars are strictly required (the node can match an empty string,
+    /// or we have insufficient static info).
+    /// </summary>
+    internal static IReadOnlyList<CharRange> ExtractRequired(RegexNode node)
+    {
+        return node switch
+        {
+            Literal lit => [new CharRange(lit.Ch, lit.Ch)],
+
+            CharClass { Negated: false } cc => cc.Ranges,
+
+            CharClass { Negated: true } cc => CharRangeHelpers.ComplementRanges(cc.Ranges, '\u0000', '\uFFFF'),
+
+            Dot => [FullRange],
+
+            Quantifier q when q.Min >= 1 => ExtractRequired(q.Inner),
+
+            Quantifier => [],
+
+            Sequence seq => ExtractUnion(seq.Items),
+
+            Alternation alt => ExtractIntersection(alt.Arms),
+
+            Group grp => ExtractRequired(grp.Inner),
+
+            // Anchors, backreferences, lookarounds contribute no char requirements.
+            _ => [],
+        };
+    }
+
+    private static IReadOnlyList<CharRange> ExtractUnion(IReadOnlyList<RegexNode> items)
+    {
+        List<CharRange> result = [];
+        foreach (RegexNode item in items)
+        {
+            IReadOnlyList<CharRange> reqs = ExtractRequired(item);
+            foreach (CharRange r in reqs)
+            {
+                result.Add(r);
+            }
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyList<CharRange> ExtractIntersection(IReadOnlyList<RegexNode> arms)
+    {
+        if (arms.Count == 0)
+        {
+            return [];
+        }
+
+        // Start with the requirements of the first arm, then keep only chars present in ALL arms.
+        IReadOnlyList<CharRange> common = ExtractRequired(arms[0]);
+        for (int i = 1; i < arms.Count; i++)
+        {
+            IReadOnlyList<CharRange> armReqs = ExtractRequired(arms[i]);
+            common = CharRangeHelpers.IntersectRangeLists(common, armReqs);
+            if (common.Count == 0)
+            {
+                return [];
+            }
+        }
+
+        return common;
+    }
+
+    /// <summary>
+    /// Returns true if the given ranges together cover the entire BMP ([\s\S] equivalent).
+    /// </summary>
+    internal static bool CoversFullAlphabet(IReadOnlyList<CharRange> ranges)
+    {
+        if (ranges.Count == 0)
+        {
+            return false;
+        }
+
+        // Sort and check coverage of [0, 0xFFFF].
+        List<(int Lo, int Hi)> sorted = [];
+        foreach (CharRange r in ranges)
+        {
+            sorted.Add((r.Low, r.High));
+        }
+
+        sorted.Sort(static (a, b) => a.Lo.CompareTo(b.Lo));
+
+        int cursor = 0;
+        foreach ((int lo, int hi) in sorted)
+        {
+            if (lo > cursor)
+            {
+                return false;
+            }
+
+            int next = hi + 1;
+            if (next > cursor)
+            {
+                cursor = next;
+            }
+        }
+
+        return cursor > 0xFFFF;
+    }
+}

--- a/src/Conjecture.Regex/LookaroundStrategy.cs
+++ b/src/Conjecture.Regex/LookaroundStrategy.cs
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Text;
+
+using Conjecture.Core;
+
+namespace Conjecture.Regex;
+
+/// <summary>
+/// Handles <see cref="LookaroundAssertion"/> nodes during string generation.
+/// </summary>
+internal static class LookaroundStrategy
+{
+    /// <summary>
+    /// Pre-scans a sequence's items for lookaround assertions and returns two collections:
+    /// <list type="bullet">
+    ///   <item>positiveRequirements — char ranges that MUST appear in the generated body.</item>
+    ///   <item>forbiddenFirstChar — char ranges that must NOT be the first character of the body
+    ///     (derived from negative lookaheads at the head of the sequence).</item>
+    ///   <item>skipBody — set to true when a negative lookahead forbids the entire alphabet,
+    ///     meaning the body should be generated at minimum length (ideally empty).</item>
+    /// </list>
+    /// </summary>
+    internal static void AnalyzeSequence(
+        IReadOnlyList<RegexNode> items,
+        out List<IReadOnlyList<CharRange>> positiveRequirements,
+        out List<IReadOnlyList<CharRange>> negativeFirstCharForbidden,
+        out bool skipBody)
+    {
+        positiveRequirements = [];
+        negativeFirstCharForbidden = [];
+        skipBody = false;
+
+        foreach (RegexNode item in items)
+        {
+            if (item is not LookaroundAssertion la)
+            {
+                continue;
+            }
+
+            IReadOnlyList<CharRange> innerReqs = CharRequirementExtractor.ExtractRequired(la.Inner);
+
+            if (la.IsAhead && la.IsPositive)
+            {
+                // (?=...) — the body must contain chars from innerReqs somewhere.
+                if (innerReqs.Count > 0)
+                {
+                    positiveRequirements.Add(innerReqs);
+                }
+            }
+            else if (la.IsAhead && !la.IsPositive)
+            {
+                // (?!...) — check if it forbids everything.
+                if (CharRequirementExtractor.CoversFullAlphabet(innerReqs))
+                {
+                    // (?![\s\S]) — impossible to have any character; force empty body.
+                    skipBody = true;
+                }
+                else if (innerReqs.Count > 0)
+                {
+                    negativeFirstCharForbidden.Add(innerReqs);
+                }
+            }
+            // Lookbehind assertions (IsAhead=false) are handled at emit time by the caller.
+        }
+    }
+
+    /// <summary>
+    /// Ensures that for each required char group, at least one char from the group
+    /// appears in the body. If not, splices one in at a random position.
+    /// </summary>
+    internal static void SatisfyPositiveRequirements(
+        IGeneratorContext ctx,
+        StringBuilder body,
+        List<IReadOnlyList<CharRange>> requirements,
+        bool firstCharConstrained)
+    {
+        foreach (IReadOnlyList<CharRange> group in requirements)
+        {
+            if (group.Count == 0)
+            {
+                continue;
+            }
+
+            bool satisfied = false;
+            for (int i = 0; i < body.Length; i++)
+            {
+                if (CharRangeHelpers.CharInRanges(body[i], group))
+                {
+                    satisfied = true;
+                    break;
+                }
+            }
+
+            if (!satisfied)
+            {
+                char needed = CharRangeHelpers.SampleFromRanges(group, ctx);
+                if (body.Length == 0)
+                {
+                    body.Append(needed);
+                }
+                else
+                {
+                    // When the first char is constrained by a forbidden-first rule, insertion at
+                    // position 0 would overwrite that constraint; clamp the lower bound to 1.
+                    int minPos = firstCharConstrained ? 1 : 0;
+                    int maxPos = body.Length;
+                    int pos = minPos >= maxPos
+                        ? maxPos
+                        : ctx.Generate(Conjecture.Core.Generate.Integers<int>(minPos, maxPos));
+                    body.Insert(pos, needed);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the complement of the given forbidden ranges within [0x00, 0xFFFF],
+    /// intersected with the allowed ranges.
+    /// </summary>
+    internal static IReadOnlyList<CharRange> ExcludeForbidden(
+        IReadOnlyList<CharRange> allowed,
+        IReadOnlyList<CharRange> forbidden)
+    {
+        if (forbidden.Count == 0)
+        {
+            return allowed;
+        }
+
+        // Build a complement of forbidden, then intersect with allowed.
+        IReadOnlyList<CharRange> complement = CharRangeHelpers.ComplementRanges(forbidden, '\u0000', '\uFFFF');
+        return CharRangeHelpers.IntersectRangeLists(allowed, complement);
+    }
+}

--- a/src/Conjecture.Regex/MatchingStrategy.cs
+++ b/src/Conjecture.Regex/MatchingStrategy.cs
@@ -10,10 +10,13 @@ using System.Text.RegularExpressions;
 using Conjecture.Core;
 using Conjecture.Core.Internal;
 
+using DotNetRegex = System.Text.RegularExpressions.Regex;
+
 namespace Conjecture.Regex;
 
 internal sealed class MatchingStrategy(
     RegexNode root,
+    DotNetRegex regex,
     RegexOptions regexOptions,
     RegexGenOptions genOptions) : Strategy<string>
 {
@@ -47,10 +50,57 @@ internal sealed class MatchingStrategy(
 
     private readonly bool ignoreCase = (regexOptions & RegexOptions.IgnoreCase) != 0;
     private readonly bool singleline = (regexOptions & RegexOptions.Singleline) != 0;
+    private readonly bool hasLookaround = ContainsLookaround(root);
+
+    private static bool ContainsLookaround(RegexNode node)
+    {
+        return node switch
+        {
+            LookaroundAssertion => true,
+            Sequence seq => ContainsLookaroundInList(seq.Items),
+            Alternation alt => ContainsLookaroundInList(alt.Arms),
+            Group grp => ContainsLookaround(grp.Inner),
+            Quantifier q => ContainsLookaround(q.Inner),
+            _ => false,
+        };
+    }
+
+    private static bool ContainsLookaroundInList(IReadOnlyList<RegexNode> items)
+    {
+        foreach (RegexNode item in items)
+        {
+            if (ContainsLookaround(item))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     internal override string Generate(ConjectureData data)
     {
-        return Conjecture.Core.Generate.Compose<string>(ctx =>
+        return hasLookaround
+            ? Conjecture.Core.Generate.Compose<string>(ctx =>
+            {
+                const int maxAttempts = 50;
+                for (int attempt = 0; attempt < maxAttempts; attempt++)
+                {
+                    StringBuilder sb = new();
+                    Dictionary<int, string> captures = [];
+                    Dictionary<string, string> namedCaptures = [];
+                    GenerateNode(ctx, root, sb, captures, namedCaptures);
+                    string candidate = sb.ToString();
+                    if (regex.IsMatch(candidate))
+                    {
+                        return candidate;
+                    }
+                }
+
+                data.MarkInvalid();
+                throw new UnsatisfiedAssumptionException();
+            }).Generate(data)
+            : Conjecture.Core.Generate.Compose<string>(ctx =>
         {
             StringBuilder sb = new();
             Dictionary<int, string> captures = [];
@@ -89,11 +139,7 @@ internal sealed class MatchingStrategy(
                 }
 
             case Sequence seq:
-                foreach (RegexNode item in seq.Items)
-                {
-                    GenerateNode(ctx, item, sb, captures, namedCaptures);
-                }
-
+                GenerateSequence(ctx, seq, sb, captures, namedCaptures);
                 break;
 
             case Group grp:
@@ -135,11 +181,198 @@ internal sealed class MatchingStrategy(
                 break;
 
             case LookaroundAssertion:
-                throw new NotImplementedException("Lookaround is implemented in cycle 294.3.");
+                // Lookarounds are handled at the Sequence level; a lone lookaround produces no output.
+                break;
 
             default:
                 throw new NotSupportedException($"Unsupported node type: {node.GetType().Name}");
         }
+    }
+
+    private void GenerateSequence(
+        IGeneratorContext ctx,
+        Sequence seq,
+        StringBuilder sb,
+        Dictionary<int, string> captures,
+        Dictionary<string, string> namedCaptures)
+    {
+        LookaroundStrategy.AnalyzeSequence(
+            seq.Items,
+            out List<IReadOnlyList<CharRange>> positiveReqs,
+            out List<IReadOnlyList<CharRange>> negativeFirstCharForbidden,
+            out bool skipBody);
+
+        // Emit any positive-lookbehind prefixes so IsMatch can find the required preceding char.
+        foreach (RegexNode item in seq.Items)
+        {
+            if (item is LookaroundAssertion { IsAhead: false, IsPositive: true } posLb)
+            {
+                IReadOnlyList<CharRange> reqs = CharRequirementExtractor.ExtractRequired(posLb.Inner);
+                if (reqs.Count > 0)
+                {
+                    // Prepend a char that satisfies the lookbehind requirement.
+                    char prefix = CharRangeHelpers.SampleFromRanges(reqs, ctx);
+                    sb.Append(prefix);
+                }
+
+                break; // Only one lookbehind prefix needed.
+            }
+        }
+
+        // Collect negative-lookahead forbidden-first-char constraints.
+        List<CharRange> combinedForbidden = [];
+        foreach (IReadOnlyList<CharRange> forbidden in negativeFirstCharForbidden)
+        {
+            foreach (CharRange r in forbidden)
+            {
+                combinedForbidden.Add(r);
+            }
+        }
+
+        bool firstCharConstrained = combinedForbidden.Count > 0;
+        bool firstBodyChar = firstCharConstrained;
+
+        if (skipBody)
+        {
+            // (?![\s\S]) — impossible lookahead: produce empty string.
+            return;
+        }
+
+        // Normal path: emit body nodes, applying first-char constraint where needed.
+        int bodyStart = sb.Length;
+        foreach (RegexNode item in seq.Items)
+        {
+            if (item is LookaroundAssertion)
+            {
+                // Already processed above; skip generation.
+                continue;
+            }
+
+            if (firstBodyChar && sb.Length == bodyStart)
+            {
+                // Intercept the first char-producing node to apply the forbidden constraint.
+                firstBodyChar = false;
+                GenerateNodeWithForbiddenFirst(ctx, item, sb, captures, namedCaptures, combinedForbidden);
+            }
+            else
+            {
+                GenerateNode(ctx, item, sb, captures, namedCaptures);
+            }
+        }
+
+        // Post-process: splice in any missing required chars for positive lookaheads.
+        if (positiveReqs.Count > 0)
+        {
+            LookaroundStrategy.SatisfyPositiveRequirements(ctx, sb, positiveReqs, firstCharConstrained);
+        }
+    }
+
+    /// <summary>
+    /// Generates a node that must not begin with a char in <paramref name="forbidden"/>.
+    /// Applies only to the first character-producing leaf of the node.
+    /// </summary>
+    private void GenerateNodeWithForbiddenFirst(
+        IGeneratorContext ctx,
+        RegexNode node,
+        StringBuilder sb,
+        Dictionary<int, string> captures,
+        Dictionary<string, string> namedCaptures,
+        List<CharRange> forbidden)
+    {
+        switch (node)
+        {
+            case CharClass cc:
+                GenerateCharClassExcluding(ctx, cc, sb, forbidden);
+                break;
+
+            case Quantifier q when q.Min >= 1:
+                // The first iteration of the quantifier must obey the constraint.
+                GenerateNodeWithForbiddenFirst(ctx, q.Inner, sb, captures, namedCaptures, forbidden);
+                // Remaining repetitions are unconstrained.
+                int maxCount = q.Max ?? (q.Min + 16);
+                int count = ctx.Generate(Conjecture.Core.Generate.Integers<int>(q.Min, maxCount));
+                for (int i = 1; i < count; i++)
+                {
+                    GenerateNode(ctx, q.Inner, sb, captures, namedCaptures);
+                }
+
+                break;
+
+            case Group grp:
+                {
+                    int startPos = sb.Length;
+                    GenerateNodeWithForbiddenFirst(ctx, grp.Inner, sb, captures, namedCaptures, forbidden);
+                    string captured = sb.ToString(startPos, sb.Length - startPos);
+                    if (grp.CaptureIndex.HasValue)
+                    {
+                        captures[grp.CaptureIndex.Value] = captured;
+                    }
+
+                    if (grp.Name is not null)
+                    {
+                        namedCaptures[grp.Name] = captured;
+                    }
+
+                    break;
+                }
+
+            case Alternation alt:
+                {
+                    int idx = ctx.Generate(Conjecture.Core.Generate.Integers<int>(0, alt.Arms.Count - 1));
+                    RegexNode chosenArm = alt.Arms[idx];
+                    // Recurse into the chosen arm with the forbidden constraint on its first node.
+                    if (chosenArm is Sequence armSeq && armSeq.Items.Count > 0)
+                    {
+                        GenerateNodeWithForbiddenFirst(ctx, armSeq.Items[0], sb, captures, namedCaptures, forbidden);
+                        for (int i = 1; i < armSeq.Items.Count; i++)
+                        {
+                            GenerateNode(ctx, armSeq.Items[i], sb, captures, namedCaptures);
+                        }
+                    }
+                    else
+                    {
+                        GenerateNodeWithForbiddenFirst(ctx, chosenArm, sb, captures, namedCaptures, forbidden);
+                    }
+
+                    break;
+                }
+
+            case Literal lit:
+                // If literal char is in the forbidden set, emit it anyway (unresolvable contradiction).
+                GenerateLiteral(ctx, lit.Ch, sb);
+                break;
+
+            default:
+                // Fall back to unconstrained generation for other node types.
+                GenerateNode(ctx, node, sb, captures, namedCaptures);
+                break;
+        }
+    }
+
+    private void GenerateCharClassExcluding(
+        IGeneratorContext ctx,
+        CharClass cc,
+        StringBuilder sb,
+        List<CharRange> forbidden)
+    {
+        IReadOnlyList<CharRange> allowed = cc.Negated
+            ? CharRangeHelpers.ComplementRanges(cc.Ranges, '\u0000', '\uFFFF')
+            : (IReadOnlyList<CharRange>)cc.Ranges;
+
+        if (ignoreCase)
+        {
+            allowed = ExpandCaseInsensitive(allowed);
+        }
+
+        IReadOnlyList<CharRange> filtered = LookaroundStrategy.ExcludeForbidden(allowed, forbidden);
+        if (filtered.Count == 0)
+        {
+            // No valid chars after exclusion — fall back to unconstrained.
+            filtered = allowed;
+        }
+
+        char ch = CharRangeHelpers.SampleFromRanges(filtered, ctx);
+        sb.Append(ch);
     }
 
     private void GenerateLiteral(IGeneratorContext ctx, char ch, StringBuilder sb)
@@ -166,13 +399,13 @@ internal sealed class MatchingStrategy(
 
         if (cc.Negated)
         {
-            IReadOnlyList<CharRange> complement = ComplementRanges(ranges, '\u0000', '\uFFFF');
-            char ch = SampleFromRanges(ctx, complement);
+            IReadOnlyList<CharRange> complement = CharRangeHelpers.ComplementRanges(ranges, '\u0000', '\uFFFF');
+            char ch = CharRangeHelpers.SampleFromRanges(complement, ctx);
             sb.Append(ch);
         }
         else
         {
-            char ch = SampleFromRanges(ctx, ranges);
+            char ch = CharRangeHelpers.SampleFromRanges(ranges, ctx);
             sb.Append(ch);
         }
     }
@@ -243,70 +476,6 @@ internal sealed class MatchingStrategy(
         }
 
         return expanded;
-    }
-
-    private static char SampleFromRanges(IGeneratorContext ctx, IReadOnlyList<CharRange> ranges)
-    {
-        // Count total chars
-        int total = 0;
-        foreach (CharRange r in ranges)
-        {
-            total += r.High - r.Low + 1;
-        }
-
-        if (total == 0)
-        {
-            return '\0';
-        }
-
-        int pick = ctx.Generate(Conjecture.Core.Generate.Integers<int>(0, total - 1));
-        foreach (CharRange r in ranges)
-        {
-            int size = r.High - r.Low + 1;
-            if (pick < size)
-            {
-                return (char)(r.Low + pick);
-            }
-
-            pick -= size;
-        }
-
-        return ranges[0].Low;
-    }
-
-    private static IReadOnlyList<CharRange> ComplementRanges(IReadOnlyList<CharRange> ranges, char lo, char hi)
-    {
-        // Normalise: sort and merge
-        List<(int, int)> sorted = [];
-        foreach (CharRange r in ranges)
-        {
-            sorted.Add((r.Low, r.High));
-        }
-
-        sorted.Sort(static (a, b) => a.Item1.CompareTo(b.Item1));
-
-        List<CharRange> result = [];
-        int cursor = lo;
-        foreach ((int rLo, int rHi) in sorted)
-        {
-            if (rLo > cursor)
-            {
-                result.Add(new CharRange((char)cursor, (char)(rLo - 1)));
-            }
-
-            cursor = Math.Max(cursor, rHi + 1);
-            if (cursor > hi)
-            {
-                break;
-            }
-        }
-
-        if (cursor <= hi)
-        {
-            result.Add(new CharRange((char)cursor, hi));
-        }
-
-        return result;
     }
 
     private void GenerateQuantifier(

--- a/src/Conjecture.Regex/RegexGenerate.cs
+++ b/src/Conjecture.Regex/RegexGenerate.cs
@@ -42,7 +42,7 @@ public static class RegexGenerate
     {
         RegexGenOptions effectiveOptions = options ?? new();
         RegexNode root = RegexParser.Parse(regex.ToString(), regex.Options);
-        return new MatchingStrategy(root, regex.Options, effectiveOptions);
+        return new MatchingStrategy(root, regex, regex.Options, effectiveOptions);
     }
 #pragma warning restore RS0026
 }


### PR DESCRIPTION
## Description

Turns `LookaroundAssertion` nodes from a `NotImplementedException` stub into proper lookaround-aware generation:

- `CharRequirementExtractor` walks a `RegexNode` tree to derive the char ranges that must (or must not) appear for the node to match. Per-node rules cover literal, char class (incl. negated), dot, quantifier (distinguishes `min=0` vs `min≥1`), sequence (union), alternation (intersection), group pass-through, and empty requirements for anchors / backreferences / lookarounds.
- `LookaroundStrategy` pre-scans each `Sequence` for lookaround children and yields a per-sequence plan:
  - positive lookahead → splice a required char into the body at a random legal position if none already present (splice range clamped to skip position 0 when a forbidden-first constraint is active, preventing conflict with a neighbouring negative lookahead);
  - negative lookahead → exclude the forbidden ranges from the first body char, recursing into `Group` and `Alternation` to keep the constraint in force; full-alphabet-forbidden short-circuits to an empty body;
  - positive lookbehind → prepend one char drawn from the lookbehind's required range so `Regex.IsMatch` anchors correctly;
  - negative lookbehind → trivially satisfied (no preceding char at string start).
- Generic retry/filter fallback: when the parsed tree contains any `LookaroundAssertion`, `MatchingStrategy.Generate` loops up to 50 attempts and validates each candidate with the compiled `Regex.IsMatch`, calling `MarkInvalid` / throwing `UnsatisfiedAssumptionException` if no candidate passes — letting `Compose` absorb the retry.
- Consolidated the duplicated `ComplementRanges`, `IntersectRangeLists`, `SampleFromRanges`, and `CharInRanges` helpers into a single `internal static class CharRangeHelpers`; `CharRequirementExtractor`, `LookaroundStrategy`, and `MatchingStrategy` all delegate.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes (42/42 green in `Conjecture.Regex.Tests` — 5 new `LookaroundStrategyTests` + 7 `MatchingStrategyTests` + 30 `RegexParserTests`)
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #351
Part of #294