### PR TITLE
Validates replay node alignment in remaining draw methods

### DIFF
--- a/src/Conjecture.Core/Internal/ConjectureData.cs
+++ b/src/Conjecture.Core/Internal/ConjectureData.cs
@@ -62,7 +62,12 @@ internal sealed class ConjectureData
         ThrowIfNotActive();
         if (replayNodes is not null)
         {
-            var node = ConsumeReplayNode();
+            IRNode node = ConsumeReplayNode();
+            if (node.Kind != IRNodeKind.Boolean)
+            {
+                Status = Status.Overrun;
+                throw new InvalidOperationException("Replay node misaligned with requested Boolean draw.");
+            }
             nodes.Add(node);
             return node.Value == 1UL;
         }
@@ -81,7 +86,12 @@ internal sealed class ConjectureData
         ThrowIfNotActive();
         if (replayNodes is not null)
         {
-            var node = ConsumeReplayNode();
+            IRNode node = ConsumeReplayNode();
+            if (node.Kind != kind || node.Value < min || node.Value > max)
+            {
+                Status = Status.Overrun;
+                throw new InvalidOperationException($"Replay node misaligned with requested {kind} range.");
+            }
             nodes.Add(node);
             return node.Value;
         }
@@ -102,7 +112,12 @@ internal sealed class ConjectureData
         ThrowIfNotActive();
         if (replayNodes is not null)
         {
-            var node = ConsumeReplayNode();
+            IRNode node = ConsumeReplayNode();
+            if (node.Kind != IRNodeKind.Bytes || (int)node.Value != length)
+            {
+                Status = Status.Overrun;
+                throw new InvalidOperationException("Replay node misaligned with requested Bytes draw.");
+            }
             nodes.Add(node);
             return node.RawBytes ?? new byte[(int)node.Value];
         }


### PR DESCRIPTION
## Description

`NextInteger` was fixed in a prior commit to validate kind and range on replay. The remaining draw methods — `NextBoolean`, `NextTyped` (covering `Float64`, `Float32`, `StringLength`, `StringChar`), and `NextBytes` — had the same gap: they consumed replay nodes without checking kind or range.

A misaligned shrink candidate could silently propagate garbage values through these paths. `NextStringLength` is the highest-risk case — an unchecked value there could drive unbounded string allocation, the same class of issue that caused 27+ GB resident memory during integer shrinking.

Each path now checks kind and (where applicable) min/max bounds or byte length, setting `Status.Overrun` and throwing on mismatch.

## Type of change

- [x] Bug fix

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style