### PR TITLE
Fix shrinker replay memory blowup on wide integer ranges

### DIFF
--- a/src/Conjecture.Core/Internal/ConjectureData.cs
+++ b/src/Conjecture.Core/Internal/ConjectureData.cs
@@ -43,11 +43,16 @@ internal sealed class ConjectureData
         ThrowIfNotActive();
         if (replayNodes is not null)
         {
-            var node = ConsumeReplayNode();
+            IRNode node = ConsumeReplayNode();
+            if (node.Kind != IRNodeKind.Integer || node.Value < min || node.Value > max)
+            {
+                Status = Status.Overrun;
+                throw new InvalidOperationException("Replay node misaligned with requested Integer range.");
+            }
             nodes.Add(node);
             return node.Value;
         }
-        var value = PrngAdapter.NextUInt64(rng!, max - min) + min;
+        ulong value = PrngAdapter.NextUInt64(rng!, max - min) + min;
         nodes.Add(IRNode.ForInteger(value, min, max));
         return value;
     }

--- a/src/Conjecture.Core/Internal/RedistributionPass.cs
+++ b/src/Conjecture.Core/Internal/RedistributionPass.cs
@@ -12,6 +12,7 @@ internal sealed class RedistributionPass : IShrinkPass
 
     public async ValueTask<bool> TryReduce(ShrinkState state)
     {
+        bool progress = false;
         for (int i = 0; i < state.Nodes.Count - 1; i++)
         {
             IRNode left = state.Nodes[i];
@@ -23,18 +24,35 @@ internal sealed class RedistributionPass : IShrinkPass
             }
 
             ulong maxShift = Math.Min(left.Value - left.Min, right.Max - right.Value);
-
-            for (ulong delta = 1; delta <= maxShift; delta++)
+            if (maxShift == 0)
             {
-                IRNode[] candidate = [.. state.Nodes];
-                candidate[i] = IRNode.ForInteger(state.Nodes[i].Value - delta, state.Nodes[i].Min, state.Nodes[i].Max);
-                candidate[i + 1] = IRNode.ForInteger(state.Nodes[i + 1].Value + delta, state.Nodes[i + 1].Min, state.Nodes[i + 1].Max);
+                continue;
+            }
+
+            ulong lo = 1, hi = maxShift;
+            bool pairProgress = false;
+            while (lo <= hi)
+            {
+                ulong mid = lo + ((hi - lo) / 2);
+                IRNode[] candidate = ShrinkHelper.Replace(state.Nodes, i, left.WithValue(left.Value - mid));
+                candidate[i + 1] = right.WithValue(right.Value + mid);
                 if (await state.TryUpdate(candidate))
                 {
-                    return true;
+                    pairProgress = true;
+                    lo = mid + 1;
+                }
+                else
+                {
+                    if (mid == 0)
+                    {
+                        break;
+                    }
+                    hi = mid - 1;
                 }
             }
+
+            progress |= pairProgress;
         }
-        return false;
+        return progress;
     }
 }


### PR DESCRIPTION
## Description

Fixes a pair of defects in the shrinker that together caused `ShrinkerHotPathBenchmarks.ShrinkCollection` to take ~180 s per op and grow to 27+ GB resident while shrinking a 20-element `List<int>` over the full `int` range.

**Root cause — `ConjectureData.NextInteger` did not validate replay node alignment.** When the shrinker produced a candidate whose first node was out of range for the next requested Integer draw, replay returned `node.Value` unchecked. `ListStrategy.Generate` then passed that (potentially huge) value to `new List<T>(size)`, allocating up to 8 GB per replay attempt. Now the replay path asserts `kind == Integer` and `min <= value <= max`, marks the run `Overrun`, and throws cleanly.

**Contributing — `RedistributionPass` linear delta enumeration.** For unbounded integer ranges `maxShift` is ~2^31, so the existing `for (delta = 1..maxShift)` loop drove billions of async replay attempts per adjacent pair, each allocating a fresh `IRNode[]`. Replaced with a binary search for the largest productive delta (mirroring `IntegerReductionPass`), using `ShrinkHelper.Replace` for single-index allocation, and accumulating progress across pairs so the outer fixpoint converges properly.

Repro (scratch file-based app, 20-elem `List<int>` over full int range): before ≥ 180 s / 27 GB, after **86 ms / kilobyte-scale allocations**.

## Type of change

- [x] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes (Core suite: 943/943)
- [x] New behavior is covered by tests (existing shrinker invariant and redistribution tests exercise both paths; misaligned replay now reliably trips `Overrun`)
- [x] Follows `.editorconfig` code style