### PR TITLE
[294.7] Docs: Conjecture.Regex how-to and reference

### DIFF
--- a/docs/site/articles/explanation/regex-engine.md
+++ b/docs/site/articles/explanation/regex-engine.md
@@ -1,0 +1,118 @@
+# How Conjecture.Regex works
+
+`Conjecture.Regex` generates strings that match (or do not match) a regular expression. This page
+explains the key decisions behind the implementation: why the package uses its own parser, how
+generation produces shrinkable output, how lookaround is resolved, and when a filter fallback is used.
+
+## Why a custom parser instead of reflection
+
+.NET's `System.Text.RegularExpressions.Regex` compiles patterns into an internal `RegexTree`
+object. Reflecting into `RegexTree` to recover the parse tree at runtime would work — but it
+is an internal, unversioned API that has broken between major .NET releases. A strategy package
+that reached into BCL internals would silently misgenerate or crash after a runtime upgrade.
+
+Roslyn exposes a `RegexParser` as part of `Microsoft.CodeAnalysis.CSharp.Features`, but pulling
+in that dependency would add the full Roslyn analyzer chain to every test project that uses
+`Conjecture.Regex` — an unacceptable overhead for what should be a self-contained package.
+
+`Conjecture.Regex` therefore ships its own recursive-descent parser. It produces a stable internal
+AST from the pattern string, driven by the same spec as .NET's engine. Because the AST is fully
+owned by this package, it remains stable across .NET runtime versions and does not couple to any
+analyzer toolchain.
+
+> [!NOTE]
+> The AST is an internal implementation detail — it is not part of the public API surface and
+> may change between minor versions of `Conjecture.Regex`.
+
+## Why IR-native shrinking works
+
+Conjecture shrinks counterexamples by manipulating the **choice-sequence IR** — the sequence of
+byte-level decisions that were made while generating a value — rather than by manipulating the
+generated value directly.
+
+For regex generation, this means:
+
+- A quantifier repetition count (`{m,n}`) is drawn as an integer from the IR. The existing
+  `IntegerReduction` shrink pass reduces it toward `m` automatically — no regex-specific shrinker
+  is needed.
+- A character drawn from a class (`[a-f]`) is drawn as an index into the sorted codepoint list.
+  The `LexMinimize` pass reduces the index toward zero, which corresponds to shrinking toward the
+  smallest codepoint in the class.
+- An alternation choice (`a|b|c`) is drawn as a branch index. The pass reduces it toward the
+  first branch.
+
+The practical result: a regex counterexample minimises to the shortest string using the simplest
+characters in the leftmost alternation branch at the minimum repetition count — exactly the
+minimal form a developer wants to read when diagnosing a failure.
+
+This is the reason `Gen.String().Filter(r.IsMatch)` is an inferior alternative: the filter
+accepts or rejects strings but cannot steer the byte buffer toward the pattern, so the shrinker
+cannot reduce the matching string at all. Shrinking with a filter-only approach produces output
+that is only as minimal as the original random sample happened to be.
+
+## How lookaround is resolved by intersection
+
+Lookahead and lookbehind assertions (`(?=…)`, `(?!…)`, `(?<=…)`, `(?<!…)`) constrain a position
+in the string without consuming characters. During generation, Conjecture resolves them by
+**intersecting their character requirements with the character class of the adjacent node**.
+
+For example, the pattern `\w(?=[a-f])` contains a `\w` node followed by a lookahead requiring
+`[a-f]`. At generation time, the engine:
+
+1. Computes the lookahead's required character set: `{a, b, c, d, e, f}`.
+2. Intersects it with `\w`'s character class: `{a-z, A-Z, 0-9, _}`.
+3. Draws the character from the intersection: `{a, b, c, d, e, f}`.
+
+The lookahead is satisfied by construction — no post-hoc filtering is needed. The drawn character
+still participates in the IR and shrinks normally toward `a`.
+
+Negative lookahead (`(?!…)`) works analogously: the excluded set is subtracted from the adjacent
+character class before drawing.
+
+## When the filter fallback is used
+
+Not all lookaround patterns can be resolved by intersection:
+
+- A lookbehind that references a capturing group whose width varies across alternation branches
+  cannot be statically resolved to a fixed character class.
+- A lookahead that references a backreference (`(?=\1)`) depends on a value drawn earlier in the
+  IR — the constraint cannot be evaluated until the backreference value is known.
+- Variable-width lookbehind (`(?<=a+)`) involves a position scan that is not reducible to a
+  single character-class intersection.
+
+In these cases, `Conjecture.Regex` generates strings from the pattern without the lookaround
+constraint, then applies a post-hoc `Filter` using the compiled `System.Text.RegularExpressions.Regex`.
+The filter budget is shared with any other `Assume` calls in the same property.
+
+> [!WARNING]
+> If a pattern combines complex lookaround with a narrow character class, the filter may exhaust
+> its budget before finding a satisfying string. The test will then fail with an
+> `UnsatisfiedAssumptionException`. Simplify the lookaround or widen the adjacent character class
+> to resolve this.
+
+## Unicode categories and the ASCII default
+
+Unicode category escapes (`\p{L}`, `\p{Lu}`, `\d`, `\w`, `\s`, etc.) match codepoint sets that
+can span tens of thousands of entries across the BMP. Sampling the full range by default would
+produce unreadable counterexamples and slow down shrinking — `\p{L}` would just as often generate
+a Tibetan or Arabic letter as a Latin one, making failure reports hard to interpret.
+
+By default, `Conjecture.Regex` samples only the ASCII subset of each category:
+
+| Escape | Default (ASCII) | Full (`UnicodeCoverage.Full`) |
+|---|---|---|
+| `\p{L}` | `a-z`, `A-Z` | All Unicode letters |
+| `\d` | `0-9` | All Unicode decimal digits |
+| `\w` | `a-z`, `A-Z`, `0-9`, `_` | All Unicode word characters |
+| `\s` | space, tab, `\r`, `\n` | All Unicode whitespace |
+
+Use `RegexGenOptions { UnicodeCategories = UnicodeCoverage.Full }` to opt in to the full range
+when the property genuinely depends on non-ASCII behaviour — for example, testing a Unicode
+normalisation pipeline or a multilingual text classifier.
+
+## See also
+
+- [How to test a regex validator](../how-to/test-regex-validator.md)
+- [Reference: Regex strategies](../reference/regex-strategies.md)
+- [Understanding shrinking](shrinking.md)
+- [ADR-0054: Regex Strategy Design](../../decisions/0054-regex-strategy-design.md)

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -15,3 +15,5 @@ items:
     href: allocation-model.md
   - name: Why MTP tests are executables
     href: mtp-model.md
