### PR TITLE
[295.3] Extended primitive mapping: Guid, decimal, date/time, and collection types

### DIFF
--- a/src/Conjecture.Core/CharStrategy.cs
+++ b/src/Conjecture.Core/CharStrategy.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class CharStrategy : Strategy<char>
+{
+    internal override char Generate(ConjectureData data)
+    {
+        ulong raw = data.NextInteger(0UL, char.MaxValue);
+        return (char)raw;
+    }
+}

--- a/src/Conjecture.Core/DateTimeStrategy.cs
+++ b/src/Conjecture.Core/DateTimeStrategy.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class DateTimeStrategy : Strategy<DateTime>
+{
+    private readonly DateTime min;
+    private readonly DateTime max;
+
+    internal DateTimeStrategy(DateTime min, DateTime max)
+    {
+        if (min > max)
+        {
+            throw new ArgumentOutOfRangeException(nameof(min), "min must be less than or equal to max.");
+        }
+
+        this.min = min;
+        this.max = max;
+    }
+
+    internal override DateTime Generate(ConjectureData data)
+    {
+        ulong rangeMinus1 = (ulong)(max.Ticks - min.Ticks);
+        ulong raw = data.NextInteger(0UL, rangeMinus1);
+        return new DateTime(min.Ticks + (long)raw, min.Kind);
+    }
+}

--- a/src/Conjecture.Core/DecimalStrategy.cs
+++ b/src/Conjecture.Core/DecimalStrategy.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class DecimalStrategy : Strategy<decimal>
+{
+    internal override decimal Generate(ConjectureData data)
+    {
+        int lo = (int)(data.NextInteger(0UL, (ulong)int.MaxValue));
+        int mid = (int)(data.NextInteger(0UL, (ulong)int.MaxValue));
+        int hi = (int)(data.NextInteger(0UL, (ulong)int.MaxValue));
+        bool isNegative = data.NextInteger(0UL, 1UL) == 1UL;
+        byte scale = (byte)data.NextInteger(0UL, 28UL);
+        return new decimal(lo, mid, hi, isNegative, scale);
+    }
+}

--- a/src/Conjecture.Core/Gen.cs
+++ b/src/Conjecture.Core/Gen.cs
@@ -245,6 +245,23 @@ public static class Generate
     public static Strategy<T> FromBytes<T>(ReadOnlySpan<byte> buffer)
         => new Internal.FromBytesStrategy<T>(buffer, Internal.SharedParameterStrategyResolver.GetDefault<T>());
 
+    /// <summary>Returns a strategy that generates random <see cref="Guid"/> values.</summary>
+    public static Strategy<Guid> Guids() => new GuidStrategy();
+
+    /// <summary>Returns a strategy that generates random <see cref="decimal"/> values.</summary>
+    public static Strategy<decimal> Decimals() => new DecimalStrategy();
+
+    /// <summary>Returns a strategy that generates random <see cref="DateTime"/> values across the full range.</summary>
+    public static Strategy<DateTime> DateTimes()
+        => new DateTimeStrategy(DateTime.MinValue, DateTime.MaxValue);
+
+    /// <summary>Returns a strategy that generates random <see cref="DateTime"/> values in [<paramref name="min"/>, <paramref name="max"/>].</summary>
+    public static Strategy<DateTime> DateTimes(DateTime min, DateTime max)
+        => new DateTimeStrategy(min, max);
+
+    /// <summary>Returns a strategy that generates random <see cref="char"/> values across the full Unicode range.</summary>
+    public static Strategy<char> Chars() => new CharStrategy();
+
     /// <summary>Returns a strategy for <typeparamref name="T"/> using its registered <see cref="IStrategyProvider{T}"/>. The type must be decorated with <c>[Arbitrary]</c>.</summary>
     public static Strategy<T> For<T>() => GenForRegistry.Resolve<T>();
 

