### PR TITLE
[294.5] KnownPatterns library

### DIFF
--- a/src/Conjecture.Regex.Tests/KnownPatternsTests.cs
+++ b/src/Conjecture.Regex.Tests/KnownPatternsTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Regex;
+
+using DotNetRegex = System.Text.RegularExpressions.Regex;
+
+namespace Conjecture.Regex.Tests;
+
+public class KnownPatternsTests
+{
+    private const ulong Seed = 42UL;
+    private const int SampleSize = 50;
+
+    // ── Email ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Email_AllSamplesMatchEmailRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.Email(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.Matches(KnownRegex.Email, s));
+    }
+
+    [Fact]
+    public void NotEmail_NoSampleMatchesEmailRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotEmail(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.DoesNotMatch(KnownRegex.Email, s));
+    }
+
+    // ── Url ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Url_AllSamplesMatchUrlRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.Url(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.Matches(KnownRegex.Url, s));
+    }
+
+    [Fact]
+    public void NotUrl_NoSampleMatchesUrlRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotUrl(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.DoesNotMatch(KnownRegex.Url, s));
+    }
+
+    // ── Uuid ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Uuid_AllSamplesMatchUuidRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.Uuid(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.Matches(KnownRegex.Uuid, s));
+    }
+
+    [Fact]
+    public void NotUuid_NoSampleMatchesUuidRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotUuid(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.DoesNotMatch(KnownRegex.Uuid, s));
+    }
+
+    // ── IsoDate ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsoDate_AllSamplesMatchIsoDateRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.IsoDate(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.Matches(KnownRegex.IsoDate, s));
+    }
+
+    [Fact]
+    public void NotIsoDate_NoSampleMatchesIsoDateRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotIsoDate(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.DoesNotMatch(KnownRegex.IsoDate, s));
+    }
+
+    // ── CreditCard ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CreditCard_AllSamplesMatchCreditCardRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.CreditCard(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.Matches(KnownRegex.CreditCard, s));
+    }
+
+    [Fact]
+    public void NotCreditCard_NoSampleMatchesCreditCardRegex()
+    {
+        IReadOnlyList<string> samples = DataGen.Sample(RegexGenerate.NotCreditCard(), SampleSize, Seed);
+        Assert.All(samples, s => Assert.DoesNotMatch(KnownRegex.CreditCard, s));
+    }
+}

--- a/src/Conjecture.Regex/KnownRegex.cs
+++ b/src/Conjecture.Regex/KnownRegex.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Text.RegularExpressions;
+
+using DotNetRegex = System.Text.RegularExpressions.Regex;
+
+namespace Conjecture.Regex;
+
+/// <summary>Curated compiled <see cref="DotNetRegex"/> constants for common patterns.</summary>
+public static class KnownRegex
+{
+    /// <summary>Matches a simple email address (local@domain.tld).</summary>
+    public static readonly DotNetRegex Email =
+        new(@"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$", RegexOptions.Compiled);
+
+    /// <summary>Matches an HTTP or HTTPS URL.</summary>
+    public static readonly DotNetRegex Url =
+        new(@"^https?://[a-zA-Z0-9.\-]+(:[0-9]{1,5})?(/[a-zA-Z0-9._~:/?#\[\]@!$&'()*+,;%=\-]*)?$", RegexOptions.Compiled);
+
+    /// <summary>Matches a UUID in the canonical 8-4-4-4-12 hyphenated format.</summary>
+    public static readonly DotNetRegex Uuid =
+        new(@"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", RegexOptions.Compiled);
+
+    /// <summary>Matches an ISO 8601 calendar date (YYYY-MM-DD).</summary>
+    public static readonly DotNetRegex IsoDate =
+        new(@"^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$", RegexOptions.Compiled);
+
+    /// <summary>Matches a 16-digit credit card number in 4-4-4-4 format with a consistent separator (space, hyphen, or none).</summary>
+    public static readonly DotNetRegex CreditCard =
+        new(@"^\d{4}([ \-]?)\d{4}\1\d{4}\1\d{4}$", RegexOptions.Compiled);
+}

