### PR TITLE
[295.6] Gen.For<T>() diagnostics: CON310, CON311, CON312

### DIFF
--- a/src/Conjecture.Generators.Tests/GenForDiagnosticTests.cs
+++ b/src/Conjecture.Generators.Tests/GenForDiagnosticTests.cs
@@ -1,0 +1,325 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Conjecture.Generators.Tests;
+
+public sealed class GenForDiagnosticTests
+{
+    // --- CON310: Generate.For<T>() where T is an interface ---
+
+    [Fact]
+    public void InterfaceTypeArgument_EmitsCon310()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public interface IShape { }
+            public class Usage
+            {
+                public void Run() { Generate.For<IShape>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == DiagnosticDescriptors.Con310.Id);
+    }
+
+    [Fact]
+    public void InterfaceTypeArgument_Con310IsError()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public interface IShape { }
+            public class Usage
+            {
+                public void Run() { Generate.For<IShape>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+        Diagnostic? con310 = diagnostics.FirstOrDefault(d => d.Id == DiagnosticDescriptors.Con310.Id);
+
+        Assert.NotNull(con310);
+        Assert.Equal(DiagnosticSeverity.Error, con310.Severity);
+    }
+
+    [Fact]
+    public void InterfaceTypeArgument_NoCodeGenerated()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public interface IShape { }
+            public class Usage
+            {
+                public void Run() { Generate.For<IShape>(); }
+            }
+            """;
+
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+
+        bool hasRegistry = trees.Any(
+            t => t.FilePath.EndsWith("GenForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
+        Assert.False(hasRegistry);
+    }
+
+    [Fact]
+    public void InterfaceTypeArgument_DiagnosticPointsToCallSite()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public interface IShape { }
+            public class Usage
+            {
+                public void Run() { Generate.For<IShape>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+        Diagnostic? con310 = diagnostics.FirstOrDefault(d => d.Id == DiagnosticDescriptors.Con310.Id);
+
+        Assert.NotNull(con310);
+        Assert.NotEqual(Location.None, con310.Location);
+    }
+
+    // --- CON311: Generate.For<T>() where T is abstract with no [Arbitrary] concrete subtypes ---
+
+    [Fact]
+    public void AbstractTypeWithNoArbitrarySubtypes_EmitsCon311()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public abstract class AbstractBase { }
+            public class ConcreteChild : AbstractBase { }
+            public class Usage
+            {
+                public void Run() { Generate.For<AbstractBase>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == DiagnosticDescriptors.Con311.Id);
+    }
+
+    [Fact]
+    public void AbstractTypeWithNoArbitrarySubtypes_Con311IsError()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public abstract class AbstractBase { }
+            public class ConcreteChild : AbstractBase { }
+            public class Usage
+            {
+                public void Run() { Generate.For<AbstractBase>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+        Diagnostic? con311 = diagnostics.FirstOrDefault(d => d.Id == DiagnosticDescriptors.Con311.Id);
+
+        Assert.NotNull(con311);
+        Assert.Equal(DiagnosticSeverity.Error, con311.Severity);
+    }
+
+    [Fact]
+    public void AbstractTypeWithNoArbitrarySubtypes_DiagnosticPointsToCallSite()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public abstract class AbstractBase { }
+            public class ConcreteChild : AbstractBase { }
+            public class Usage
+            {
+                public void Run() { Generate.For<AbstractBase>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+        Diagnostic? con311 = diagnostics.FirstOrDefault(d => d.Id == DiagnosticDescriptors.Con311.Id);
+
+        Assert.NotNull(con311);
+        Assert.NotEqual(Location.None, con311.Location);
+    }
+
+    // --- CON312: Generate.For<T>() where T has no registered IStrategyProvider<T> ---
+
+    [Fact]
+    public void ConcreteTypeWithNoArbitraryAndNoProvider_EmitsCon312()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public class Order { public int Id { get; set; } }
+            public class Usage
+            {
+                public void Run() { Generate.For<Order>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+
+        Assert.Contains(diagnostics, d => d.Id == DiagnosticDescriptors.Con312.Id);
+    }
+
+    [Fact]
+    public void ConcreteTypeWithNoArbitraryAndNoProvider_Con312IsError()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public class Order { public int Id { get; set; } }
+            public class Usage
+            {
+                public void Run() { Generate.For<Order>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+        Diagnostic? con312 = diagnostics.FirstOrDefault(d => d.Id == DiagnosticDescriptors.Con312.Id);
+
+        Assert.NotNull(con312);
+        Assert.Equal(DiagnosticSeverity.Error, con312.Severity);
+    }
+
+    [Fact]
+    public void ConcreteTypeWithNoArbitraryAndNoProvider_DiagnosticPointsToCallSite()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            public class Order { public int Id { get; set; } }
+            public class Usage
+            {
+                public void Run() { Generate.For<Order>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+        Diagnostic? con312 = diagnostics.FirstOrDefault(d => d.Id == DiagnosticDescriptors.Con312.Id);
+
+        Assert.NotNull(con312);
+        Assert.NotEqual(Location.None, con312.Location);
+    }
+
+    // --- No diagnostic: Generate.For<T>() where T has [Arbitrary] ---
+
+    [Fact]
+    public void ArbitraryDecoratedType_ProducesNoCon310Con311Con312()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record Order(int Id, string Name);
+            public class Usage
+            {
+                public void Run() { Generate.For<Order>(); }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+
+        Assert.DoesNotContain(diagnostics, d => d.Id == DiagnosticDescriptors.Con310.Id);
+        Assert.DoesNotContain(diagnostics, d => d.Id == DiagnosticDescriptors.Con311.Id);
+        Assert.DoesNotContain(diagnostics, d => d.Id == DiagnosticDescriptors.Con312.Id);
+    }
+
+    [Fact]
+    public void ArbitraryDecoratedType_RegistryEntryEmitted()
+    {
+        string source = """
+            using Conjecture.Core;
+            namespace MyApp;
+            [Arbitrary] public partial record Order(int Id, string Name);
+            public class Usage
+            {
+                public void Run() { Generate.For<Order>(); }
+            }
+            """;
+
+        (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
+
+        bool hasRegistry = trees.Any(
+            t => t.FilePath.EndsWith("GenForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
+        Assert.True(hasRegistry);
+    }
+
+    // --- CON311: nested [Arbitrary] subtype should suppress CON311 ---
+
+    [Fact]
+    public void AbstractTypeWithNestedArbitrarySubtype_NoCon311()
+    {
+        string source = """
+            using Conjecture.Core;
+            using System.Threading;
+
+            namespace Tests;
+
+            public abstract class Shape { }
+
+            public class ShapeContainer
+            {
+                [Arbitrary]
+                public partial class Circle : Shape
+                {
+                    public double Radius { get; init; }
+                }
+            }
+
+            public class Usage
+            {
+                public void Use() => _ = Generate.For<Shape>();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = GetGeneratorDiagnostics(source);
+        Diagnostic? con311 = diagnostics.FirstOrDefault(d => d.Id == DiagnosticDescriptors.Con311.Id);
+
+        Assert.Null(con311);
+    }
+
+    // --- helpers ---
+
+    private static ImmutableArray<Diagnostic> GetGeneratorDiagnostics(string source)
+    {
+        (_, _, ImmutableArray<Diagnostic> diagnostics) = RunGenerator(source);
+        return diagnostics;
+    }
+
+    private static (ImmutableArray<SyntaxTree> GeneratedTrees, Compilation Output, ImmutableArray<Diagnostic> GeneratorDiagnostics) RunGenerator(string source)
+    {
+        string runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        CSharpCompilation inputCompilation = CSharpCompilation.Create(
+            assemblyName: "TestAssembly",
+            syntaxTrees: [CSharpSyntaxTree.ParseText(source)],
+            references:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+                MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Collections.dll")),
+                MetadataReference.CreateFromFile(typeof(Conjecture.Core.ArbitraryAttribute).Assembly.Location),
+            ],
+            options: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new GenForGenerator());
+        GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
+
+        Compilation outputCompilation = inputCompilation.AddSyntaxTrees(result.GeneratedTrees);
+        return (result.GeneratedTrees, outputCompilation, result.Diagnostics);
+    }
+}