--- a/src/Conjecture.Core/GuidStrategy.cs
+++ b/src/Conjecture.Core/GuidStrategy.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class GuidStrategy : Strategy<Guid>
+{
+    internal override Guid Generate(ConjectureData data)
+    {
+        ulong hi = data.NextInteger(0UL, ulong.MaxValue);
+        ulong lo = data.NextInteger(0UL, ulong.MaxValue);
+        Span<byte> bytes = stackalloc byte[16];
+        BitConverter.TryWriteBytes(bytes, hi);
+        BitConverter.TryWriteBytes(bytes[8..], lo);
+        return new Guid(bytes);
+    }
+}

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -9,3 +9,8 @@ static Conjecture.Core.GenForRegistry.Register(System.Type! type, System.Func<Co
 static Conjecture.Core.Generate.For<T>() -> Conjecture.Core.Strategy<T>!
 static Conjecture.Core.GenForRegistry.RegisterOverride(System.Type! type, System.Func<object!, object!>! factory) -> void
 static Conjecture.Core.GenForRegistry.ResolveWithOverrides<T>(Conjecture.Core.ForConfiguration<T>! cfg) -> Conjecture.Core.Strategy<T>!
+static Conjecture.Core.Generate.Guids() -> Conjecture.Core.Strategy<System.Guid>!
+static Conjecture.Core.Generate.Decimals() -> Conjecture.Core.Strategy<decimal>!
+static Conjecture.Core.Generate.DateTimes() -> Conjecture.Core.Strategy<System.DateTime>!
+static Conjecture.Core.Generate.DateTimes(System.DateTime min, System.DateTime max) -> Conjecture.Core.Strategy<System.DateTime>!
+static Conjecture.Core.Generate.Chars() -> Conjecture.Core.Strategy<char>!

--- a/src/Conjecture.Generators.Tests/NestedTypeGeneratorTests.cs
+++ b/src/Conjecture.Generators.Tests/NestedTypeGeneratorTests.cs
@@ -76,7 +76,7 @@ public sealed class NestedTypeGeneratorTests
         string text = GetGeneratedText(
             "using Conjecture.Core; using System.Collections.Generic; namespace MyApp; [Arbitrary] public partial record W(List<int> Items);",
             "W.g.cs");
-        Assert.Contains("Generate.Lists<int>(", text);
+        Assert.Contains("Generate.Lists(", text);
         Assert.Contains("Generate.Integers<int>()", text);
     }
 