--- a/src/Conjecture.Regex/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Regex/PublicAPI.Unshipped.txt
@@ -11,3 +11,19 @@ static Conjecture.Regex.RegexGenerate.NotMatching(System.Text.RegularExpressions
 Conjecture.Regex.UnicodeCoverage
 Conjecture.Regex.UnicodeCoverage.Ascii = 0 -> Conjecture.Regex.UnicodeCoverage
 Conjecture.Regex.UnicodeCoverage.Full = 1 -> Conjecture.Regex.UnicodeCoverage
+Conjecture.Regex.KnownRegex
+static readonly Conjecture.Regex.KnownRegex.CreditCard -> System.Text.RegularExpressions.Regex!
+static readonly Conjecture.Regex.KnownRegex.Email -> System.Text.RegularExpressions.Regex!
+static readonly Conjecture.Regex.KnownRegex.IsoDate -> System.Text.RegularExpressions.Regex!
+static readonly Conjecture.Regex.KnownRegex.Url -> System.Text.RegularExpressions.Regex!
+static readonly Conjecture.Regex.KnownRegex.Uuid -> System.Text.RegularExpressions.Regex!
+static Conjecture.Regex.RegexGenerate.CreditCard() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.Email() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.IsoDate() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.NotCreditCard() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.NotEmail() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.NotIsoDate() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.NotUrl() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.NotUuid() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.Url() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.RegexGenerate.Uuid() -> Conjecture.Core.Strategy<string!>!

--- a/src/Conjecture.Regex/RegexGenerate.cs
+++ b/src/Conjecture.Regex/RegexGenerate.cs
@@ -51,6 +51,36 @@ public static class RegexGenerate
     }
 #pragma warning restore RS0026
 
+    /// <summary>Returns a strategy that generates strings matching <see cref="KnownRegex.Email"/>.</summary>
+    public static Strategy<string> Email() => Matching(KnownRegex.Email);
+
+    /// <summary>Returns a strategy that generates strings that do not match <see cref="KnownRegex.Email"/>.</summary>
+    public static Strategy<string> NotEmail() => NotMatching(KnownRegex.Email);
+
+    /// <summary>Returns a strategy that generates strings matching <see cref="KnownRegex.Url"/>.</summary>
+    public static Strategy<string> Url() => Matching(KnownRegex.Url);
+
+    /// <summary>Returns a strategy that generates strings that do not match <see cref="KnownRegex.Url"/>.</summary>
+    public static Strategy<string> NotUrl() => NotMatching(KnownRegex.Url);
+
+    /// <summary>Returns a strategy that generates strings matching <see cref="KnownRegex.Uuid"/>.</summary>
+    public static Strategy<string> Uuid() => Matching(KnownRegex.Uuid);
+
+    /// <summary>Returns a strategy that generates strings that do not match <see cref="KnownRegex.Uuid"/>.</summary>
+    public static Strategy<string> NotUuid() => NotMatching(KnownRegex.Uuid);
+
+    /// <summary>Returns a strategy that generates strings matching <see cref="KnownRegex.IsoDate"/>.</summary>
+    public static Strategy<string> IsoDate() => Matching(KnownRegex.IsoDate);
+
+    /// <summary>Returns a strategy that generates strings that do not match <see cref="KnownRegex.IsoDate"/>.</summary>
+    public static Strategy<string> NotIsoDate() => NotMatching(KnownRegex.IsoDate);
+
+    /// <summary>Returns a strategy that generates strings matching <see cref="KnownRegex.CreditCard"/>.</summary>
+    public static Strategy<string> CreditCard() => Matching(KnownRegex.CreditCard);
+
+    /// <summary>Returns a strategy that generates strings that do not match <see cref="KnownRegex.CreditCard"/>.</summary>
+    public static Strategy<string> NotCreditCard() => NotMatching(KnownRegex.CreditCard);
+
     private static DotNetRegex GetOrAddCached(string pattern)
     {
         return Cache.GetOrAdd(pattern, static p =>


### PR DESCRIPTION
## Description

Adds `KnownRegex` — a static class of curated compiled `Regex` constants for common patterns (Email, Url, Uuid, IsoDate, CreditCard) — and 10 factory methods on `RegexGenerate` that delegate to the existing `Matching`/`NotMatching` API.

The `CreditCard` pattern uses a backreference to enforce consistent separators (space, hyphen, or none) across all digit groups.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #353
Part of #294