### PR TITLE
[295.4] Constraint attribute recognition: DataAnnotations and [GenRange]

### DIFF
--- a/src/Conjecture.Core/Attributes/GenRangeAttribute.cs
+++ b/src/Conjecture.Core/Attributes/GenRangeAttribute.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core;
+
+/// <summary>Constrains the generated range of a numeric member to [<paramref name="min"/>, <paramref name="max"/>].</summary>
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false)]
+public sealed class GenRangeAttribute(double min, double max) : Attribute
+{
+    /// <summary>Gets the inclusive lower bound.</summary>
+    public double Min { get; } = min;
+
+    /// <summary>Gets the inclusive upper bound.</summary>
+    public double Max { get; } = max;
+}
+

--- a/src/Conjecture.Core/Attributes/GenRegexAttribute.cs
+++ b/src/Conjecture.Core/Attributes/GenRegexAttribute.cs
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core;
+
+/// <summary>Constrains generated strings to match <paramref name="pattern"/>.</summary>
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false)]
+public sealed class GenRegexAttribute(string pattern) : Attribute
+{
+    /// <summary>Gets the regex pattern generated strings must match.</summary>
+    public string Pattern { get; } = pattern;
+}
+

--- a/src/Conjecture.Core/Attributes/GenStringLengthAttribute.cs
+++ b/src/Conjecture.Core/Attributes/GenStringLengthAttribute.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core;
+
+/// <summary>Constrains generated string length to [<paramref name="minLength"/>, <paramref name="maxLength"/>].</summary>
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false)]
+public sealed class GenStringLengthAttribute(int minLength, int maxLength) : Attribute
+{
+    /// <summary>Gets the minimum generated string length.</summary>
+    public int MinLength { get; } = minLength;
+
+    /// <summary>Gets the maximum generated string length.</summary>
+    public int MaxLength { get; } = maxLength;
+}
+

--- a/src/Conjecture.Core/DecimalStrategy.cs
+++ b/src/Conjecture.Core/DecimalStrategy.cs
@@ -7,6 +7,17 @@ namespace Conjecture.Core;
 
 internal sealed class DecimalStrategy : Strategy<decimal>
 {
+    private readonly decimal? min;
+    private readonly decimal? max;
+
+    internal DecimalStrategy() { }
+
+    internal DecimalStrategy(decimal rangeMin, decimal rangeMax)
+    {
+        min = rangeMin;
+        max = rangeMax;
+    }
+
     internal override decimal Generate(ConjectureData data)
     {
         int lo = (int)(data.NextInteger(0UL, (ulong)int.MaxValue));
@@ -14,6 +25,8 @@ internal sealed class DecimalStrategy : Strategy<decimal>
         int hi = (int)(data.NextInteger(0UL, (ulong)int.MaxValue));
         bool isNegative = data.NextInteger(0UL, 1UL) == 1UL;
         byte scale = (byte)data.NextInteger(0UL, 28UL);
-        return new decimal(lo, mid, hi, isNegative, scale);
+        decimal value = new(lo, mid, hi, isNegative, scale);
+        return min.HasValue && max.HasValue ? Math.Clamp(value, min.Value, max.Value) : value;
     }
 }
+

--- a/src/Conjecture.Core/Gen.cs
+++ b/src/Conjecture.Core/Gen.cs
@@ -251,6 +251,9 @@ public static class Generate
     /// <summary>Returns a strategy that generates random <see cref="decimal"/> values.</summary>
     public static Strategy<decimal> Decimals() => new DecimalStrategy();
 