--- a/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
+++ b/src/Conjecture.Generators/AnalyzerReleases.Unshipped.md
@@ -8,4 +8,7 @@ CON205 | Conjecture | Warning | Concrete subtype excluded from sealed hierarchy 
 CON300 | Conjecture | Error | [Arbitrary] base type must be abstract
 CON301 | Conjecture | Error | [Arbitrary] base type must be a class or record, not an interface or struct
 CON302 | Conjecture | Error | No concrete [Arbitrary] subtypes found for abstract base type
+CON310 | Usage | Error | Generate.For<T>() target is an interface
+CON311 | Usage | Error | Generate.For<T>() target is abstract with no [Arbitrary] subtypes
+CON312 | Usage | Error | Generate.For<T>() has no registered provider
 CON313 | Usage | Warning | Mutually recursive [Arbitrary] types without [GenMaxDepth]

--- a/src/Conjecture.Generators/DiagnosticDescriptors.cs
+++ b/src/Conjecture.Generators/DiagnosticDescriptors.cs
@@ -79,6 +79,30 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
+    internal static readonly DiagnosticDescriptor Con310 = new(
+        id: "CON310",
+        title: "Generate.For<T>() target is an interface",
+        messageFormat: "Generate.For<{0}>() cannot generate a strategy because '{0}' is an interface; apply [Arbitrary] to each concrete implementation and compose with Generate.OneOf()",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor Con311 = new(
+        id: "CON311",
+        title: "Generate.For<T>() target is abstract with no [Arbitrary] subtypes",
+        messageFormat: "Generate.For<{0}>() cannot generate a strategy because '{0}' is abstract and has no [Arbitrary]-decorated concrete subtypes",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor Con312 = new(
+        id: "CON312",
+        title: "Generate.For<T>() has no registered provider",
+        messageFormat: "Generate.For<{0}>() cannot generate a strategy because no IStrategyProvider<{0}> is registered; decorate '{0}' with [Arbitrary]",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     internal static readonly DiagnosticDescriptor Con313MutualRecursionWithoutMaxDepth = new(
         id: "CON313",
         title: "Mutual recursion without [GenMaxDepth]",

--- a/src/Conjecture.Generators/GenForGenerator.cs
+++ b/src/Conjecture.Generators/GenForGenerator.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Text;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Conjecture.Generators;
@@ -17,15 +18,17 @@ public sealed class GenForGenerator : IIncrementalGenerator
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        IncrementalValueProvider<ImmutableDictionary<string, string>> registry =
+            context.CompilationProvider.Select(static (compilation, _) => ProviderRegistry.Build(compilation));
+
+        RegisterCallSiteDiagnosticPipeline(context, registry);
+
         IncrementalValuesProvider<INamedTypeSymbol> types = context.SyntaxProvider
             .ForAttributeWithMetadataName(
                 "Conjecture.Core.ArbitraryAttribute",
                 predicate: static (node, _) => node is TypeDeclarationSyntax,
                 transform: static (ctx, _) => (INamedTypeSymbol)ctx.TargetSymbol)
             .Where(static symbol => !symbol.IsAbstract && !ImplementsStrategyProvider(symbol));
-
-        IncrementalValueProvider<ImmutableDictionary<string, string>> registry =
-            context.CompilationProvider.Select(static (compilation, _) => ProviderRegistry.Build(compilation));
 
         IncrementalValuesProvider<(INamedTypeSymbol Symbol, ImmutableDictionary<string, string> Registry)> combined =
             types.Combine(registry);
@@ -79,6 +82,199 @@ public sealed class GenForGenerator : IIncrementalGenerator
                 ctx.AddSource(model.TypeName + "Arbitrary.g.cs", arbitrarySource);
             }
         });
+    }
+
+    private static void RegisterCallSiteDiagnosticPipeline(
+        IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<ImmutableDictionary<string, string>> registryProvider)
+    {
+        IncrementalValuesProvider<InvocationExpressionSyntax> forCallSites =
+            context.SyntaxProvider.CreateSyntaxProvider(
+                predicate: static (node, _) => node is InvocationExpressionSyntax invocation
+                    && IsForCallSite(invocation),
+                transform: static (ctx, _) => (InvocationExpressionSyntax)ctx.Node);
+
+        IncrementalValuesProvider<(ITypeSymbol? TypeArg, Location Location, Compilation Compilation)> resolvedCalls =
+            forCallSites.Combine(context.CompilationProvider)
+                .Select(static (pair, _) => ResolveForTypeArg(pair.Left, pair.Right));
+
+        IncrementalValuesProvider<((ITypeSymbol? TypeArg, Location Location, Compilation Compilation) Left, ImmutableDictionary<string, string> Right)> withRegistry =
+            resolvedCalls.Combine(registryProvider);
+
+        context.RegisterSourceOutput(withRegistry, static (ctx, pair) =>
+        {
+            (ITypeSymbol? typeArg, Location location, Compilation compilation) = pair.Left;
+            ImmutableDictionary<string, string> registry = pair.Right;
+
+            if (typeArg is null)
+            {
+                return;
+            }
+
+            string typeName = typeArg.ToDisplayString(TypeModelExtractor.TypeNameFormat);
+
+            if (typeArg.TypeKind == TypeKind.Interface)
+            {
+                ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Con310, location, typeName));
+                return;
+            }
+
+            if (typeArg.IsAbstract)
+            {
+                if (!HasArbitraryConcreteSubtype(typeArg, compilation))
+                {
+                    ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Con311, location, typeName));
+                }
+
+                return;
+            }
+
+            if (!registry.ContainsKey(typeName) && !SymbolHelpers.HasArbitraryAttribute((INamedTypeSymbol)typeArg))
+            {
+                ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.Con312, location, typeName));
+            }
+        });
+    }
+
+    private static bool IsForCallSite(InvocationExpressionSyntax invocation)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+
+        if (memberAccess.Name is not GenericNameSyntax genericName)
+        {
+            return false;
+        }
+
+        if (genericName.Identifier.Text != "For")
+        {
+            return false;
+        }
+
+        if (genericName.TypeArgumentList.Arguments.Count != 1)
+        {
+            return false;
+        }
+
+        if (invocation.ArgumentList.Arguments.Count != 0)
+        {
+            return false;
+        }
+
+        string receiverName = memberAccess.Expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.Text,
+            MemberAccessExpressionSyntax nested => nested.Name.Identifier.Text,
+            _ => string.Empty,
+        };
+
+        return receiverName == "Generate";
+    }
+
+    private static (ITypeSymbol? TypeArg, Location Location, Compilation Compilation) ResolveForTypeArg(
+        InvocationExpressionSyntax invocation,
+        Compilation compilation)
+    {
+        SemanticModel semanticModel = compilation.GetSemanticModel(invocation.SyntaxTree);
+
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess ||
+            memberAccess.Name is not GenericNameSyntax genericName ||
+            genericName.TypeArgumentList.Arguments.Count == 0)
+        {
+            return (null, invocation.GetLocation(), compilation);
+        }
+
+        TypeSyntax typeArgSyntax = genericName.TypeArgumentList.Arguments[0];
+        ITypeSymbol? typeArg = semanticModel.GetTypeInfo(typeArgSyntax).Type;
+
+        if (semanticModel.GetSymbolInfo(invocation).Symbol is IMethodSymbol method &&
+            method.ContainingType.ToDisplayString() != "Conjecture.Core.Generate")
+        {
+            return (null, invocation.GetLocation(), compilation);
+        }
+
+        return (typeArg, invocation.GetLocation(), compilation);
+    }
+
+    private static bool HasArbitraryConcreteSubtype(ITypeSymbol abstractType, Compilation compilation)
+    {
+        if (SearchNamespaceForArbitrarySubtype(compilation.Assembly.GlobalNamespace, abstractType))
+        {
+            return true;
+        }
+
+        foreach (MetadataReference reference in compilation.References)
+        {
+            if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol referencedAssembly &&
+                SearchNamespaceForArbitrarySubtype(referencedAssembly.GlobalNamespace, abstractType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool SearchNamespaceForArbitrarySubtype(INamespaceSymbol ns, ITypeSymbol abstractType)
+    {
+        foreach (INamedTypeSymbol type in ns.GetTypeMembers())
+        {
+            if (!type.IsAbstract && InheritsFromClass(type, abstractType) && SymbolHelpers.HasArbitraryAttribute(type))
+            {
+                return true;
+            }
+
+            if (SearchTypeForArbitrarySubtype(type, abstractType))
+            {
+                return true;
+            }
+        }
+
+        foreach (INamespaceSymbol subNs in ns.GetNamespaceMembers())
+        {
+            if (SearchNamespaceForArbitrarySubtype(subNs, abstractType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool SearchTypeForArbitrarySubtype(INamedTypeSymbol containingType, ITypeSymbol abstractType)
+    {
+        foreach (INamedTypeSymbol nested in containingType.GetTypeMembers())
+        {
+            if (!nested.IsAbstract && InheritsFromClass(nested, abstractType) && SymbolHelpers.HasArbitraryAttribute(nested))
+            {
+                return true;
+            }
+
+            if (SearchTypeForArbitrarySubtype(nested, abstractType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool InheritsFromClass(ITypeSymbol type, ITypeSymbol baseType)
+    {
+        ITypeSymbol? current = type.BaseType;
+        while (current is not null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, baseType))
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
     }
 
     private static string EmitArbitraryWithOverrides(TypeModel model)


### PR DESCRIPTION
## Description

Adds compile-time diagnostics to `GenForGenerator` that fire at `Generate.For<T>()` call sites when the type argument cannot produce a valid strategy:

| Code | Trigger | Action |
|------|---------|--------|
| CON310 | T is an interface | Apply `[Arbitrary]` to each concrete implementation and compose with `Generate.OneOf()` |
| CON311 | T is abstract with no `[Arbitrary]` concrete subtypes | Add `[Arbitrary]` to at least one concrete subtype |
| CON312 | T has no `IStrategyProvider<T>` registered | Decorate T with `[Arbitrary]` |

The call-site pipeline uses `CreateSyntaxProvider` to find `Generate.For<T>()` invocations, resolves T semantically (verifying the receiver is `Conjecture.Core.Generate`, not a user-defined class), and shares the single `ProviderRegistry` build with the existing `[Arbitrary]` pipeline. CON311 searches the current assembly and all referenced assemblies including nested types.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #362
Part of #295