### PR TITLE
[295.5] Recursive type handling and [GenMaxDepth] attribute

### DIFF
--- a/src/Conjecture.Core/Attributes/GenMaxDepthAttribute.cs
+++ b/src/Conjecture.Core/Attributes/GenMaxDepthAttribute.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+namespace Conjecture.Core;
+
+/// <summary>Caps the recursive generation depth for a self-referential or mutually recursive type to <paramref name="maxDepth"/>.</summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+public sealed class GenMaxDepthAttribute(int maxDepth) : Attribute
+{
+    /// <summary>Gets the maximum generation depth.</summary>
+    public int MaxDepth { get; } = maxDepth;
+}

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -26,3 +26,6 @@ Conjecture.Core.GenRegexAttribute.Pattern.get -> string!
 static Conjecture.Core.Generate.DateTimes() -> Conjecture.Core.Strategy<System.DateTime>!
 static Conjecture.Core.Generate.DateTimes(System.DateTime min, System.DateTime max) -> Conjecture.Core.Strategy<System.DateTime>!
 static Conjecture.Core.Generate.Chars() -> Conjecture.Core.Strategy<char>!
+Conjecture.Core.GenMaxDepthAttribute
+Conjecture.Core.GenMaxDepthAttribute.GenMaxDepthAttribute(int maxDepth) -> void
+Conjecture.Core.GenMaxDepthAttribute.MaxDepth.get -> int

