### PR TITLE
[294.4] NotMatchingStrategy: mutation-based non-matching generator

### DIFF
--- a/src/Conjecture.Regex.Tests/NotMatchingStrategyTests.cs
+++ b/src/Conjecture.Regex.Tests/NotMatchingStrategyTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Regex;
+
+using DotNetRegex = System.Text.RegularExpressions.Regex;
+
+namespace Conjecture.Regex.Tests;
+
+public class NotMatchingStrategyTests
+{
+    // ── 1. Fixed-shape pattern: no sample matches ─────────────────────────────
+
+    [Fact]
+    public void NotMatching_FixedShapePattern_NoSampleMatches()
+    {
+        string pattern = @"^\d{3}-\d{2}-\d{4}$";
+        DotNetRegex regex = new(pattern);
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotMatching(pattern), 50, seed: 1UL);
+
+        Assert.All(samples, s => Assert.False(regex.IsMatch(s), s));
+    }
+
+    // ── 2. Lowercase-alpha anchored: every sample contains no lowercase ASCII ──
+
+    [Fact]
+    public void NotMatching_LowercaseAlpha_SamplesAreNotAllLowercase()
+    {
+        string pattern = @"[a-z]+";
+        DotNetRegex regex = new(pattern);
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotMatching(pattern), 50, seed: 2UL);
+
+        Assert.All(samples, s => Assert.False(regex.IsMatch(s), s));
+    }
+
+    // ── 3. Empty-anchor pattern: no sample is the empty string ───────────────
+
+    [Fact]
+    public void NotMatching_EmptyAnchor_SamplesAreNonEmpty()
+    {
+        string pattern = @"^$";
+        DotNetRegex regex = new(pattern);
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotMatching(pattern), 50, seed: 3UL);
+
+        Assert.All(samples, s =>
+        {
+            Assert.True(s.Length > 0, $"Expected non-empty string, got empty: '{s}'");
+            Assert.False(regex.IsMatch(s), s);
+        });
+    }
+
+    // ── 4. Hard-to-mutate pattern: filter fallback produces non-matching ──────
+
+    [Fact]
+    public void NotMatching_HardToMutatePattern_FilterFallbackProducesNonMatching()
+    {
+        string pattern = @"^[a-zA-Z0-9]*$";
+        DotNetRegex regex = new(pattern);
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotMatching(pattern), 20, seed: 4UL);
+
+        Assert.All(samples, s => Assert.False(regex.IsMatch(s), s));
+    }
+
+    // ── 5. Sampling terminates within implicit timeout ────────────────────────
+
+    [Fact]
+    public void NotMatching_Sampling_TerminatesWithinTimeout()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotMatching(@"^\d{3}$"), 30, seed: 5UL);
+
+        Assert.Equal(30, samples.Count);
+    }
+
+    // ── 6. Regex overload: behaves identically to pattern overload ────────────
+
+    [Fact]
+    public void NotMatching_RegexOverload_NoSampleMatches()
+    {
+        DotNetRegex regex = new(@"^\d{3}-\d{2}-\d{4}$");
+
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotMatching(regex), 50, seed: 1UL);
+
+        Assert.All(samples, s => Assert.False(regex.IsMatch(s), s));
+    }
+}

--- a/src/Conjecture.Regex/NotMatchingStrategy.cs
+++ b/src/Conjecture.Regex/NotMatchingStrategy.cs
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Text.RegularExpressions;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+using DotNetRegex = System.Text.RegularExpressions.Regex;
+
+namespace Conjecture.Regex;
+
+internal sealed class NotMatchingStrategy : Strategy<string>
+{
+    private const int MaxAttempts = 100;
+    private const int FallbackAttempts = 50;
+
+    private enum Op { Insert, Delete, Replace }
+
+    private readonly DotNetRegex regex;
+    private readonly MatchingStrategy matchingStrategy;
+
+    internal NotMatchingStrategy(DotNetRegex regex, string pattern, RegexGenOptions? options)
+    {
+        this.regex = regex;
+        RegexGenOptions effectiveOptions = options ?? new();
+        RegexNode root = RegexParser.Parse(pattern, regex.Options);
+        matchingStrategy = new MatchingStrategy(root, regex, regex.Options, effectiveOptions);
+    }
+
+    internal override string Generate(ConjectureData data)
+    {
+        return Conjecture.Core.Generate.Compose<string>(ctx =>
+        {
+            string candidate = ctx.Generate(matchingStrategy);
+
+            for (int attempt = 0; attempt < MaxAttempts; attempt++)
+            {
+                string mutated = Mutate(ctx, candidate);
+                if (!regex.IsMatch(mutated))
+                {
+                    return mutated;
+                }
+            }
+
+            Strategy<string> fallback = Conjecture.Core.Generate.Strings(minLength: 0, maxLength: 32);
+            for (int i = 0; i < FallbackAttempts; i++)
+            {
+                string s = ctx.Generate(fallback);
+                if (!regex.IsMatch(s))
+                {
+                    return s;
+                }
+            }
+
+            data.MarkInvalid();
+            throw new UnsatisfiedAssumptionException();
+        }).Generate(data);
+    }
+
+    private string Mutate(IGeneratorContext ctx, string s)
+    {
+        Op[] ops = [Op.Insert, Op.Delete, Op.Replace];
+        Op op = ctx.Generate(Conjecture.Core.Generate.SampledFrom(ops));
+
+        if (op == Op.Delete && s.Length == 0)
+        {
+            op = Op.Insert;
+        }
+
+        if (op == Op.Replace && s.Length == 0)
+        {
+            op = Op.Insert;
+        }
+
+        return op switch
+        {
+            Op.Insert => DoInsert(ctx, s),
+            Op.Delete => DoDelete(ctx, s),
+            Op.Replace => DoReplace(ctx, s),
+            _ => s,
+        };
+    }
+
+    private static string DoInsert(IGeneratorContext ctx, string s)
+    {
+        int index = ctx.Generate(Conjecture.Core.Generate.Integers<int>(0, s.Length));
+        char ch = (char)ctx.Generate(Conjecture.Core.Generate.Integers<int>(0x20, 0x7E));
+        return s.Insert(index, new string(ch, 1));
+    }
+
+    private static string DoDelete(IGeneratorContext ctx, string s)
+    {
+        int index = ctx.Generate(Conjecture.Core.Generate.Integers<int>(0, s.Length - 1));
+        return s.Remove(index, 1);
+    }
+
+    private static string DoReplace(IGeneratorContext ctx, string s)
+    {
+        int index = ctx.Generate(Conjecture.Core.Generate.Integers<int>(0, s.Length - 1));
+        int charCode = ctx.Generate(Conjecture.Core.Generate.Integers<int>(0x20, 0x7E));
+        if (charCode == s[index])
+        {
+            charCode ^= 1;
+            // Clamp to printable range.
+            if (charCode < 0x20)
+            {
+                charCode = 0x21;
+            }
+
+            if (charCode > 0x7E)
+            {
+                charCode = 0x7D;
+            }
+        }
+
+        char[] chars = s.ToCharArray();
+        chars[index] = (char)charCode;
+        return new string(chars);
+    }
+}