--- a/src/Conjecture.Generators.Tests/PrimitiveMappingTests.cs
+++ b/src/Conjecture.Generators.Tests/PrimitiveMappingTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Conjecture.Generators.Tests;
+
+public sealed class PrimitiveMappingTests
+{
+    [Fact]
+    public void Record_WithGuidProperty_EmitsGuids()
+    {
+        string text = GetGeneratedText(
+            "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Order(System.Guid Id);",
+            "Order.g.cs");
+
+        Assert.Contains("Generate.Guids()", text);
+    }
+
+    [Fact]
+    public void Record_WithDecimalProperty_EmitsDecimals()
+    {
+        string text = GetGeneratedText(
+            "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Invoice(decimal Total);",
+            "Invoice.g.cs");
+
+        Assert.Contains("Generate.Decimals()", text);
+    }
+
+    [Fact]
+    public void Record_WithDateOnlyProperty_EmitsDateOnlyValues()
+    {
+        string text = GetGeneratedText(
+            "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Event(System.DateOnly PlacedOn);",
+            "Event.g.cs");
+
+        Assert.Contains("Generate.DateOnlyValues()", text);
+    }
+
+    [Fact]
+    public void Record_WithListOfStringProperty_EmitsListsOfStrings()
+    {
+        string text = GetGeneratedText(
+            "using Conjecture.Core; using System.Collections.Generic; namespace MyApp; [Arbitrary] public partial record Tags(List<string> Items);",
+            "Tags.g.cs");
+
+        Assert.Contains("Generate.Lists(", text);
+        Assert.Contains("Generate.Strings()", text);
+    }
+
+    [Fact]
+    public void Record_WithDictionaryProperty_EmitsDictionaries()
+    {
+        string text = GetGeneratedText(
+            "using Conjecture.Core; using System.Collections.Generic; namespace MyApp; [Arbitrary] public partial record Lookup(Dictionary<string, int> Map);",
+            "Lookup.g.cs");
+
+        Assert.Contains("Generate.Dictionaries(", text);
+        Assert.Contains("Generate.Strings()", text);
+        Assert.Contains("Generate.Integers<int>()", text);
+    }
+
+    [Fact]
+    public void Record_WithImmutableArrayOfGuidProperty_EmitsImmutableArrayStrategy()
+    {
+        string text = GetGeneratedText(
+            "using Conjecture.Core; using System.Collections.Immutable; namespace MyApp; [Arbitrary] public partial record Batch(ImmutableArray<System.Guid> Ids);",
+            "Batch.g.cs");
+
+        Assert.Contains("ImmutableArray", text);
+        Assert.Contains("Generate.Guids()", text);
+    }
+
+    [Fact]
+    public void Record_WithValueTupleProperty_EmitsTuples()
+    {
+        string text = GetGeneratedText(
+            "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Pair((int, string) Value);",
+            "Pair.g.cs");
+
+        Assert.Contains("Generate.Tuples(", text);
+    }
+
+    [Fact]
+    public void Record_WithUnknownCollectionType_EmitsCon202Diagnostic()
+    {
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(
+            "using Conjecture.Core; using System.Collections.ObjectModel; namespace MyApp; [Arbitrary] public partial record Bag(ObservableCollection<int> Items);");
+
+        Assert.Contains(diagnostics, d => d.Id == "CON202");
+    }
+
+    private static string GetGeneratedText(string source, string fileName)
+    {
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+        SyntaxTree? tree = trees.FirstOrDefault(
+            t => t.FilePath.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(tree);
+        return tree.GetText().ToString();
+    }
+
+    private static ImmutableArray<Diagnostic> GetGeneratorDiagnostics(string source)
+    {
+        (_, _, ImmutableArray<Diagnostic> diagnostics) = RunGenerator(source);
+        return diagnostics;
+    }
+
+    private static (ImmutableArray<SyntaxTree> GeneratedTrees, Compilation Output, ImmutableArray<Diagnostic> GeneratorDiagnostics) RunGenerator(string source)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        CSharpCompilation inputCompilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.Immutable.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.ObjectModel.dll")),
+                MetadataReference.CreateFromFile(typeof(Conjecture.Core.ArbitraryAttribute).Assembly.Location),
+            ],
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new ArbitraryGenerator());
+        GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
+
+        Compilation outputCompilation = inputCompilation.AddSyntaxTrees(result.GeneratedTrees);
+        return (result.GeneratedTrees, outputCompilation, result.Diagnostics);
+    }
+}

--- a/src/Conjecture.Generators/StrategyEmitter.cs
+++ b/src/Conjecture.Generators/StrategyEmitter.cs
@@ -17,8 +17,14 @@ internal static class StrategyEmitter
         ["System.String"] = ("global::Conjecture.Core.Generate.Strings()", "string"),
         ["System.Double"] = ("global::Conjecture.Core.Generate.Doubles()", "double"),
         ["System.Single"] = ("global::Conjecture.Core.Generate.Floats()", "float"),