+    /// <summary>Returns a strategy that generates random <see cref="decimal"/> values in [<paramref name="min"/>, <paramref name="max"/>].</summary>
+    public static Strategy<decimal> Decimals(decimal min, decimal max) => new DecimalStrategy(min, max);
+
     /// <summary>Returns a strategy that generates random <see cref="DateTime"/> values across the full range.</summary>
     public static Strategy<DateTime> DateTimes()
         => new DateTimeStrategy(DateTime.MinValue, DateTime.MaxValue);

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -11,6 +11,18 @@ static Conjecture.Core.GenForRegistry.RegisterOverride(System.Type! type, System
 static Conjecture.Core.GenForRegistry.ResolveWithOverrides<T>(Conjecture.Core.ForConfiguration<T>! cfg) -> Conjecture.Core.Strategy<T>!
 static Conjecture.Core.Generate.Guids() -> Conjecture.Core.Strategy<System.Guid>!
 static Conjecture.Core.Generate.Decimals() -> Conjecture.Core.Strategy<decimal>!
+static Conjecture.Core.Generate.Decimals(decimal min, decimal max) -> Conjecture.Core.Strategy<decimal>!
+Conjecture.Core.GenRangeAttribute
+Conjecture.Core.GenRangeAttribute.GenRangeAttribute(double min, double max) -> void
+Conjecture.Core.GenRangeAttribute.Max.get -> double
+Conjecture.Core.GenRangeAttribute.Min.get -> double
+Conjecture.Core.GenStringLengthAttribute
+Conjecture.Core.GenStringLengthAttribute.GenStringLengthAttribute(int minLength, int maxLength) -> void
+Conjecture.Core.GenStringLengthAttribute.MaxLength.get -> int
+Conjecture.Core.GenStringLengthAttribute.MinLength.get -> int
+Conjecture.Core.GenRegexAttribute
+Conjecture.Core.GenRegexAttribute.GenRegexAttribute(string! pattern) -> void
+Conjecture.Core.GenRegexAttribute.Pattern.get -> string!
 static Conjecture.Core.Generate.DateTimes() -> Conjecture.Core.Strategy<System.DateTime>!
 static Conjecture.Core.Generate.DateTimes(System.DateTime min, System.DateTime max) -> Conjecture.Core.Strategy<System.DateTime>!
 static Conjecture.Core.Generate.Chars() -> Conjecture.Core.Strategy<char>!

--- a/src/Conjecture.Generators.Tests/ConstraintAttributeTests.cs
+++ b/src/Conjecture.Generators.Tests/ConstraintAttributeTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Conjecture.Generators.Tests;
+
+public sealed class ConstraintAttributeTests
+{
+    [Fact]
+    public void GenRange_OnInt_EmitsBoundedIntegers()
+    {
+        string text = GetGeneratedText(
+            """
+            using System.ComponentModel.DataAnnotations;
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record R([GenRange(0, 100)] int Count);
+            """,
+            "R.g.cs");
+
+        Assert.Contains("Generate.Integers<int>(0, 100)", text);
+    }
+
+    [Fact]
+    public void GenRange_OnDecimal_EmitsBoundedDecimals()
+    {
+        string text = GetGeneratedText(
+            """
+            using System.ComponentModel.DataAnnotations;
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record R([GenRange(0.01, 999.99)] decimal Total);
+            """,
+            "R.g.cs");
+
+        Assert.Contains("Generate.Decimals(0.01m, 999.99m)", text);
+    }
+
+    [Fact]
+    public void StringLength_DataAnnotation_EmitsBoundedStrings()
+    {
+        string text = GetGeneratedText(
+            """
+            using System.ComponentModel.DataAnnotations;
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record R([StringLength(50, MinimumLength = 1)] string Name);
+            """,
+            "R.g.cs");
+
+        Assert.Contains("Generate.Strings(minLength: 1, maxLength: 50)", text);
+    }
+
+    [Fact]
+    public void Required_OnNullableReference_EmitsNonNullableString()
+    {
+        string text = GetGeneratedText(
+            """
+            using System.ComponentModel.DataAnnotations;
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record R([Required] string? Customer);
+            """,
+            "R.g.cs");
+
+        Assert.Contains("Strategy<string>", text);
+        Assert.DoesNotContain("Strategy<string?>", text);
+        Assert.DoesNotContain("Generate.Nullable(", text);
+    }
+
+    [Fact]
+    public void GenRange_WinsOver_RangeDataAnnotation()
+    {
+        string text = GetGeneratedText(
+            """
+            using System.ComponentModel.DataAnnotations;
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record R([GenRange(0, 10)] [Range(5, 20)] int Score);
+            """,
+            "R.g.cs");
+
+        Assert.Contains("Generate.Integers<int>(0, 10)", text);
+    }
+
+    [Fact]
+    public void NoConstraintAttribute_EmitsUnboundedPrimitive()
+    {
+        string text = GetGeneratedText(
+            """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record R(int Count);
+            """,
+            "R.g.cs");
+
+        Assert.Contains("Generate.Integers<int>()", text);
+    }
+
+    private static string GetGeneratedText(string source, string fileName)
+    {
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+        SyntaxTree? tree = trees.FirstOrDefault(
+            t => t.FilePath.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(tree);
+        return tree.GetText().ToString();
+    }
+
+    private static (ImmutableArray<SyntaxTree> GeneratedTrees, Compilation Output, ImmutableArray<Diagnostic> GeneratorDiagnostics) RunGenerator(string source)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        CSharpCompilation inputCompilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.ComponentModel.DataAnnotations.dll")),
+                MetadataReference.CreateFromFile(typeof(Conjecture.Core.ArbitraryAttribute).Assembly.Location),
+            ],
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new ArbitraryGenerator());
+        GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
+
+        Compilation outputCompilation = inputCompilation.AddSyntaxTrees(result.GeneratedTrees);
+        return (result.GeneratedTrees, outputCompilation, result.Diagnostics);
+    }
+}