+  - name: How Conjecture.Regex works
+    href: regex-engine.md

--- a/docs/site/articles/how-to/test-regex-validator.md
+++ b/docs/site/articles/how-to/test-regex-validator.md
@@ -1,0 +1,118 @@
+# How to test a regex validator with property-based tests
+
+Use `RegexGenerate.Matching` and `RegexGenerate.NotMatching` to prove that a validator accepts
+every well-formed input and rejects every ill-formed one — without hand-writing examples.
+
+## Install
+
+```bash
+dotnet add package Conjecture.Regex
+```
+
+## Write a positive property
+
+A positive property proves that the validator never rejects what the regex allows.
+
+Suppose you have a `ProductCode` DTO with a `[RegularExpression]` annotation:
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+
+public record ProductCode([RegularExpression(@"^[A-Z]{3}-\d{4}$")] string Value);
+```
+
+Write a property that feeds only matching strings:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Regex;
+using System.ComponentModel.DataAnnotations;
+
+[Property]
+public bool ProductCode_AcceptsAllMatchingValues()
+{
+    string value = DataGen.SampleOne(RegexGenerate.Matching(@"^[A-Z]{3}-\d{4}$"));
+    IList<ValidationResult> results = [];
+    bool isValid = Validator.TryValidateObject(
+        new ProductCode(value),
+        new ValidationContext(new ProductCode(value)),
+        results,
+        validateAllProperties: true);
+    return isValid;
+}
+```
+
+Conjecture generates hundreds of matching strings per run — boundary lengths, all-uppercase,
+maximum digit values — and the property fails if the validator ever rejects one.
+
+## Write a negative property
+
+A negative property proves the validator never accepts what the regex disallows:
+
+```csharp
+[Property]
+public bool ProductCode_RejectsAllNonMatchingValues()
+{
+    string value = DataGen.SampleOne(RegexGenerate.NotMatching(@"^[A-Z]{3}-\d{4}$"));
+    IList<ValidationResult> results = [];
+    bool isValid = Validator.TryValidateObject(
+        new ProductCode(value),
+        new ValidationContext(new ProductCode(value)),
+        results,
+        validateAllProperties: true);
+    return !isValid;
+}
+```
+
+> [!TIP]
+> Run positive and negative properties in the same test class so a refactored validator
+> that accidentally widens or narrows its regex is caught on both sides simultaneously.
+
+## Use a compiled `Regex` for reuse
+
+If the same pattern appears in both production code and tests, share the compiled instance:
+
+```csharp
+using System.Text.RegularExpressions;
+
+// Shared, compiled regex — same object used by production code and tests
+[GeneratedRegex(@"^[A-Z]{3}-\d{4}$")]
+private static partial Regex ProductCodeRegex();
+
+[Property]
+public bool ProductCode_AcceptsMatchingValues()
+{
+    string value = DataGen.SampleOne(RegexGenerate.Matching(ProductCodeRegex()));
+    return ProductCodeRegex().IsMatch(value);
+}
+```
+
+Passing a `Regex` instance ensures that `RegexOptions` set on the compiled regex (such as
+`IgnoreCase`) are carried through to the generator automatically.
+
+## Use well-known pattern shortcuts
+
+For common formats, skip the raw pattern and call the named factory method directly:
+
+```csharp
+[Property]
+public bool EmailService_SendsToMatchingAddresses()
+{
+    string address = DataGen.SampleOne(RegexGenerate.Email());
+    return new MailAddress(address) is not null;
+}
+
+[Property]
+public bool OrderId_MustBeUuid()
+{
+    string id = DataGen.SampleOne(RegexGenerate.Uuid());
+    return Guid.TryParse(id, out _);
+}
+```
+
+Available shortcuts: `Email`, `Url`, `Uuid`, `IsoDate`, `CreditCard` — and `Not*` variants for each.
+
+## See also
+
+- [Reference: Regex strategies](../reference/regex-strategies.md) — full API surface
+- [Explanation: How Conjecture.Regex works](../explanation/regex-engine.md) — parser, shrinking, and lookaround

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -35,5 +35,7 @@ items:
     href: explore-strategies.md
   - name: Use the MCP server
     href: use-mcp-server.md