-        ["System.Decimal"] = ("global::Conjecture.Core.Generate.Just(default(decimal))", "decimal"),
-        ["System.Guid"] = ("global::Conjecture.Core.Generate.Just(default(global::System.Guid))", "global::System.Guid"),
+        ["System.Decimal"] = ("global::Conjecture.Core.Generate.Decimals()", "decimal"),
+        ["System.Char"] = ("global::Conjecture.Core.Generate.Chars()", "char"),
+        ["System.Guid"] = ("global::Conjecture.Core.Generate.Guids()", "global::System.Guid"),
+        ["System.DateTime"] = ("global::Conjecture.Core.Generate.DateTimes()", "global::System.DateTime"),
+        ["System.DateTimeOffset"] = ("global::Conjecture.Core.Generate.DateTimeOffsets()", "global::System.DateTimeOffset"),
+        ["System.DateOnly"] = ("global::Conjecture.Core.Generate.DateOnlyValues()", "global::System.DateOnly"),
+        ["System.TimeOnly"] = ("global::Conjecture.Core.Generate.TimeOnlyValues()", "global::System.TimeOnly"),
+        ["System.TimeSpan"] = ("global::Conjecture.Core.Generate.TimeSpans()", "global::System.TimeSpan"),
         ["System.UInt32"] = ("global::Conjecture.Core.Generate.Integers<uint>()", "uint"),
         ["System.UInt64"] = ("global::Conjecture.Core.Generate.Integers<ulong>()", "ulong"),
         ["System.Int16"] = ("global::Conjecture.Core.Generate.Integers<short>()", "short"),
@@ -138,6 +144,18 @@ internal static class StrategyEmitter
             PrimitiveData.TryGetValue(member.AuxiliaryTypeName, out (string GenExpr, string ShortName) l)
                 ? "global::System.Collections.Generic.List<" + l.ShortName + ">"
                 : "/* unsupported */",
+        MemberGenerationKind.Dictionary =>
+            BuildDictionaryStrategyType(member.AuxiliaryTypeName),
+        MemberGenerationKind.ImmutableArray =>
+            PrimitiveData.TryGetValue(member.AuxiliaryTypeName, out (string GenExpr, string ShortName) ia)
+                ? "global::System.Collections.Immutable.ImmutableArray<" + ia.ShortName + ">"
+                : "/* unsupported */",
+        MemberGenerationKind.Set =>
+            PrimitiveData.TryGetValue(member.AuxiliaryTypeName, out (string GenExpr, string ShortName) s)
+                ? "global::System.Collections.Generic.IReadOnlySet<" + s.ShortName + ">"
+                : "/* unsupported */",
+        MemberGenerationKind.ValueTuple =>
+            BuildValueTupleStrategyType(member.AuxiliaryTypeName),
         MemberGenerationKind.ArbitraryReference =>
             "global::" + member.TypeFullName,
         MemberGenerationKind.ExternalStrategyProvider =>
@@ -153,9 +171,19 @@ internal static class StrategyEmitter
             MemberGenerationKind.Enum =>
                 "global::Conjecture.Core.Generate.Enums<global::" + member.TypeFullName + ">()",
             MemberGenerationKind.NullableValue =>
-                BuildWrappedExpr(member.AuxiliaryTypeName, "Nullable"),
+                PrimitiveData.TryGetValue(member.AuxiliaryTypeName, out (string GenExpr, string ShortName) nv)
+                    ? "global::Conjecture.Core.Generate.Nullable<" + nv.ShortName + ">(" + nv.GenExpr + ")"
+                    : $"/* unsupported nullable inner type: {member.AuxiliaryTypeName} */",
             MemberGenerationKind.List =>
                 BuildWrappedExpr(member.AuxiliaryTypeName, "Lists"),
+            MemberGenerationKind.Dictionary =>
+                BuildDictionaryGenExpr(member.AuxiliaryTypeName),
+            MemberGenerationKind.ImmutableArray =>
+                BuildWrappedExpr(member.AuxiliaryTypeName, "Lists") + ".Select(global::System.Collections.Immutable.ImmutableArray.CreateRange)",
+            MemberGenerationKind.Set =>
+                BuildWrappedExpr(member.AuxiliaryTypeName, "Sets"),
+            MemberGenerationKind.ValueTuple =>
+                BuildValueTupleGenExpr(member.AuxiliaryTypeName),
             MemberGenerationKind.ArbitraryReference =>
                 "new global::" + member.TypeFullName + "Arbitrary().Create()",
             MemberGenerationKind.ExternalStrategyProvider =>