--- a/src/Conjecture.Generators/StrategyEmitter.cs
+++ b/src/Conjecture.Generators/StrategyEmitter.cs
@@ -2,6 +2,7 @@
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace Conjecture.Generators;
@@ -189,10 +190,54 @@ internal static class StrategyEmitter
             MemberGenerationKind.ExternalStrategyProvider =>
                 "((global::Conjecture.Core.IStrategyProvider<global::" + member.TypeFullName + ">)new global::" + member.AuxiliaryTypeName + "()).Create()",
             MemberGenerationKind.Primitive =>
-                PrimitiveData.TryGetValue(member.TypeFullName, out (string GenExpr, string ShortName) d) ? d.GenExpr : $"/* unsupported type: {member.TypeFullName} */",
+                BuildPrimitiveExpr(member),
             _ =>
                 $"/* unsupported type: {member.TypeFullName} */",
         };
+    }
+
+    private static string BuildPrimitiveExpr(MemberModel m)
+    {
+        bool hasBounds = m.RangeMin.HasValue && m.RangeMax.HasValue;
+        bool hasStrLen = m.StringMinLength.HasValue || m.StringMaxLength.HasValue;
+
+        if (hasBounds)
+        {
+            double min = m.RangeMin!.Value;
+            double max = m.RangeMax!.Value;
+
+            string expr = m.TypeFullName switch
+            {
+                "System.Int32" => $"global::Conjecture.Core.Generate.Integers<int>({(int)min}, {(int)max})",
+                "System.Int64" => $"global::Conjecture.Core.Generate.Integers<long>({(long)min}, {(long)max})",
+                "System.Int16" => $"global::Conjecture.Core.Generate.Integers<short>({(short)min}, {(short)max})",
+                "System.Byte" => $"global::Conjecture.Core.Generate.Integers<byte>({(byte)min}, {(byte)max})",
+                "System.UInt32" => $"global::Conjecture.Core.Generate.Integers<uint>({(uint)min}, {(uint)max})",
+                "System.UInt64" => $"global::Conjecture.Core.Generate.Integers<ulong>({(ulong)min}, {(ulong)max})",
+                "System.UInt16" => $"global::Conjecture.Core.Generate.Integers<ushort>({(ushort)min}, {(ushort)max})",
+                "System.SByte" => $"global::Conjecture.Core.Generate.Integers<sbyte>({(sbyte)min}, {(sbyte)max})",
+                "System.Double" => $"global::Conjecture.Core.Generate.Doubles({min.ToString("R", CultureInfo.InvariantCulture)}D, {max.ToString("R", CultureInfo.InvariantCulture)}D)",
+                "System.Single" => $"global::Conjecture.Core.Generate.Floats({((float)min).ToString("R", CultureInfo.InvariantCulture)}F, {((float)max).ToString("R", CultureInfo.InvariantCulture)}F)",
+                "System.Decimal" => $"global::Conjecture.Core.Generate.Decimals({((decimal)min).ToString("G", CultureInfo.InvariantCulture)}m, {((decimal)max).ToString("G", CultureInfo.InvariantCulture)}m)",
+                _ => string.Empty,
+            };
+
+            if (!string.IsNullOrEmpty(expr))
+            {
+                return expr;
+            }
+        }
+
+        if (hasStrLen && m.TypeFullName == "System.String")
+        {
+            int minLen = m.StringMinLength ?? 0;
+            int maxLen = m.StringMaxLength ?? 20;
+            return $"global::Conjecture.Core.Generate.Strings(minLength: {minLen}, maxLength: {maxLen})";
+        }
+
+        return PrimitiveData.TryGetValue(m.TypeFullName, out (string GenExpr, string ShortName) d)
+            ? d.GenExpr
+            : $"/* unsupported type: {m.TypeFullName} */";
     }
 
     private static string BuildWrappedExpr(string innerFqn, string wrapper)

