### PR TITLE
[295.8] Docs: Gen.For<T>() how-to, reference, and explanation

### DIFF
--- a/docs/site/articles/explanation/gen-for-source-generator.md
+++ b/docs/site/articles/explanation/gen-for-source-generator.md
@@ -1,0 +1,103 @@
+# Understanding Gen.For&lt;T&gt;() source generation
+
+`Generate.For<T>()` is the call-site entry point for a strategy the compiler derived from your type at build time. This page explains why source generation was chosen over alternatives, how the emitted code is wired together, and how `Generate.For<T>()` fits into a broader property test.
+
+## Why not reflection?
+
+The obvious alternative to source generation is runtime reflection: inspect the type's constructor at runtime, resolve a strategy for each parameter type, and assemble a `Generate.Compose` call dynamically.
+
+Reflection works — but it has three costs that source generation avoids:
+
+**AOT and trim compatibility.** .NET 8+ AOT compilation and IL trimming eliminate types and members that are not statically referenced. A reflection-based generator would force you to annotate every DTO with `[DynamicallyAccessedMembers]` or disable trimming for the assembly. Source generation produces ordinary C# code that the trimmer understands natively.
+
+**Compile-time feedback.** When reflection fails — because the constructor is private, a parameter type has no strategy, or the type is abstract — the error surfaces at runtime, often in a test run. Source generation surfaces the same error as a Roslyn diagnostic at build time, before a test ever runs. CON312 ("no registered provider") is impossible to reach in a green build; CON202 ("no resolvable strategy for parameter") is a warning before you write a single test.
+
+**Debuggability.** The generated code is ordinary C# you can step through. There are no `MethodInfo.Invoke` frames, no dynamic proxy layers, no `Expression.Lambda.Compile` pipelines.
+
+## How the generator works
+
+When the Roslyn incremental generator sees `[Arbitrary]` on a `partial` type, it performs three steps at build time:
+
+**1. Type model extraction.** The generator reads the type's constructor — primary constructor for records, most-accessible constructor for classes and structs. It maps each parameter to a strategy expression using the primitive mapping table, respecting `[GenRange]`, `[GenStringLength]`, `[GenRegex]`, and `[GenMaxDepth]` attributes.
+
+**2. Code emission.** The generator emits two things alongside the type:
+- An `IStrategyProvider<T>` implementation (e.g. `OrderArbitrary`) that calls `Generate.Compose` with the resolved strategies.
+- An override-aware variant (`CreateWithOverrides`) that accepts a `ForConfiguration<T>` and substitutes overridden properties.
+
+A typical emission for `Order(Guid Id, string Customer, decimal Total)` looks like:
+
+```csharp
+// Auto-generated
+internal sealed class OrderArbitrary : IStrategyProvider<Order>
+{
+    public Strategy<Order> Create() =>
+        Generate.Compose<Order>(ctx => new Order(
+            ctx.Generate(Generate.Guids()),
+            ctx.Generate(Generate.Strings()),
+            ctx.Generate(Generate.Decimals())));
+
+    public static Strategy<Order> CreateWithOverrides(ForConfiguration<Order> cfg) =>
+        Generate.Compose<Order>(ctx => new Order(
+            ctx.Generate(cfg.TryGet<Guid>("Id") ?? Generate.Guids()),
+            ctx.Generate(cfg.TryGet<string>("Customer") ?? Generate.Strings()),
+            ctx.Generate(cfg.TryGet<decimal>("Total") ?? Generate.Decimals())));
+}
+```
+
+**3. Registry wiring.** The generator also emits a `[ModuleInitializer]` that registers both the provider and the override factory with `GenForRegistry`:
+
+```csharp
+[ModuleInitializer]
+internal static void RegisterOrderArbitrary()
+{
+    GenForRegistry.Register(typeof(Order), static () => new OrderArbitrary());
+    GenForRegistry.RegisterOverride(typeof(Order),
+        static cfg => OrderArbitrary.CreateWithOverrides((ForConfiguration<Order>)cfg));
+}
+```
+
+`[ModuleInitializer]` runs before any user code in the assembly — registration is guaranteed to be complete before the first `Generate.For<Order>()` call.
+
+## How `Generate.For<T>()` resolves a strategy
+
+`Generate.For<T>()` delegates to `GenForRegistry.Resolve<T>()`, which looks up the registered factory by `typeof(T)` in a `ConcurrentDictionary`. The lookup is O(1) and allocation-free after the first call.
+
+`Generate.For<T>(cfg => ...)` takes the override path: it constructs a `ForConfiguration<T>`, runs your callback, then calls `GenForRegistry.ResolveWithOverrides<T>(cfg)`, which invokes the override-aware factory. The override factory calls `cfg.TryGet<TProp>(propertyName)` for each parameter — if an override exists it uses it, otherwise it falls back to the default strategy.
+
+The result is a `Strategy<T>` like any other. It composes, shrinks, and replays exactly as if you had written the `Generate.Compose` call by hand.
+
+## Composing with property tests
+
+`Generate.For<T>()` returns a `Strategy<T>`. You can use it anywhere a strategy is accepted:
+
+```csharp
+// As a standalone strategy
+Strategy<Order> orders = Generate.For<Order>();
+
+// Composed with other strategies
+Strategy<(Order, Payment)> pairs = Generate.Tuples(
+    Generate.For<Order>(),
+    Generate.For<Payment>());
+
+// As a stateful testing source
+Strategy<StateMachineRun<ShopState>> runs =
+    Generate.StateMachine<ShopMachine, ShopState, ShopCommand>();
+```
+
+For `[Property]` parameters, `[From<OrderArbitrary>]` is the idiomatic shorthand — it passes `new OrderArbitrary().Create()` as the parameter strategy. `Generate.For<T>()` gives you the same strategy as an expression when you need to compose it or pass it around.
+
+> [!NOTE]
+> CON105 fires when a `[Property]` parameter's type has an `[Arbitrary]` provider but `[From<T>]` is absent. The analyzer nudges you toward the declarative style, but there is no behavioral difference between `[From<OrderArbitrary>]` and building the strategy manually with `Generate.For<Order>()`.
+
+## The registry and AOT
+
+`GenForRegistry` is a `public static` class backed by two `ConcurrentDictionary<Type, Func<...>>` fields. Keeping it public allows generated code in user assemblies to call `Register` and `RegisterOverride`. The dictionaries use `Type` as the key rather than a generic type parameter, which is AOT-safe: no `MakeGenericType`, no `MethodInfo.Invoke`, no `Activator.CreateInstance`.
+
+The generated factories are `static` lambdas (`static () => new OrderArbitrary()`). `static` lambdas are compiler-lowered to static methods, so they produce no closures and hold no references that would confuse the trimmer.
+
+## Further reading
+
+- [How to use Gen.For&lt;T&gt;()](../how-to/use-gen-for.md) — step-by-step recipes
+- [Reference: Gen.For&lt;T&gt;()](../reference/gen-for.md) — attribute table, primitive mapping, diagnostics
+- [How to use source generators](../how-to/use-source-generators.md) — `[Arbitrary]` basics
+- [Understanding sealed hierarchy strategies](sealed-hierarchy-strategies.md) — hierarchy mode for abstract types

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -5,6 +5,8 @@ items:
     href: shrinking.md
   - name: Sealed hierarchy strategies
     href: sealed-hierarchy-strategies.md