--- a/src/Conjecture.Generators.Tests/RecursiveTypeTests.cs
+++ b/src/Conjecture.Generators.Tests/RecursiveTypeTests.cs
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Conjecture.Generators.Tests;
+
+public sealed class RecursiveTypeTests
+{
+    // --- Behaviour 1: self-referential type emits Generate.Recursive with default maxDepth: 5 ---
+
+    [Fact]
+    public void SelfReferentialRecord_EmitsGenerateRecursiveWrapper()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record TreeNode(int Value, [Arbitrary] TreeNode? Child);
+            """;
+
+        string text = GetGeneratedText(source, "TreeNode.g.cs");
+
+        Assert.Contains("Generate.Recursive<", text);
+    }
+
+    [Fact]
+    public void SelfReferentialRecord_DefaultMaxDepthIsFive()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record TreeNode(int Value, [Arbitrary] TreeNode? Child);
+            """;
+
+        string text = GetGeneratedText(source, "TreeNode.g.cs");
+
+        Assert.Contains("maxDepth: 5", text);
+    }
+
+    // --- Behaviour 2: [GenMaxDepth(3)] overrides maxDepth ---
+
+    [Fact]
+    public void GenMaxDepthAttribute_OverridesDefaultMaxDepth()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary, GenMaxDepth(3)] public partial record TreeNode(int Value, [Arbitrary] TreeNode? Child);
+            """;
+
+        string text = GetGeneratedText(source, "TreeNode.g.cs");
+
+        Assert.Contains("maxDepth: 3", text);
+    }
+
+    [Fact]
+    public void GenMaxDepthAttribute_DoesNotEmitDefaultMaxDepth()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary, GenMaxDepth(3)] public partial record TreeNode(int Value, [Arbitrary] TreeNode? Child);
+            """;
+
+        string text = GetGeneratedText(source, "TreeNode.g.cs");
+
+        Assert.DoesNotContain("maxDepth: 5", text);
+    }
+
+    // --- Behaviour 3: mutually recursive types emit CON313 warning ---
+
+    [Fact]
+    public void MutuallyRecursiveTypes_EmitsCon313Warning()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record Alpha(int X, [Arbitrary] Beta? Next);
+            [Arbitrary] public partial record Beta(int Y, [Arbitrary] Alpha? Next);
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == "CON313");
+    }
+
+    [Fact]
+    public void MutuallyRecursiveTypes_Con313IsWarning()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record Alpha(int X, [Arbitrary] Beta? Next);
+            [Arbitrary] public partial record Beta(int Y, [Arbitrary] Alpha? Next);
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+        Diagnostic? con313 = diagnostics.FirstOrDefault(d => d.Id == "CON313");
+
+        Assert.NotNull(con313);
+        Assert.Equal(DiagnosticSeverity.Warning, con313.Severity);
+    }
+
+    [Fact]
+    public void MutuallyRecursiveTypes_StillGeneratesOutput()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record Alpha(int X, [Arbitrary] Beta? Next);
+            [Arbitrary] public partial record Beta(int Y, [Arbitrary] Alpha? Next);
+            """;
+
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+
+        Assert.NotEmpty(trees);
+    }
+
+    // --- Behaviour 4: non-recursive type does NOT emit Generate.Recursive ---
+
+    [Fact]
+    public void NonRecursiveRecord_DoesNotEmitGenerateRecursive()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record Person(string Name, int Age);
+            """;
+
+        string text = GetGeneratedText(source, "Person.g.cs");
+
+        Assert.DoesNotContain("Generate.Recursive", text);
+    }
+
+    // --- Behaviour 5: base case passes null for recursive slot ---
+
+    [Fact]
+    public void SelfReferentialRecord_BaseCasePassesNullForChildParameter()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record TreeNode(int Value, [Arbitrary] TreeNode? Child);
+            """;
+
+        string text = GetGeneratedText(source, "TreeNode.g.cs");
+
+        Assert.Contains("null", text);
+    }
+
+    // --- Behaviour 6: self-referential class with object-initializer mode emits valid Generate.Recursive ---
+
+    [Fact]
+    public void SelfReferentialType_WithObjectInitializerMode_EmitsValidCode()
+    {
+        string source = """
+            using Conjecture.Core;
+
+            namespace Tests;
+
+            [Arbitrary]
+            public class TreeClass
+            {
+                public string Name { get; init; } = "";
+                public TreeClass? Child { get; init; }
+            }
+            """;
+
+        string text = GetGeneratedText(source, "TreeClassArbitrary.g.cs");
+
+        Assert.Contains("Generate.Recursive<", text);
+        Assert.DoesNotContain("new global::Tests.TreeClass(", text);
+    }
+
+    // --- Behaviour 7: mutual recursion via nullable init property triggers CON313 ---
+
+    [Fact]
+    public void MutuallyRecursiveTypes_ViaInitProperty_EmitsCon313Warning()
+    {
+        string source = """
+            using Conjecture.Core;
+
+            namespace Tests;
+
+            [Arbitrary]
+            public class NodeA
+            {
+                public string Value { get; init; } = "";
+                public NodeB? Partner { get; init; }
+            }
+
+            [Arbitrary]
+            public class NodeB
+            {
+                public int Score { get; init; }
+                public NodeA? Back { get; init; }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+        Diagnostic? con313 = diagnostics.FirstOrDefault(d => d.Id == "CON313");
+
+        Assert.NotNull(con313);
+    }
+
+    // --- helpers ---
+
+    private static string GetGeneratedText(string source, string fileName)
+    {
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+        SyntaxTree? tree = trees.FirstOrDefault(
+            t => t.FilePath.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
+        Assert.NotNull(tree);
+        return tree.GetText().ToString();
+    }
+
+    private static ImmutableArray<Diagnostic> GetGeneratorDiagnostics(string source)
+    {
+        (_, _, ImmutableArray<Diagnostic> diagnostics) = RunGenerator(source);
+        return diagnostics;
+    }
+
+    private static (ImmutableArray<SyntaxTree> GeneratedTrees, Compilation Output, ImmutableArray<Diagnostic> GeneratorDiagnostics) RunGenerator(string source)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        CSharpCompilation inputCompilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
+                MetadataReference.CreateFromFile(typeof(Conjecture.Core.ArbitraryAttribute).Assembly.Location),
+            ],
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new ArbitraryGenerator());
+        GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
+
+        Compilation outputCompilation = inputCompilation.AddSyntaxTrees(result.GeneratedTrees);
+        return (result.GeneratedTrees, outputCompilation, result.Diagnostics);
+    }
+}

--- a/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ CON205 | Conjecture | Warning | Concrete subtype excluded from sealed hierarchy 
 CON300 | Conjecture | Error | [Arbitrary] base type must be abstract
 CON301 | Conjecture | Error | [Arbitrary] base type must be a class or record, not an interface or struct
 CON302 | Conjecture | Error | No concrete [Arbitrary] subtypes found for abstract base type