+  - name: Test a regex validator
+    href: test-regex-validator.md
   - name: Troubleshoot
     href: troubleshoot.md

--- a/docs/site/articles/reference/regex-strategies.md
+++ b/docs/site/articles/reference/regex-strategies.md
@@ -1,0 +1,152 @@
+# Regex strategies reference
+
+All factory methods in the `Conjecture.Regex` package.
+
+## Package
+
+```bash
+dotnet add package Conjecture.Regex
+```
+
+Namespace: `Conjecture.Regex`
+
+---
+
+## `RegexGenerate.Matching`
+
+```csharp
+Strategy<string> RegexGenerate.Matching(string pattern, RegexGenOptions? options = null)
+Strategy<string> RegexGenerate.Matching(Regex regex,   RegexGenOptions? options = null)
+```
+
+Returns a strategy that generates strings that match `pattern` or `regex`.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `pattern` | `string` | — | A .NET regex pattern. Compiled and cached internally. |
+| `regex` | `Regex` | — | A pre-compiled `Regex` instance. `RegexOptions` are read from the instance. |
+| `options` | `RegexGenOptions?` | `null` | Generation knobs; `null` uses `new RegexGenOptions()` defaults. |
+
+The string patterns are parsed by Conjecture's own recursive-descent parser into a stable internal
+AST. Generation is driven from that AST through ordinary choice-sequence IR primitives, so quantifier
+counts and character indices shrink automatically alongside the generated value.
+
+---
+
+## `RegexGenerate.NotMatching`
+
+```csharp
+Strategy<string> RegexGenerate.NotMatching(string pattern, RegexGenOptions? options = null)
+Strategy<string> RegexGenerate.NotMatching(Regex regex,   RegexGenOptions? options = null)
+```
+
+Returns a strategy that generates strings that do **not** match `pattern` or `regex`.
+
+The strategy mutates the parsed AST to negate character classes and quantifier boundaries, then
+applies a filter pass using the compiled `Regex` to discard any strings that slip through.
+
+---
+
+## Known-pattern shortcuts
+
+Convenience factories for common formats. Each has a `Not*` variant.
+
+| Method | Pattern description | Counterpart |
+|---|---|---|
+| `RegexGenerate.Email()` | RFC-5322 simplified address | `RegexGenerate.NotEmail()` |
+| `RegexGenerate.Url()` | HTTP/HTTPS URL | `RegexGenerate.NotUrl()` |
+| `RegexGenerate.Uuid()` | UUID v4 hyphenated lowercase | `RegexGenerate.NotUuid()` |
+| `RegexGenerate.IsoDate()` | ISO 8601 date (`YYYY-MM-DD`) | `RegexGenerate.NotIsoDate()` |
+| `RegexGenerate.CreditCard()` | 13–19 digit Luhn-valid number | `RegexGenerate.NotCreditCard()` |
+
+The underlying patterns are exposed on `KnownRegex` as compiled `Regex` instances:
+
+```csharp
+using System.Text.RegularExpressions;
+using Conjecture.Regex;
+
+Regex emailPattern = KnownRegex.Email;
+Regex urlPattern   = KnownRegex.Url;
+Regex uuidPattern  = KnownRegex.Uuid;
+Regex isoDatePattern = KnownRegex.IsoDate;
+Regex creditCardPattern = KnownRegex.CreditCard;
+```
+
+---
+
+## `RegexGenOptions`
+
+```csharp
+public sealed class RegexGenOptions
+{
+    public UnicodeCoverage UnicodeCategories { get; init; } = UnicodeCoverage.Ascii;
+}
+```
+
+| Property | Type | Default | Description |
+|---|---|---|---|
+| `UnicodeCategories` | `UnicodeCoverage` | `Ascii` | Controls the sampling range for Unicode category escapes (`\p{L}`, `\d`, `\w`, etc.). |
+
+### `UnicodeCoverage`
+
+| Value | Behaviour |
+|---|---|
+| `Ascii` (default) | Category escapes draw from their ASCII subset. `\p{L}` → ASCII letters; `\d` → `0`–`9`. Keeps generated strings short, human-readable, and fast-shrinking. |
+| `Full` | Category escapes draw from the full Unicode BMP. Use when the property genuinely depends on non-ASCII codepoints (e.g. testing a Unicode normalisation pipeline). |
+
+```csharp
+// Default: ASCII only
+Strategy<string> s1 = RegexGenerate.Matching(@"\p{L}+");
+
+// Opt in to full Unicode range
+Strategy<string> s2 = RegexGenerate.Matching(
+    @"\p{L}+",
+    new RegexGenOptions { UnicodeCategories = UnicodeCoverage.Full });
+```
+
+---
+
+## `RegexOptions` support
+
+When the `Regex` overload is used, `RegexOptions` set on the instance are read intrinsically by
+the parser:
+
+| Option | Effect on generation |
+|---|---|
+| `IgnoreCase` | Literal characters emit both cases with equal probability. |
+| `Singleline` | `.` includes `\n` in its character class. |
+| `Multiline` | `^` and `$` match at line boundaries, not only string start/end. |
+
+---
+
+## Supported regex syntax
+
+All standard .NET regex syntax is supported, including:
+
+- Literal characters, character classes (`[a-z]`, `[^0-9]`)
+- Shorthand escapes (`\d`, `\w`, `\s`, `\D`, `\W`, `\S`)
+- Unicode categories (`\p{L}`, `\P{Lu}`)
+- Quantifiers (`*`, `+`, `?`, `{m,n}`)
+- Alternation (`a|b|c`)
+- Groups — capturing, non-capturing, named (`(?<name>…)`)
+- Lookahead / lookbehind — `(?=…)`, `(?!…)`, `(?<=…)`, `(?<!…)`
+- Backreferences (`\1`, `\k<name>`)
+- Conditionals (`(?(cond)yes|no)`)
+
+Possessive quantifiers (`*+`, `++`, `?+`) are not supported by .NET's own regex engine and
+are not recognised.
+
+---
+
+## Upcoming
+
+**`RegexGenerate.ReDoSHunter`** — adversarial timing generation for detecting catastrophic
+backtracking — is planned for v0.15.0. See [issue #366](https://github.com/kommundsen/Conjecture/issues/366).
+
+---
+
+## See also
+
+- [How to test a regex validator](../how-to/test-regex-validator.md)
+- [Explanation: How Conjecture.Regex works](../explanation/regex-engine.md)
+- [Reference: String strategies](string-strategies.md)

--- a/docs/site/articles/reference/toc.yml
+++ b/docs/site/articles/reference/toc.yml
@@ -13,6 +13,8 @@ items:
     href: analyzers.md
   - name: Time strategies
     href: time-strategies.md
+  - name: Regex strategies
+    href: regex-strategies.md
   - name: Formatters
     href: formatters.md
   - name: Telemetry


### PR DESCRIPTION
## Description

Adds Diataxis-structured documentation for the `Conjecture.Regex` package:

- **How-to** ([`test-regex-validator.md`](docs/site/articles/how-to/test-regex-validator.md)): step-by-step guide for testing a regex validator with positive and negative property tests, using `RegexGenerate.Matching` / `RegexGenerate.NotMatching`, a `[RegularExpression]` DTO example, compiled `[GeneratedRegex]` reuse, and known-pattern shortcuts.
- **Reference** ([`regex-strategies.md`](docs/site/articles/reference/regex-strategies.md)): full API table for `RegexGenerate` (all overloads, known-pattern shortcuts, `KnownRegex`, `RegexGenOptions`, `UnicodeCoverage`, `RegexOptions` support, supported syntax, upcoming `ReDoSHunter`).
- **Explanation** ([`regex-engine.md`](docs/site/articles/explanation/regex-engine.md)): why the package uses its own recursive-descent parser instead of reflection or Roslyn; how IR-native shrinking works; how lookaround is resolved by char-class intersection; when the filter fallback is used; why Unicode categories default to ASCII.

All three `toc.yml` files updated.

## Type of change

- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #355
Part of #294