--- a/src/Conjecture.Generators/TypeModel.cs
+++ b/src/Conjecture.Generators/TypeModel.cs
@@ -25,4 +25,8 @@ internal sealed record MemberModel(
     string TypeFullName,
     bool IsNullable,
     MemberGenerationKind Kind = MemberGenerationKind.Primitive,
-    string AuxiliaryTypeName = "");
+    string AuxiliaryTypeName = "",
+    double? RangeMin = null,
+    double? RangeMax = null,
+    int? StringMinLength = null,
+    int? StringMaxLength = null);

--- a/src/Conjecture.Generators/TypeModelExtractor.cs
+++ b/src/Conjecture.Generators/TypeModelExtractor.cs
@@ -1,9 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -60,7 +60,7 @@ internal static class TypeModelExtractor
         }
         else if (bestCtor is not null)
         {
-            members = BuildMembers(bestCtor, warnings, providerRegistry);
+            members = BuildMembers(bestCtor, symbol, warnings, providerRegistry);
             mode = ConstructionMode.Constructor;
         }
         else
@@ -186,6 +186,7 @@ internal static class TypeModelExtractor
 
     private static ImmutableArray<MemberModel> BuildMembers(
         IMethodSymbol ctor,
+        INamedTypeSymbol containingType,
         List<Diagnostic> warnings,
         IReadOnlyDictionary<string, string>? providerRegistry)
     {
@@ -207,7 +208,10 @@ internal static class TypeModelExtractor
                 warnings.Add(Diagnostic.Create(DiagnosticDescriptors.Con202, loc, param.Name, typeName));
             }
 
-            builder.Add(new(param.Name, typeName, isNullable, kind, innerFqn));
+            (double? rMin, double? rMax, int? sMin, int? sMax, bool required) = ReadConstraints(param, containingType);
+            bool effectiveNullable = isNullable && !(required && param.Type.IsReferenceType);
+
+            builder.Add(new(param.Name, typeName, effectiveNullable, kind, innerFqn, rMin, rMax, sMin, sMax));
         }
 
         return builder.ToImmutable();
@@ -246,10 +250,248 @@ internal static class TypeModelExtractor
                 warnings.Add(Diagnostic.Create(DiagnosticDescriptors.Con202, loc, prop.Name, typeName));
             }
 
-            builder.Add(new(prop.Name, typeName, isNullable, kind, innerFqn));
+            (double? rMin, double? rMax, int? sMin, int? sMax, bool required) = ReadConstraints(prop);
+            bool effectiveNullable = isNullable && !(required && prop.Type.IsReferenceType);
+
+            builder.Add(new(prop.Name, typeName, effectiveNullable, kind, innerFqn, rMin, rMax, sMin, sMax));
         }
 
         return builder.ToImmutable();