@@ -170,7 +198,73 @@ internal static class StrategyEmitter
     private static string BuildWrappedExpr(string innerFqn, string wrapper)
     {
         return PrimitiveData.TryGetValue(innerFqn, out (string GenExpr, string ShortName) data)
-            ? "global::Conjecture.Core.Generate." + wrapper + "<" + data.ShortName + ">(" + data.GenExpr + ")"
+            ? "global::Conjecture.Core.Generate." + wrapper + "(" + data.GenExpr + ")"
             : $"/* unsupported {wrapper} inner type: {innerFqn} */";
+    }
+
+    private static string BuildDictionaryStrategyType(string aux)
+    {
+        int pipe = aux.IndexOf('|');
+        if (pipe < 0)
+        {
+            return "/* unsupported */";
+        }
+
+        string keyFqn = aux.Substring(0, pipe);
+        string valFqn = aux.Substring(pipe + 1);
+        string keyShort = PrimitiveData.TryGetValue(keyFqn, out (string GenExpr, string ShortName) k) ? k.ShortName : "/* unsupported */";
+        string valShort = PrimitiveData.TryGetValue(valFqn, out (string GenExpr, string ShortName) v) ? v.ShortName : "/* unsupported */";
+        return "global::System.Collections.Generic.IReadOnlyDictionary<" + keyShort + ", " + valShort + ">";
+    }
+
+    private static string BuildDictionaryGenExpr(string aux)
+    {
+        int pipe = aux.IndexOf('|');
+        if (pipe < 0)
+        {
+            return "/* unsupported */";
+        }
+
+        string keyFqn = aux.Substring(0, pipe);
+        string valFqn = aux.Substring(pipe + 1);
+        string keyExpr = PrimitiveData.TryGetValue(keyFqn, out (string GenExpr, string ShortName) k) ? k.GenExpr : "/* unsupported */";
+        string valExpr = PrimitiveData.TryGetValue(valFqn, out (string GenExpr, string ShortName) v) ? v.GenExpr : "/* unsupported */";
+        return "global::Conjecture.Core.Generate.Dictionaries(" + keyExpr + ", " + valExpr + ")";
+    }
+
+    private static string BuildValueTupleStrategyType(string aux)
+    {
+        string[] parts = aux.Split('|');
+        StringBuilder sb = new("(");
+        for (int i = 0; i < parts.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            sb.Append(PrimitiveData.TryGetValue(parts[i], out (string GenExpr, string ShortName) p) ? p.ShortName : "/* unsupported */");
+        }
+
+        sb.Append(')');
+        return sb.ToString();
+    }
+
+    private static string BuildValueTupleGenExpr(string aux)
+    {
+        string[] parts = aux.Split('|');
+        StringBuilder sb = new("global::Conjecture.Core.Generate.Tuples(");
+        for (int i = 0; i < parts.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(", ");
+            }
+
+            sb.Append(PrimitiveData.TryGetValue(parts[i], out (string GenExpr, string ShortName) p) ? p.GenExpr : "/* unsupported */");
+        }
+
+        sb.Append(')');
+        return sb.ToString();
     }
 }

--- a/src/Conjecture.Generators/TypeModel.cs
+++ b/src/Conjecture.Generators/TypeModel.cs
@@ -9,7 +9,7 @@ namespace Conjecture.Generators;
 
 internal enum ConstructionMode { Constructor, ObjectInitializer, PartialConstructor }
 