--- a/src/Conjecture.Regex/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Regex/PublicAPI.Unshipped.txt
@@ -6,6 +6,8 @@ Conjecture.Regex.RegexGenOptions.UnicodeCategories.init -> void
 Conjecture.Regex.RegexGenerate
 static Conjecture.Regex.RegexGenerate.Matching(string! pattern, Conjecture.Regex.RegexGenOptions? options = null) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Regex.RegexGenerate.Matching(System.Text.RegularExpressions.Regex! regex, Conjecture.Regex.RegexGenOptions? options = null) -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.NotMatching(string! pattern, Conjecture.Regex.RegexGenOptions? options = null) -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.NotMatching(System.Text.RegularExpressions.Regex! regex, Conjecture.Regex.RegexGenOptions? options = null) -> Conjecture.Core.Strategy<string!>!
 Conjecture.Regex.UnicodeCoverage
 Conjecture.Regex.UnicodeCoverage.Ascii = 0 -> Conjecture.Regex.UnicodeCoverage
 Conjecture.Regex.UnicodeCoverage.Full = 1 -> Conjecture.Regex.UnicodeCoverage

--- a/src/Conjecture.Regex/RegexGenerate.cs
+++ b/src/Conjecture.Regex/RegexGenerate.cs
@@ -25,15 +25,7 @@ public static class RegexGenerate
     /// <summary>Returns a strategy that generates strings matching <paramref name="pattern"/>.</summary>
     public static Strategy<string> Matching(string pattern, RegexGenOptions? options = null)
     {
-        DotNetRegex regex = Cache.GetOrAdd(pattern, static p =>
-        {
-            if (Cache.Count >= CacheCapacity)
-            {
-                Cache.Clear();
-            }
-
-            return new DotNetRegex(p);
-        });
+        DotNetRegex regex = GetOrAddCached(pattern);
         return Matching(regex, options);
     }
 
@@ -44,5 +36,31 @@ public static class RegexGenerate
         RegexNode root = RegexParser.Parse(regex.ToString(), regex.Options);
         return new MatchingStrategy(root, regex, regex.Options, effectiveOptions);
     }
+
+    /// <summary>Returns a strategy that generates strings that do not match <paramref name="pattern"/>.</summary>
+    public static Strategy<string> NotMatching(string pattern, RegexGenOptions? options = null)
+    {
+        DotNetRegex regex = GetOrAddCached(pattern);
+        return NotMatching(regex, options);
+    }
+
+    /// <summary>Returns a strategy that generates strings that do not match <paramref name="regex"/>.</summary>
+    public static Strategy<string> NotMatching(DotNetRegex regex, RegexGenOptions? options = null)
+    {
+        return new NotMatchingStrategy(regex, regex.ToString(), options);
+    }
 #pragma warning restore RS0026
+
+    private static DotNetRegex GetOrAddCached(string pattern)
+    {
+        return Cache.GetOrAdd(pattern, static p =>
+        {
+            if (Cache.Count >= CacheCapacity)
+            {
+                Cache.Clear();
+            }
+
+            return new DotNetRegex(p);
+        });
+    }
 }


### PR DESCRIPTION
## Description

Adds `RegexGenerate.NotMatching(string pattern, ...)` and `RegexGenerate.NotMatching(Regex regex, ...)` — a `Strategy<string>` that produces values guaranteed to fail the given regex:

1. Draw a matching candidate from the shared `MatchingStrategy` pipeline.
2. Mutate it — Insert / Delete / Replace at a random index — up to 100 attempts; the first mutation that breaks the match wins.
3. If all mutations still match, fall back to `Generate.Strings` + `Regex.IsMatch` filter (up to 50 attempts). Final exhaustion calls `MarkInvalid` / throws `UnsatisfiedAssumptionException`, letting the outer `Compose` retry budget absorb.

Skipped the issue-body's speculative `CharClassMap` parser annotation — the random-printable-ASCII mutation plus filter fallback covers the test matrix without bloating the parser.

Extracted `GetOrAddCached(string pattern)` in `RegexGenerate` so the `Matching` and `NotMatching` string-overloads share one bounded cap-and-clear pattern cache.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes (6/6 `NotMatchingStrategyTests` green; 48/48 across the full `Conjecture.Regex.Tests` suite)
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #352
Part of #294