+CON313 | Usage | Warning | Mutually recursive [Arbitrary] types without [GenMaxDepth]

--- a/src/Conjecture.Generators/ArbitraryGenerator.cs
+++ b/src/Conjecture.Generators/ArbitraryGenerator.cs
@@ -52,7 +52,8 @@ public sealed class ArbitraryGenerator : IIncrementalGenerator
             }
 
             string source = StrategyEmitter.Emit(model!);
-            ctx.AddSource(model!.TypeName + ".g", source);
+            string hintName = model!.IsPartial ? model.TypeName + ".g" : model.TypeName + "Arbitrary.g";
+            ctx.AddSource(hintName, source);
         });
 
         // Hierarchy pipeline: only abstract types

--- a/src/Conjecture.Generators/DiagnosticDescriptors.cs
+++ b/src/Conjecture.Generators/DiagnosticDescriptors.cs
@@ -78,4 +78,12 @@ internal static class DiagnosticDescriptors
         category: "Conjecture",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor Con313MutualRecursionWithoutMaxDepth = new(
+        id: "CON313",
+        title: "Mutual recursion without [GenMaxDepth]",
+        messageFormat: "Types '{0}' and '{1}' are mutually recursive but neither has [GenMaxDepth]. Add [GenMaxDepth(n)] to cap generation depth.",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
 }

--- a/src/Conjecture.Generators/StrategyEmitter.cs
+++ b/src/Conjecture.Generators/StrategyEmitter.cs
@@ -54,12 +54,19 @@ internal static class StrategyEmitter
 
         bool isPartialCtor = model.ConstructionMode == ConstructionMode.PartialConstructor;
         string fieldVisibility = isPartialCtor ? "internal" : "private";
+        bool hasRecursive = HasAnyRecursiveMember(model);
 
         if (!model.Members.IsEmpty)
         {
             for (int i = 0; i < model.Members.Length; i++)
             {
                 MemberModel member = model.Members[i];
+                // Recursive members have no static field — they are resolved via `inner` at emit time
+                if (member.Kind == MemberGenerationKind.Recursive)
+                {
+                    continue;
+                }
+
                 sb.AppendLine("    " + fieldVisibility + " static readonly global::Conjecture.Core.Strategy<" + ResolveStrategyType(member) + "> _s" + i + " = " + ResolveGenExpr(member) + ";");
             }
             sb.AppendLine();
@@ -75,6 +82,10 @@ internal static class StrategyEmitter
             sb.AppendLine("            return new " + fqn + "();");
             sb.AppendLine("        });");
             sb.AppendLine("    }");
+        }
+        else if (hasRecursive)
+        {
+            EmitRecursiveCreate(sb, model, fqn);
         }
         else
         {
@@ -107,7 +118,6 @@ internal static class StrategyEmitter
                     sb.AppendLine("            ctx.Generate(_s" + i + ")" + suffix);
                 }
             }
-
         }
 
         sb.AppendLine("}");
@@ -131,6 +141,91 @@ internal static class StrategyEmitter
         }
 
         return sb.ToString();