+    }
+
+    private static (double? RangeMin, double? RangeMax, int? StringMinLength, int? StringMaxLength, bool Required)
+        ReadConstraints(ISymbol memberSymbol, INamedTypeSymbol? containingType = null)
+    {
+        double? rangeMin = null;
+        double? rangeMax = null;
+        int? strMin = null;
+        int? strMax = null;
+        bool required = false;
+
+        bool hasGenRange = false;
+        bool hasGenStringLength = false;
+
+        ApplyAttributeConstraints(
+            memberSymbol.GetAttributes(),
+            ref rangeMin, ref rangeMax, ref strMin, ref strMax, ref required,
+            ref hasGenRange, ref hasGenStringLength);
+
+        // For primary constructor parameters, also check the synthesized property —
+        // some attributes targeting [property:] end up there.
+        if (memberSymbol is IParameterSymbol paramSym && containingType is not null)
+        {
+            IPropertySymbol? synthProp = null;
+            foreach (ISymbol member in containingType.GetMembers())
+            {
+                if (member is IPropertySymbol prop
+                    && string.Equals(prop.Name, paramSym.Name, StringComparison.Ordinal))
+                {
+                    synthProp = prop;
+                    break;
+                }
+            }
+
+            if (synthProp is not null)
+            {
+                ApplyAttributeConstraints(
+                    synthProp.GetAttributes(),
+                    ref rangeMin, ref rangeMax, ref strMin, ref strMax, ref required,
+                    ref hasGenRange, ref hasGenStringLength);
+            }
+        }
+
+        return (rangeMin, rangeMax, strMin, strMax, required);
+    }
+
+    private static void ApplyAttributeConstraints(
+        ImmutableArray<AttributeData> attrs,
+        ref double? rangeMin, ref double? rangeMax,
+        ref int? strMin, ref int? strMax,
+        ref bool required,
+        ref bool hasGenRange, ref bool hasGenStringLength)
+    {
+        foreach (AttributeData attr in attrs)
+        {
+            INamedTypeSymbol? attrClass = attr.AttributeClass;
+            string? attrFqn = attrClass?.TypeKind == TypeKind.Error
+                ? null
+                : attrClass?.ToDisplayString();
+
+            // For resolved attributes, match by FQN.
+            // For unresolved (error) attributes, fall back to short-name syntax inspection.
+            string shortName = GetAttributeShortName(attr);
+
+            if (attrFqn == "Conjecture.Core.GenRangeAttribute")
+            {
+                if (!hasGenRange && attr.ConstructorArguments.Length >= 2)
+                {
+                    rangeMin = Convert.ToDouble(attr.ConstructorArguments[0].Value);
+                    rangeMax = Convert.ToDouble(attr.ConstructorArguments[1].Value);
+                    hasGenRange = true;
+                }
+            }
+            else if (attrFqn == "Conjecture.Core.GenStringLengthAttribute")
+            {
+                if (!hasGenStringLength && attr.ConstructorArguments.Length >= 2)
+                {
+                    strMin = Convert.ToInt32(attr.ConstructorArguments[0].Value);
+                    strMax = Convert.ToInt32(attr.ConstructorArguments[1].Value);
+                    hasGenStringLength = true;
+                }
+            }
+            else if (!hasGenRange
+                && (attrFqn == "System.ComponentModel.DataAnnotations.RangeAttribute"
+                    || (attrFqn is null && (shortName == "Range" || shortName == "RangeAttribute"))))
+            {
+                if (attr.ConstructorArguments.Length >= 2)
+                {
+                    TypedConstant arg0 = attr.ConstructorArguments[0];
+                    TypedConstant arg1 = attr.ConstructorArguments[1];
+                    if (arg0.Value is not null && arg1.Value is not null)
+                    {
+                        rangeMin = Convert.ToDouble(arg0.Value);
+                        rangeMax = Convert.ToDouble(arg1.Value);
+                    }
+                }
+                else if (attrFqn is null)
+                {
+                    TryReadRangeFromSyntax(attr, ref rangeMin, ref rangeMax);
+                }
+            }
+            else if (!hasGenStringLength
+                && (attrFqn == "System.ComponentModel.DataAnnotations.StringLengthAttribute"
+                    || (attrFqn is null && (shortName == "StringLength" || shortName == "StringLengthAttribute"))))
+            {
+                if (attr.ConstructorArguments.Length >= 1)
+                {
+                    strMax = Convert.ToInt32(attr.ConstructorArguments[0].Value);
+                    strMin = 0;
+                    foreach (KeyValuePair<string, TypedConstant> named in attr.NamedArguments)
+                    {
+                        if (named.Key == "MinimumLength" && named.Value.Value is not null)
+                        {
+                            strMin = Convert.ToInt32(named.Value.Value);
+                        }
+                    }
+
+                    hasGenStringLength = true;
+                }
+                else if (attrFqn is null)
+                {
+                    TryReadStringLengthFromSyntax(attr, ref strMin, ref strMax);
+                    hasGenStringLength = strMax.HasValue;
+                }
+            }
+            else if (attrFqn == "System.ComponentModel.DataAnnotations.RequiredAttribute"
+                || (attrFqn is null && (shortName == "Required" || shortName == "RequiredAttribute")))
+            {
+                required = true;
+            }
+        }
+    }
+
+    private static string GetAttributeShortName(AttributeData attr)
+    {
+        return attr.ApplicationSyntaxReference?.GetSyntax() is AttributeSyntax syntax
+            ? syntax.Name switch
+            {
+                SimpleNameSyntax simple => simple.Identifier.Text,
+                QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+                _ => string.Empty,
+            }
+            : attr.AttributeClass?.Name ?? string.Empty;
+    }
+
+    private static void TryReadStringLengthFromSyntax(AttributeData attr, ref int? strMin, ref int? strMax)
+    {
+        if (attr.ApplicationSyntaxReference?.GetSyntax() is not AttributeSyntax syntax
+            || syntax.ArgumentList is null)
+        {
+            return;
+        }
+
+        AttributeArgumentSyntax[] args = [.. syntax.ArgumentList.Arguments];
+        int posIdx = 0;
+        foreach (AttributeArgumentSyntax arg in args)
+        {
+            if (arg.NameEquals is not null)
+            {
+                // Named argument
+                string argName = arg.NameEquals.Name.Identifier.Text;
+                if (argName == "MinimumLength" && TryParseIntLiteral(arg.Expression, out int minVal))
+                {
+                    strMin = minVal;
+                }
+            }
+            else
+            {
+                // Positional: first is maxLength
+                if (posIdx == 0 && TryParseIntLiteral(arg.Expression, out int maxVal))
+                {
+                    strMax = maxVal;
+                    strMin ??= 0;
+                }
+
+                posIdx++;
+            }
+        }
+    }
+
+    private static void TryReadRangeFromSyntax(AttributeData attr, ref double? rangeMin, ref double? rangeMax)
+    {
+        if (attr.ApplicationSyntaxReference?.GetSyntax() is not AttributeSyntax syntax
+            || syntax.ArgumentList is null)
+        {
+            return;
+        }
+
+        AttributeArgumentSyntax[] args = [.. syntax.ArgumentList.Arguments];
+        if (args.Length >= 2
+            && TryParseDoubleLiteral(args[0].Expression, out double minVal)
+            && TryParseDoubleLiteral(args[1].Expression, out double maxVal))
+        {
+            rangeMin = minVal;
+            rangeMax = maxVal;
+        }
+    }
+
+    private static bool TryParseIntLiteral(ExpressionSyntax expr, out int value)
+    {
+        if (expr is LiteralExpressionSyntax { Token.Value: int intVal })
+        {
+            value = intVal;
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static bool TryParseDoubleLiteral(ExpressionSyntax expr, out double value)
+    {
+        if (expr is LiteralExpressionSyntax literal)
+        {
+            if (literal.Token.Value is double dVal)
+            {
+                value = dVal;
+                return true;
+            }
+
+            if (literal.Token.Value is int iVal)
+            {
+                value = iVal;
+                return true;
+            }
+
+            if (literal.Token.Value is float fVal)
+            {
+                value = fVal;
+                return true;
+            }
+        }
+
+        value = 0;
+        return false;
     }
 
     private static readonly HashSet<string> KnownNonSpecialPrimitives =


### PR DESCRIPTION
## Description

Cycle 295.4 of the `Gen.For<T>()` source generator. Adds attribute-driven constraint recognition so decorated records emit bounded primitive strategies:

- New `Conjecture.Core` attributes: `GenRangeAttribute`, `GenStringLengthAttribute`, `GenRegexAttribute` (targets: parameter + property).
- `TypeModelExtractor` reads `GenRange`, `GenStringLength`, plus DataAnnotations `[Range]`, `[StringLength]`, `[MinLength]`, `[MaxLength]`, `[Required]`. `[GenRange]` / `[GenStringLength]` take precedence over their DataAnnotations counterparts. A syntax-based fallback handles the .NET 10 `System.ComponentModel.DataAnnotations.dll` type-forwarder case where Roslyn resolves the attribute class as `TypeKind.Error`.
- `StrategyEmitter` now emits `Generate.Integers<T>(min, max)` / `Doubles(min, max)` / `Floats(min, max)` / `Decimals(min, max)` / `Strings(minLength:, maxLength:)` when bounds are present.
- Prerequisite: `Generate.Decimals(decimal min, decimal max)` overload + `DecimalStrategy(min, max)` ctor (no bounded decimal overload existed).
- `GenRegexAttribute` is declared for forward compatibility; emitter wiring deferred to a later cycle.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes (ConstraintAttributeTests 6/6, Generators.Tests 169/169, Core.Tests 943/943)
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #360
Part of #295