-internal enum MemberGenerationKind { Primitive, Enum, NullableValue, List, ArbitraryReference, ExternalStrategyProvider, Unsupported }
+internal enum MemberGenerationKind { Primitive, Enum, NullableValue, List, ArbitraryReference, ExternalStrategyProvider, Unsupported, Dictionary, ImmutableArray, Set, ValueTuple }
 
 internal sealed record TypeModel(
     string FullyQualifiedName,

--- a/src/Conjecture.Generators/TypeModelExtractor.cs
+++ b/src/Conjecture.Generators/TypeModelExtractor.cs
@@ -252,11 +252,28 @@ internal static class TypeModelExtractor
         return builder.ToImmutable();
     }
 
+    private static readonly HashSet<string> KnownNonSpecialPrimitives =
+    [
+        "System.Guid",
+        "System.DateTime",
+        "System.DateTimeOffset",
+        "System.DateOnly",
+        "System.TimeOnly",
+        "System.TimeSpan",
+    ];
+
     private static (MemberGenerationKind Kind, string InnerFqn) ClassifyMemberType(
         ITypeSymbol type,
         IReadOnlyDictionary<string, string>? providerRegistry)
     {
         if (IsPrimitive(type.SpecialType))
+        {
+            return (MemberGenerationKind.Primitive, "");
+        }
+
+        string typeFqn = type.ToDisplayString(TypeNameFormat);
+
+        if (KnownNonSpecialPrimitives.Contains(typeFqn))
         {
             return (MemberGenerationKind.Primitive, "");
         }
@@ -272,16 +289,43 @@ internal static class TypeModelExtractor
             return (MemberGenerationKind.NullableValue, innerFqn);
         }
 
-        if (type is INamedTypeSymbol { Name: "List", TypeArguments.Length: 1 } listType
-            && listType.ContainingNamespace is
-            {
-                Name: "Generic",
-                ContainingNamespace.Name: "Collections",
-                ContainingNamespace.ContainingNamespace.Name: "System"
-            })
+        if (type is INamedTypeSymbol { IsTupleType: true } tupleType
+            && tupleType.TypeArguments.Length is >= 2 and <= 4)
         {
-            string innerFqn = listType.TypeArguments[0].ToDisplayString(TypeNameFormat);
-            return (MemberGenerationKind.List, innerFqn);
+            ImmutableArray<string>.Builder parts = ImmutableArray.CreateBuilder<string>(tupleType.TypeArguments.Length);
+            foreach (ITypeSymbol arg in tupleType.TypeArguments)
+            {
+                parts.Add(arg.ToDisplayString(TypeNameFormat));
+            }
+
+            return (MemberGenerationKind.ValueTuple, string.Join("|", parts));
+        }
+
+        if (type is INamedTypeSymbol { TypeArguments.Length: 1 } singleArgType
+            && IsInSystemCollectionsGeneric(singleArgType))
+        {
+            string innerFqn = singleArgType.TypeArguments[0].ToDisplayString(TypeNameFormat);
+            return singleArgType.Name switch
+            {
+                "List" or "IReadOnlyList" or "IList" => (MemberGenerationKind.List, innerFqn),
+                "HashSet" or "IReadOnlySet" => (MemberGenerationKind.Set, innerFqn),
+                _ => (MemberGenerationKind.Unsupported, ""),
+            };
+        }
+
+        if (type is INamedTypeSymbol { Name: "ImmutableArray", TypeArguments.Length: 1 } immArrType
+            && IsInSystemCollectionsImmutable(immArrType))
+        {
+            string innerFqn = immArrType.TypeArguments[0].ToDisplayString(TypeNameFormat);
+            return (MemberGenerationKind.ImmutableArray, innerFqn);
+        }
+
+        if (type is INamedTypeSymbol { Name: "Dictionary", TypeArguments.Length: 2 } dictType
+            && IsInSystemCollectionsGeneric(dictType))
+        {
+            string keyFqn = dictType.TypeArguments[0].ToDisplayString(TypeNameFormat);
+            string valFqn = dictType.TypeArguments[1].ToDisplayString(TypeNameFormat);
+            return (MemberGenerationKind.Dictionary, keyFqn + "|" + valFqn);
         }
 
         if (type is INamedTypeSymbol namedType && SymbolHelpers.HasArbitraryAttribute(namedType))