+    }
+
+    private static bool HasAnyRecursiveMember(TypeModel model)
+    {
+        foreach (MemberModel m in model.Members)
+        {
+            if (m.Kind == MemberGenerationKind.Recursive)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void EmitRecursiveCreate(StringBuilder sb, TypeModel model, string fqn)
+    {
+        sb.AppendLine("    public global::Conjecture.Core.Strategy<" + fqn + "> Create() =>");
+        sb.AppendLine("        global::Conjecture.Core.Generate.Recursive<" + fqn + ">(");
+
+        if (model.ConstructionMode == ConstructionMode.ObjectInitializer)
+        {
+            EmitObjectInitializerRecursiveCases(sb, model, fqn);
+        }
+        else
+        {
+            // Base case: all recursive members get null, others use their strategy
+            sb.Append("            global::Conjecture.Core.Generate.Compose<" + fqn + ">(ctx => new " + fqn + "(");
+            EmitConstructorArgs(sb, model, isBaseCase: true);
+            sb.AppendLine("),");
+
+            // Recursive case: recursive members use ctx.Generate(inner)
+            sb.Append("            inner => global::Conjecture.Core.Generate.Compose<" + fqn + ">(ctx => new " + fqn + "(");
+            EmitConstructorArgs(sb, model, isBaseCase: false);
+            sb.AppendLine("),");
+        }
+
+        sb.AppendLine("            maxDepth: " + model.MaxDepth + ");");
+    }
+
+    private static void EmitObjectInitializerRecursiveCases(StringBuilder sb, TypeModel model, string fqn)
+    {
+        // Base case
+        sb.AppendLine("            global::Conjecture.Core.Generate.Compose<" + fqn + ">(ctx => new " + fqn + " {");
+        for (int i = 0; i < model.Members.Length; i++)
+        {
+            MemberModel member = model.Members[i];
+            bool isLast = i == model.Members.Length - 1;
+            string arg = member.Kind == MemberGenerationKind.Recursive ? "null" : "ctx.Generate(_s" + i + ")";
+            string suffix = isLast ? " })," : ",";
+            sb.AppendLine("                " + member.Name + " = " + arg + suffix);
+        }
+
+        // Recursive case
+        sb.AppendLine("            inner => global::Conjecture.Core.Generate.Compose<" + fqn + ">(ctx => new " + fqn + " {");
+        for (int i = 0; i < model.Members.Length; i++)
+        {
+            MemberModel member = model.Members[i];
+            bool isLast = i == model.Members.Length - 1;
+            string arg = member.Kind == MemberGenerationKind.Recursive ? "ctx.Generate(inner)" : "ctx.Generate(_s" + i + ")";
+            string suffix = isLast ? " })," : ",";
+            sb.AppendLine("                " + member.Name + " = " + arg + suffix);
+        }
+    }
+
+    private static void EmitConstructorArgs(StringBuilder sb, TypeModel model, bool isBaseCase)
+    {
+        if (model.Members.IsEmpty)
+        {
+            sb.Append("))");
+            return;
+        }
+
+        sb.AppendLine();
+        for (int i = 0; i < model.Members.Length; i++)
+        {
+            MemberModel member = model.Members[i];
+            bool isLast = i == model.Members.Length - 1;
+            string suffix = isLast ? "))" : ",";
+            string arg = member.Kind == MemberGenerationKind.Recursive
+                ? (isBaseCase ? "null" : "ctx.Generate(inner)")
+                : "ctx.Generate(_s" + i + ")";
+
+            sb.AppendLine("                " + arg + suffix);
+        }
     }
 
     internal static string ResolveStrategyType(MemberModel member) => member.Kind switch
@@ -160,6 +255,8 @@ internal static class StrategyEmitter
         MemberGenerationKind.ArbitraryReference =>
             "global::" + member.TypeFullName,
         MemberGenerationKind.ExternalStrategyProvider =>
+            "global::" + member.TypeFullName,
+        MemberGenerationKind.Recursive =>
             "global::" + member.TypeFullName,
         _ =>
             "/* unsupported */",
@@ -191,6 +288,8 @@ internal static class StrategyEmitter
                 "((global::Conjecture.Core.IStrategyProvider<global::" + member.TypeFullName + ">)new global::" + member.AuxiliaryTypeName + "()).Create()",
             MemberGenerationKind.Primitive =>
                 BuildPrimitiveExpr(member),
+            MemberGenerationKind.Recursive =>
+                "inner",
             _ =>
                 $"/* unsupported type: {member.TypeFullName} */",
         };

--- a/src/Conjecture.Generators/TypeModel.cs
+++ b/src/Conjecture.Generators/TypeModel.cs
@@ -9,7 +9,7 @@ namespace Conjecture.Generators;
 
 internal enum ConstructionMode { Constructor, ObjectInitializer, PartialConstructor }
 
-internal enum MemberGenerationKind { Primitive, Enum, NullableValue, List, ArbitraryReference, ExternalStrategyProvider, Unsupported, Dictionary, ImmutableArray, Set, ValueTuple }
+internal enum MemberGenerationKind { Primitive, Enum, NullableValue, List, ArbitraryReference, ExternalStrategyProvider, Unsupported, Dictionary, ImmutableArray, Set, ValueTuple, Recursive }
 
 internal sealed record TypeModel(
     string FullyQualifiedName,
@@ -18,7 +18,9 @@ internal sealed record TypeModel(
     TypeKind TypeKind,
     ImmutableArray<string> TypeParameters,
     ImmutableArray<MemberModel> Members,
-    ConstructionMode ConstructionMode = ConstructionMode.Constructor);
+    ConstructionMode ConstructionMode = ConstructionMode.Constructor,
+    int MaxDepth = 5,
+    bool IsPartial = true);
 
 internal sealed record MemberModel(
     string Name,

--- a/src/Conjecture.Generators/TypeModelExtractor.cs
+++ b/src/Conjecture.Generators/TypeModelExtractor.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -21,13 +22,14 @@ internal static class TypeModelExtractor
     internal static (TypeModel? Model, ImmutableArray<Diagnostic> Diagnostics) Extract(
         INamedTypeSymbol symbol,
         IReadOnlyDictionary<string, string>? providerRegistry = null)
+        => Extract(symbol, providerRegistry, ImmutableHashSet<string>.Empty);
+
+    private static (TypeModel? Model, ImmutableArray<Diagnostic> Diagnostics) Extract(
+        INamedTypeSymbol symbol,
+        IReadOnlyDictionary<string, string>? providerRegistry,
+        ImmutableHashSet<string> recursionStack)
     {
         Location location = symbol.Locations.Length > 0 ? symbol.Locations[0] : Location.None;
-
-        if (!IsPartial(symbol))
-        {
-            return (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con201, location, symbol.Name)));
-        }
 
         List<ConstructorDeclarationSyntax> partialCtors = FindPartialConstructors(symbol);
 
@@ -49,41 +51,135 @@ internal static class TypeModelExtractor
 
         ImmutableArray<string> typeParameters = BuildTypeParameters(symbol);
 
+        string currentFqn = symbol.ToDisplayString(TypeNameFormat);
+        ImmutableHashSet<string> newStack = recursionStack.Add(currentFqn);
+
+        int maxDepth = ReadMaxDepth(symbol);
+        bool isPartial = IsPartial(symbol);
+
         List<Diagnostic> warnings = [];
+        List<INamedTypeSymbol> arbitraryRefSymbols = [];
         ImmutableArray<MemberModel> members;
         ConstructionMode mode;
 
         if (partialCtors.Count == 1)
         {
-            members = BuildInitPropertyMembers(symbol, warnings, providerRegistry);
+            if (!isPartial)
+            {
+                return (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con201, location, symbol.Name)));
+            }
+
+            members = BuildInitPropertyMembers(symbol, warnings, providerRegistry, newStack, arbitraryRefSymbols);
             mode = ConstructionMode.PartialConstructor;
         }
         else if (bestCtor is not null)
         {
-            members = BuildMembers(bestCtor, symbol, warnings, providerRegistry);
+            if (!isPartial)
+            {
+                return (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con201, location, symbol.Name)));
+            }
+
+            members = BuildMembers(bestCtor, symbol, warnings, providerRegistry, newStack, arbitraryRefSymbols);
             mode = ConstructionMode.Constructor;
         }
         else
         {
-            members = BuildInitPropertyMembers(symbol, warnings, providerRegistry);
+            members = BuildInitPropertyMembers(symbol, warnings, providerRegistry, newStack, arbitraryRefSymbols);
             if (members.IsEmpty)
             {
-                return (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con200, location, symbol.Name)));
+                return !isPartial
+                    ? (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con201, location, symbol.Name)))
+                    : (null, ImmutableArray.Create(Diagnostic.Create(DiagnosticDescriptors.Con200, location, symbol.Name)));
             }
 
             mode = ConstructionMode.ObjectInitializer;
         }
 