+  - name: Gen.For&lt;T&gt;() source generation
+    href: gen-for-source-generator.md
   - name: Targeted testing
     href: targeted-testing.md
   - name: The example database

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -17,6 +17,8 @@ items:
     href: manage-example-database.md
   - name: Use source generators
     href: use-source-generators.md
+  - name: Use Gen.For&lt;T&gt;()
+    href: use-gen-for.md
   - name: Use sealed hierarchy strategies
     href: use-sealed-hierarchy-strategies.md
   - name: Configure logging

--- a/docs/site/articles/how-to/use-gen-for.md
+++ b/docs/site/articles/how-to/use-gen-for.md
@@ -1,0 +1,153 @@
+# How to use Gen.For&lt;T&gt;()
+
+Use `Generate.For<T>()` to get a `Strategy<T>` for any type decorated with `[Arbitrary]`. The source generator emits the strategy at compile time — no runtime reflection, no manual composition.
+
+## Prerequisites
+
+- Your type is a `partial` record, class, or struct with an accessible constructor
+- All constructor parameters have auto-resolvable strategies (primitives, strings, collections, enums, or other `[Arbitrary]` types)
+
+See [How to use source generators](use-source-generators.md) for the full list of supported types.
+
+## Generate values for a record or class
+
+### 1. Annotate the type
+
+```csharp
+using Conjecture.Core;
+
+[Arbitrary]
+public partial record Order(Guid Id, string Customer, decimal Total, DateOnly PlacedOn);
+```
+
+### 2. Use `Generate.For<T>()` in a property test
+
+# [xUnit v2](#tab/xunit-v2)
+
+```csharp
+[Property]
+public bool Orders_always_have_a_customer(Order order)
+{
+    Strategy<Order> orders = Generate.For<Order>();
+    // or inline:
+    // [From<OrderArbitrary>] Order order
+    return order.Customer.Length > 0;
+}
+```
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+[Property]
+public bool Orders_always_have_a_customer(Order order)
+{
+    Strategy<Order> orders = Generate.For<Order>();
+    return order.Customer.Length > 0;
+}
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+[Property]
+public bool Orders_always_have_a_customer(Order order)
+{
+    Strategy<Order> orders = Generate.For<Order>();
+    return order.Customer.Length > 0;
+}
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+[Property]
+public bool Orders_always_have_a_customer(Order order)
+{
+    Strategy<Order> orders = Generate.For<Order>();
+    return order.Customer.Length > 0;
+}
+```
+
+***
+
+`Generate.For<Order>()` resolves the registered strategy. Use `[From<OrderArbitrary>]` on a parameter to feed generated `Order` values directly into the test.
+
+## Override specific properties at the call site
+
+Use `Generate.For<T>(cfg => cfg.Override(...))` to substitute a different strategy for one or more properties without creating a new provider class.
+
+```csharp
+Strategy<Order> highValueOrders = Generate.For<Order>(cfg => cfg
+    .Override(o => o.Total, Generate.Decimals(1_000m, 100_000m))
+    .Override(o => o.PlacedOn, Generate.DateOnlyValues(
+        new DateOnly(2020, 1, 1),
+        DateOnly.FromDateTime(DateTime.Today))));
+```
+
+Overrides compose: the rest of the properties (`Id`, `Customer`) continue to use their generated defaults.
+
+## Apply constraint attributes
+
+Attach generation constraints directly on constructor parameters or properties. The generator picks them up at compile time — no code changes needed at the call site.
+
+### Constrain a numeric range
+
+```csharp
+[Arbitrary]
+public partial record Product(
+    string Name,
+    [GenRange(0.01, 9_999.99)] decimal Price,
+    [GenRange(0, 10_000)] int Stock);
+```
+
+`[GenRange]` applies to any numeric parameter (`int`, `long`, `double`, `decimal`, etc.).
+
+### Constrain string length
+
+```csharp
+[Arbitrary]
+public partial record Customer(
+    [GenStringLength(1, 100)] string Name,
+    [GenStringLength(5, 254)] string Email);
+```
+
+### Constrain string format with a regex
+
+```csharp
+[Arbitrary]
+public partial record UkPostcode(
+    [GenRegex(@"^[A-Z]{1,2}\d[A-Z\d]? \d[ABD-HJLNP-UW-Z]{2}$")] string Value);
+```
+
+> [!NOTE]
+> `[GenRegex]` requires the `Conjecture.Regex` package to be referenced. If it is absent, the generator falls back to unconstrained strings and emits a **CON202** warning.
+
+## Handle self-referential types
+
+For types that reference themselves, use `[GenMaxDepth]` to cap generation depth.
+
+```csharp
+[Arbitrary]
+[GenMaxDepth(3)]
+public partial class TreeNode
+{
+    public TreeNode(int Value, TreeNode? Left, TreeNode? Right) { /* ... */ }
+    public int Value { get; }
+    public TreeNode? Left { get; }
+    public TreeNode? Right { get; }
+}
+```
+
+The generator emits a depth-bounded strategy: at `maxDepth = 0` it generates a leaf node (nullable child parameters become `null`); at greater depths it recurses.
+
+Without `[GenMaxDepth]` on a self-referential type, the generator emits a **CON313** warning and uses a default depth of 5.
+
+> [!TIP]
+> Deeper trees find more edge cases but slow down generation and shrinking. Start with `[GenMaxDepth(3)]` and increase only if you need deeper coverage.
+
+## See also
+
+- [Reference: Gen.For&lt;T&gt;()](../reference/gen-for.md) — attribute table, primitive mapping, diagnostics
+- [Understanding Gen.For&lt;T&gt;() source generation](../explanation/gen-for-source-generator.md) — why source generation and how the registry works
+- [How to use source generators](use-source-generators.md) — `[Arbitrary]` basics and supported types
+- [How to generate sealed class hierarchies](use-sealed-hierarchy-strategies.md) — abstract base + subtypes pattern

--- a/docs/site/articles/how-to/use-source-generators.md
+++ b/docs/site/articles/how-to/use-source-generators.md
@@ -97,5 +97,7 @@ public partial struct Point
 
 ## See also
 
+- [How to use Gen.For&lt;T&gt;()](use-gen-for.md) — overrides, constraint attributes, recursive types
+- [Reference: Gen.For&lt;T&gt;()](../reference/gen-for.md) — attribute table, primitive mapping, diagnostics
 - [Reference: Analyzers](../reference/analyzers.md) — runtime analyzer rules (CON100–CON111, CJ0050)
 - [Reference: Attributes](../reference/attributes.md) — `[Arbitrary]`, `[From<T>]` full reference

--- a/docs/site/articles/reference/analyzers.md
+++ b/docs/site/articles/reference/analyzers.md
@@ -225,6 +225,17 @@ The `[Arbitrary]` source generator reports its own set of diagnostics:
 | CON201 | Error | `[Arbitrary]` type is not `partial` |
 | CON202 | Warning | Constructor parameter type has no resolvable strategy |
 
+### `Generate.For<T>()` call-site diagnostics (CON310–CON313)
+
+These fire at `Generate.For<T>()` or `[From<T>]` call sites. See [Reference: Gen.For&lt;T&gt;()](gen-for.md#generatefort-call-site-diagnostics) for resolution steps.
+
+| ID | Severity | Description |
+|---|---|---|
+| CON310 | Error | `Generate.For<T>()` target is an interface |
+| CON311 | Error | `Generate.For<T>()` target is abstract with no `[Arbitrary]` subtypes |
+| CON312 | Error | `Generate.For<T>()` has no registered provider — type lacks `[Arbitrary]` |
+| CON313 | Warning | Mutually recursive `[Arbitrary]` types without `[GenMaxDepth]` |
+
 ### Sealed hierarchy diagnostics (CON205, CON300–CON302)
 
 These fire when `[Arbitrary]` is applied to an abstract class (hierarchy mode).

--- a/docs/site/articles/reference/attributes.md
+++ b/docs/site/articles/reference/attributes.md
@@ -168,6 +168,17 @@ Requirements:
 
 See [How to use source generators](../how-to/use-source-generators.md) for full usage and supported types.
 
+## Gen.For&lt;T&gt;() constraint attributes
+
+Applied to constructor parameters or `init` properties of `[Arbitrary]` types to constrain what the source generator produces. See [Reference: Gen.For&lt;T&gt;()](gen-for.md) for the full attribute reference.
+
+| Attribute | Target | Effect |
+|---|---|---|
+| `[GenRange(min, max)]` | Numeric parameters | Constrains generated value to [`min`, `max`] |
+| `[GenStringLength(min, max)]` | `string` parameters | Constrains generated string length |
+| `[GenRegex(pattern)]` | `string` parameters | Constrains generated strings to match the pattern |
+| `[GenMaxDepth(n)]` | The type itself | Caps recursive generation depth to `n` |
+
 ## `[assembly: ConjectureSettings]`
 
 Applies `ConjectureSettings` to every `[Property]` test in the assembly. See `[ConjectureSettings]` above for properties.

--- a/docs/site/articles/reference/gen-for.md
+++ b/docs/site/articles/reference/gen-for.md
@@ -1,0 +1,237 @@
+# Gen.For&lt;T&gt;() reference
+
+API surface, attribute reference, primitive mapping, and diagnostic codes for `Generate.For<T>()` and the constraint attributes.
+
+## `Generate.For<T>()`
+
+**Namespace:** `Conjecture.Core`  
+**Package:** `Conjecture.Core` (bundled — no extra NuGet package)
+
+```csharp
+// Returns the registered strategy for T.
+public static Strategy<T> For<T>();
+
+// Returns the registered strategy for T with property overrides applied.
+public static Strategy<T> For<T>(Action<ForConfiguration<T>> configure);
+```
+
+`T` must be decorated with `[Arbitrary]`. If no provider is registered, a **CON312** error is raised at the call site.
+
+## `ForConfiguration<T>`
+
+Passed to the `configure` callback in `Generate.For<T>(cfg => ...)`.
+
+### `Override<TProp>`
+
+```csharp
+public ForConfiguration<T> Override<TProp>(
+    Expression<Func<T, TProp>> selector,
+    Strategy<TProp> strategy);
+```
+
+Replaces the strategy for the property identified by `selector` with `strategy`. Multiple overrides can be chained; all other properties use their generated defaults.
+
+```csharp
+Strategy<Order> orders = Generate.For<Order>(cfg => cfg
+    .Override(o => o.Total, Generate.Decimals(0m, 999.99m))
+    .Override(o => o.Customer, Generate.Strings(minLength: 1)));
+```
+
+**Constraints:**
+- `selector` must be a simple member-access expression (e.g., `o => o.Total`). Nested access and method calls are not supported.
+- The `TProp` of the override must match the property's declared type exactly.
+
+## Constraint attributes
+
+Constraint attributes are applied to constructor parameters or `init` properties of `[Arbitrary]` types. The source generator reads them at compile time.
+
+### `[GenRange]`
+
+```csharp
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+public sealed class GenRangeAttribute(double min, double max) : Attribute
+```
+
+Constrains the generated range for a numeric parameter to [`min`, `max`]. Applies to `int`, `long`, `short`, `byte`, `uint`, `ulong`, `ushort`, `sbyte`, `float`, `double`, and `decimal`.
+
+```csharp
+[Arbitrary]
+public partial record Product(
+    [GenRange(0.01, 9_999.99)] decimal Price,
+    [GenRange(1, 500)] int Quantity);
+```
+
+### `[GenStringLength]`
+
+```csharp
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+public sealed class GenStringLengthAttribute(int minLength, int maxLength) : Attribute
+```
+
+Constrains the length of generated strings to [`minLength`, `maxLength`].
+
+```csharp
+[Arbitrary]
+public partial record Customer(
+    [GenStringLength(1, 100)] string Name,
+    [GenStringLength(5, 254)] string Email);
+```
+
+### `[GenRegex]`
+
+```csharp
+[AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property)]
+public sealed class GenRegexAttribute(string pattern) : Attribute
+```
+
+Constrains generated strings to match `pattern`. Requires the `Conjecture.Regex` package.
+
+```csharp
+[Arbitrary]
+public partial record PhoneNumber(
+    [GenRegex(@"^\+\d{7,15}$")] string Value);
+```
+
+If `Conjecture.Regex` is not referenced, the generator emits **CON202** and falls back to unconstrained strings.
+
+### `[GenMaxDepth]`
+
+```csharp
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+public sealed class GenMaxDepthAttribute(int maxDepth) : Attribute
+```
+
+Applied to the **type** (not a parameter) to cap recursive generation depth. Required on self-referential or mutually recursive types; optional on non-recursive types.
+
+```csharp
+[Arbitrary]
+[GenMaxDepth(4)]
+public partial class TreeNode
+{
+    public TreeNode(int Value, TreeNode? Left, TreeNode? Right) { /* ... */ }
+}
+```
+
+At depth 0, nullable recursive parameters produce `null` (leaf nodes). At depth > 0, recursion continues up to the cap.
+
+Default depth when the attribute is absent: **5**.
+
+## Primitive type → default strategy mapping
+
+| Parameter type | Generated strategy |
+|---|---|
+| `bool` | `Generate.Booleans()` |
+| `byte`, `short`, `int`, `long` | `Generate.Integers<T>()` (full range) |
+| `uint`, `ulong`, `ushort`, `sbyte` | `Generate.Integers<T>()` (full range) |
+| `float` | `Generate.Floats()` |
+| `double` | `Generate.Doubles()` |
+| `decimal` | `Generate.Decimals()` |
+| `string` | `Generate.Strings()` (length 0–20, printable ASCII) |
+| `char` | `Generate.Chars()` |
+| `Guid` | `Generate.Guids()` |
+| `DateTime` | `Generate.DateTimes()` |
+| `DateTimeOffset` | `Generate.DateTimeOffsets()` |
+| `DateOnly` | `Generate.DateOnlyValues()` |
+| `TimeOnly` | `Generate.TimeOnlyValues()` |
+| `TimeSpan` | `Generate.TimeSpans()` |
+| `T?` (value type) | `Generate.Nullable(inner)` |
+| `T?` (reference type) | `inner.OrNull()` (~10% null probability) |
+| Enum `T` | `Generate.Enums<T>()` |
+| `[Arbitrary]` type | `Generate.For<T>()` (nested) |
+
+`[GenRange]`, `[GenStringLength]`, and `[GenRegex]` override the defaults for the individual parameter they are applied to.
+
+## Supported collection types
+
+| Parameter type | Generated strategy |
+|---|---|
+| `List<T>` | `Generate.Lists(inner)` |
+| `IReadOnlyList<T>` | `Generate.Lists(inner)` |
+| `IList<T>` | `Generate.Lists(inner)` |
+| `IEnumerable<T>` | `Generate.Lists(inner)` |
+| `T[]` | `Generate.Lists(inner).Select(l => l.ToArray())` |
+| `IReadOnlySet<T>`, `HashSet<T>` | `Generate.Sets(inner)` |
+| `IReadOnlyDictionary<K,V>`, `Dictionary<K,V>` | `Generate.Dictionaries(keyInner, valueInner)` |
+
+Collection size defaults to 0–100 elements. Apply `[GenRange]` to a `List<T>` parameter to constrain the element count.
+
+## `Generate.For<T>()` call-site diagnostics
+
+These diagnostics fire at the `Generate.For<T>()` or `[From<T>]` call site, not on the type declaration.
+
+### CON310 — target is an interface
+
+**Severity:** Error
+
+`Generate.For<T>()` cannot generate a strategy for an interface type. Apply `[Arbitrary]` to each concrete implementation and use `Generate.OneOf(...)` to combine them.
+
+```csharp
+// Error:
+Strategy<IShape> shapes = Generate.For<IShape>();  // CON310
+
+// Fix: use concrete types
+Strategy<IShape> shapes = Generate.OneOf(
+    Generate.For<Circle>().Select(c => (IShape)c),
+    Generate.For<Rectangle>().Select(r => (IShape)r));
+```
+
+### CON311 — abstract type with no `[Arbitrary]` subtypes
+
+**Severity:** Error
+
+The type is abstract but has no concrete subtypes decorated with `[Arbitrary]` in the compilation.
+
+```csharp
+// Error:
+[Arbitrary]
+public abstract partial class Animal { }
+
+Strategy<Animal> animals = Generate.For<Animal>();  // CON311
+
+// Fix: add [Arbitrary] to at least one concrete subtype
+[Arbitrary]
+public partial class Dog : Animal { }
+```
+
+### CON312 — no registered provider
+
+**Severity:** Error
+
+`Generate.For<T>()` was called for a type that has no `[Arbitrary]` attribute and therefore no registered `IStrategyProvider<T>`.
+
+```csharp
+// Error:
+public class Widget { }
+Strategy<Widget> widgets = Generate.For<Widget>();  // CON312
+
+// Fix: add [Arbitrary] and make the type partial
+[Arbitrary]
+public partial class Widget { }
+```
+
+### CON313 — mutual recursion without `[GenMaxDepth]`
+
+**Severity:** Warning
+
+Two or more `[Arbitrary]` types reference each other without either having `[GenMaxDepth]`. Generation may be very deep or diverge.
+
+```csharp
+// Warning — CON313:
+[Arbitrary]
+public partial record Parent(Child? Child);
+
+[Arbitrary]
+public partial record Child(Parent? Parent);
+
+// Fix: add [GenMaxDepth] to at least one side
+[Arbitrary]
+[GenMaxDepth(3)]
+public partial record Parent(Child? Child);
+```
+
+## See also
+
+- [How to use Gen.For&lt;T&gt;()](../how-to/use-gen-for.md) — step-by-step recipes
+- [Understanding Gen.For&lt;T&gt;() source generation](../explanation/gen-for-source-generator.md) — design rationale and registry mechanics
+- [Reference: Analyzers](analyzers.md) — CON200–CON202, CON205, CON300–CON302 (type-declaration diagnostics)
+- [Reference: Attributes](attributes.md) — `[Arbitrary]`, `[From<T>]`, `[FromFactory]`

--- a/docs/site/articles/reference/toc.yml
+++ b/docs/site/articles/reference/toc.yml
@@ -9,6 +9,8 @@ items:
     href: extension-properties.md
   - name: Attributes
     href: attributes.md
+  - name: Gen.For&lt;T&gt;()
+    href: gen-for.md
   - name: Analyzers
     href: analyzers.md
   - name: Time strategies


### PR DESCRIPTION
## Description

Adds Diataxis-structured documentation for the `Gen.For<T>()` source generator feature across all three applicable quadrants.

**New files:**
- `docs/site/articles/how-to/use-gen-for.md` — four task-oriented recipes: basic `[Arbitrary]` + `Generate.For<T>()` usage, call-site property overrides with `ForConfiguration<T>`, constraint attributes (`[GenRange]`, `[GenStringLength]`, `[GenRegex]`), and `[GenMaxDepth]` for recursive types
- `docs/site/articles/reference/gen-for.md` — `ForConfiguration<T>.Override()` signature, full constraint attribute reference, primitive-to-strategy mapping table, supported collection types, CON310–CON313 diagnostics with resolution steps
- `docs/site/articles/explanation/gen-for-source-generator.md` — why source generation over reflection (AOT/trim safety, compile-time feedback, debuggability), how the emitted `[ModuleInitializer]` registry wiring works, how `Generate.For<T>()` composes with property tests

**Updated:** `toc.yml` ×3, `attributes.md` (constraint attribute summary table), `analyzers.md` (CON310–CON313 table), `use-source-generators.md` (cross-reference links)

## Type of change

- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #364
Part of #295