@@ -289,23 +333,37 @@ internal static class TypeModelExtractor
             return (MemberGenerationKind.ArbitraryReference, "");
         }
 
-        if (providerRegistry is not null)
+        if (providerRegistry is not null && providerRegistry.TryGetValue(typeFqn, out string? providerFqn))
         {
-            string typeFqn = type.ToDisplayString(TypeNameFormat);
-            if (providerRegistry.TryGetValue(typeFqn, out string? providerFqn))
-            {
-                return (MemberGenerationKind.ExternalStrategyProvider, providerFqn);
-            }
+            return (MemberGenerationKind.ExternalStrategyProvider, providerFqn);
         }
 
         return (MemberGenerationKind.Unsupported, "");
     }
 
+    private static bool IsInSystemCollectionsGeneric(INamedTypeSymbol type)
+        => type.ContainingNamespace is
+        {
+            Name: "Generic",
+            ContainingNamespace.Name: "Collections",
+            ContainingNamespace.ContainingNamespace.Name: "System",
+            ContainingNamespace.ContainingNamespace.ContainingNamespace.IsGlobalNamespace: true,
+        };
+
+    private static bool IsInSystemCollectionsImmutable(INamedTypeSymbol type)
+        => type.ContainingNamespace is
+        {
+            Name: "Immutable",
+            ContainingNamespace.Name: "Collections",
+            ContainingNamespace.ContainingNamespace.Name: "System",
+            ContainingNamespace.ContainingNamespace.ContainingNamespace.IsGlobalNamespace: true,
+        };
+
     private static bool IsPrimitive(SpecialType st)
     {
         return st is SpecialType.System_Int32 or SpecialType.System_Int64 or SpecialType.System_Byte
             or SpecialType.System_Boolean or SpecialType.System_String
-            or SpecialType.System_Double or SpecialType.System_Single
+            or SpecialType.System_Double or SpecialType.System_Single or SpecialType.System_Char
             or SpecialType.System_Decimal or SpecialType.System_UInt32 or SpecialType.System_UInt64
             or SpecialType.System_Int16 or SpecialType.System_UInt16 or SpecialType.System_SByte;
     }


### PR DESCRIPTION
## Description

Extends the `Gen.For<T>()` source generator to emit correct strategies for a much wider range of member types. Previously, `Guid` and `decimal` fell back to `Generate.Just(default(...))` (always the same value), and collection types like `Dictionary`, `ImmutableArray`, `HashSet`, and `ValueTuple` were unsupported (emitting a CON202 diagnostic). This cycle wires them all up to proper randomising strategies.

**Core additions:**
- `Generate.Guids()`, `Generate.Decimals()`, `Generate.DateTimes()`, `Generate.Chars()` factory methods
- `GuidStrategy`, `DecimalStrategy`, `DateTimeStrategy`, `CharStrategy` internal implementations
- `DateTimeStrategy` follows the sibling guard pattern (`min ≤ max` enforced in constructor)

**Generator additions:**
- `TypeModelExtractor`: recognises `Guid`/`DateTime`/`DateTimeOffset`/`DateOnly`/`TimeOnly`/`TimeSpan` as primitives; classifies `ImmutableArray<T>`, `Dictionary<K,V>`, `HashSet<T>`/`IReadOnlySet<T>`, `IReadOnlyList<T>`/`IList<T>`, `ValueTuple` (2–4 elements)
- `MemberGenerationKind`: adds `Dictionary`, `ImmutableArray`, `Set`, `ValueTuple`
- `StrategyEmitter`: emits `Generate.Dictionaries(...)`, `Generate.Lists(...).Select(ImmutableArray.CreateRange)`, `Generate.Sets(...)`, `Generate.Tuples(...)` for each new kind; collection gen-exprs omit redundant type args (C# infers them)

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #359
Part of #295