+        // Detect mutual recursion: if any [Arbitrary] member type (not self-recursive) references
+        // back to the current type, and neither has [GenMaxDepth], emit CON313.
+        if (maxDepth < 0)
+        {
+            foreach (INamedTypeSymbol refSymbol in arbitraryRefSymbols)
+            {
+                if (ReadMaxDepth(refSymbol) < 0
+                    && TypeReferencesBack(refSymbol, currentFqn))
+                {
+                    warnings.Add(Diagnostic.Create(
+                        DiagnosticDescriptors.Con313MutualRecursionWithoutMaxDepth,
+                        location,
+                        currentFqn,
+                        refSymbol.ToDisplayString(TypeNameFormat)));
+                    break;
+                }
+            }
+        }
+
         TypeModel model = new(
-            FullyQualifiedName: symbol.ToDisplayString(TypeNameFormat),
+            FullyQualifiedName: currentFqn,
             Namespace: ns,
             TypeName: symbol.Name,
             TypeKind: symbol.TypeKind,
             TypeParameters: typeParameters,
             Members: members,
-            ConstructionMode: mode);
+            ConstructionMode: mode,
+            MaxDepth: maxDepth < 0 ? 5 : maxDepth,
+            IsPartial: isPartial);
 
         return (model, warnings.ToImmutableArray());
+    }
+
+    private static int ReadMaxDepth(INamedTypeSymbol symbol)
+    {
+        foreach (AttributeData attr in symbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.ToDisplayString() == "Conjecture.Core.GenMaxDepthAttribute"
+                && attr.ConstructorArguments.Length == 1
+                && attr.ConstructorArguments[0].Value is int depth)
+            {
+                return depth;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool TypeReferencesBack(INamedTypeSymbol symbol, string targetFqn)
+    {
+        IMethodSymbol? ctor = FindBestConstructor(symbol);
+        if (ctor is not null)
+        {
+            foreach (IParameterSymbol param in ctor.Parameters)
+            {
+                ITypeSymbol paramType = param.Type.WithNullableAnnotation(NullableAnnotation.None);
+                string fqn = paramType.ToDisplayString(TypeNameFormat);
+                if (fqn == targetFqn)
+                {
+                    return true;
+                }
+            }
+        }
+
+        foreach (ISymbol member in symbol.GetMembers())
+        {
+            if (member is not IPropertySymbol prop)
+            {
+                continue;
+            }
+
+            if (prop.DeclaredAccessibility != Accessibility.Public || prop.SetMethod is null || !prop.SetMethod.IsInitOnly)
+            {
+                continue;
+            }
+
+            ITypeSymbol propType = prop.Type.WithNullableAnnotation(NullableAnnotation.None);
+            string fqn = propType.ToDisplayString(TypeNameFormat);
+            if (fqn == targetFqn)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool HasModifier(SyntaxTokenList modifiers, SyntaxKind kind)
@@ -188,7 +284,9 @@ internal static class TypeModelExtractor
         IMethodSymbol ctor,
         INamedTypeSymbol containingType,
         List<Diagnostic> warnings,
-        IReadOnlyDictionary<string, string>? providerRegistry)
+        IReadOnlyDictionary<string, string>? providerRegistry,
+        ImmutableHashSet<string> recursionStack,
+        List<INamedTypeSymbol> arbitraryRefSymbols)
     {
         if (ctor.Parameters.IsEmpty)
         {
@@ -200,12 +298,17 @@ internal static class TypeModelExtractor
         {
             string typeName = param.Type.ToDisplayString(TypeNameFormat);
             bool isNullable = param.NullableAnnotation == NullableAnnotation.Annotated;
-            (MemberGenerationKind kind, string innerFqn) = ClassifyMemberType(param.Type, providerRegistry);
+            (MemberGenerationKind kind, string innerFqn) = ClassifyMemberType(param.Type, providerRegistry, recursionStack);
 
             if (kind == MemberGenerationKind.Unsupported)
             {
                 Location loc = param.Locations.Length > 0 ? param.Locations[0] : Location.None;
                 warnings.Add(Diagnostic.Create(DiagnosticDescriptors.Con202, loc, param.Name, typeName));
+            }
+
+            if (kind == MemberGenerationKind.ArbitraryReference && param.Type is INamedTypeSymbol refNamed)
+            {
+                arbitraryRefSymbols.Add(refNamed);
             }
 
             (double? rMin, double? rMax, int? sMin, int? sMax, bool required) = ReadConstraints(param, containingType);
@@ -220,7 +323,9 @@ internal static class TypeModelExtractor
     private static ImmutableArray<MemberModel> BuildInitPropertyMembers(
         INamedTypeSymbol symbol,
         List<Diagnostic> warnings,
-        IReadOnlyDictionary<string, string>? providerRegistry)
+        IReadOnlyDictionary<string, string>? providerRegistry,
+        ImmutableHashSet<string> recursionStack,
+        List<INamedTypeSymbol> arbitraryRefSymbols)
     {
         ImmutableArray<MemberModel>.Builder builder = ImmutableArray.CreateBuilder<MemberModel>();
         foreach (ISymbol member in symbol.GetMembers())
@@ -242,12 +347,17 @@ internal static class TypeModelExtractor
 
             string typeName = prop.Type.ToDisplayString(TypeNameFormat);
             bool isNullable = prop.NullableAnnotation == NullableAnnotation.Annotated;
-            (MemberGenerationKind kind, string innerFqn) = ClassifyMemberType(prop.Type, providerRegistry);
+            (MemberGenerationKind kind, string innerFqn) = ClassifyMemberType(prop.Type, providerRegistry, recursionStack);
 
             if (kind == MemberGenerationKind.Unsupported)
             {
                 Location loc = prop.Locations.Length > 0 ? prop.Locations[0] : Location.None;
                 warnings.Add(Diagnostic.Create(DiagnosticDescriptors.Con202, loc, prop.Name, typeName));
+            }
+
+            if (kind == MemberGenerationKind.ArbitraryReference && prop.Type is INamedTypeSymbol refNamed)
+            {
+                arbitraryRefSymbols.Add(refNamed);
             }
 
             (double? rMin, double? rMax, int? sMin, int? sMax, bool required) = ReadConstraints(prop);
@@ -506,7 +616,8 @@ internal static class TypeModelExtractor
 
     private static (MemberGenerationKind Kind, string InnerFqn) ClassifyMemberType(
         ITypeSymbol type,
-        IReadOnlyDictionary<string, string>? providerRegistry)
+        IReadOnlyDictionary<string, string>? providerRegistry,
+        ImmutableHashSet<string> recursionStack)
     {
         if (IsPrimitive(type.SpecialType))
         {
@@ -572,7 +683,9 @@ internal static class TypeModelExtractor
 
         if (type is INamedTypeSymbol namedType && SymbolHelpers.HasArbitraryAttribute(namedType))
         {
-            return (MemberGenerationKind.ArbitraryReference, "");
+            return recursionStack.Contains(typeFqn)
+                ? (MemberGenerationKind.Recursive, "")
+                : (MemberGenerationKind.ArbitraryReference, "");
         }
 
         if (providerRegistry is not null && providerRegistry.TryGetValue(typeFqn, out string? providerFqn))


### PR DESCRIPTION
## Description

Adds recursive type detection and bounded generation to `Gen.For<T>()`. Self-referential and mutually recursive `[Arbitrary]` types now emit `Generate.Recursive<T>()` wrappers instead of failing or producing unbounded output.

Key changes:
- **`GenMaxDepthAttribute`** — new public attribute (`[GenMaxDepth(n)]`) on a type caps the recursion depth used in generated strategies; defaults to 5 if absent
- **`MemberGenerationKind.Recursive`** — new enum variant; classified when `ClassifyMemberType` encounters a type already in the active recursion stack
- **`TypeModelExtractor`** — threads an `ImmutableHashSet<string>` recursion stack through `Extract` / `BuildMembers` / `BuildInitPropertyMembers` / `ClassifyMemberType`; reads `[GenMaxDepth]`; detects mutual recursion via `TypeReferencesBack` and emits CON313 when neither type has `[GenMaxDepth]`
- **`StrategyEmitter`** — wraps recursive types in `Generate.Recursive<T>(baseCase, recursive, maxDepth)`; base case passes `null` for recursive slots; supports both constructor and object-initializer construction modes
- **CON313** — new warning diagnostic: mutually recursive `[Arbitrary]` types without `[GenMaxDepth]`
- Non-partial types with `init`-only properties now work in ObjectInitializer mode without requiring `partial`; types with no accessible members fall back to CON201

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #361
Part of #295