### PR TITLE
[366.1] NestedQuantifierDetector: identify nested-quantifier nodes in RegexNode AST

### DIFF
--- a/src/Conjecture.Regex.Tests/NestedQuantifierDetectorTests.cs
+++ b/src/Conjecture.Regex.Tests/NestedQuantifierDetectorTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Text.RegularExpressions;
+
+namespace Conjecture.Regex.Tests;
+
+public sealed class NestedQuantifierDetectorTests
+{
+    // ── Returns true (nested quantifiers present) ─────────────────────────────
+
+    [Theory]
+    [InlineData(@"(a+)+$")]
+    [InlineData(@"([a-zA-Z]+)*$")]
+    [InlineData(@"(a|aa)+$")]
+    [InlineData(@"(a|b)+")] // conservative: any alternation under quantifier is flagged
+    public void HasNestedQuantifiers_PatternWithNestedQuantifiers_ReturnsTrue(string pattern)
+    {
+        RegexNode root = RegexParser.Parse(pattern, RegexOptions.None);
+
+        bool result = NestedQuantifierDetector.HasNestedQuantifiers(root);
+
+        Assert.True(result);
+    }
+
+    // ── Returns false (no nested quantifiers) ────────────────────────────────
+
+    [Theory]
+    [InlineData(@"a+b+")]
+    [InlineData(@"(abc)+")]
+    [InlineData(@"[a-z]{3,10}")]
+    [InlineData(@"a+|b+")] // sibling quantifiers inside alternation arms, no outer quantifier
+    public void HasNestedQuantifiers_PatternWithoutNestedQuantifiers_ReturnsFalse(string pattern)
+    {
+        RegexNode root = RegexParser.Parse(pattern, RegexOptions.None);
+
+        bool result = NestedQuantifierDetector.HasNestedQuantifiers(root);
+
+        Assert.False(result);
+    }
+}

--- a/src/Conjecture.Regex/NestedQuantifierDetector.cs
+++ b/src/Conjecture.Regex/NestedQuantifierDetector.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+
+namespace Conjecture.Regex;
+
+internal static class NestedQuantifierDetector
+{
+    internal static bool HasNestedQuantifiers(RegexNode root)
+    {
+        return ContainsNestedQuantifier(root, insideQuantifier: false);
+    }
+
+    private static bool ContainsNestedQuantifier(RegexNode node, bool insideQuantifier)
+    {
+        return node switch
+        {
+            Quantifier q => insideQuantifier || ContainsNestedQuantifier(q.Inner, insideQuantifier: true),
+            Alternation alt => insideQuantifier || ContainsNestedQuantifierInList(alt.Arms, insideQuantifier),
+            Sequence seq => ContainsNestedQuantifierInList(seq.Items, insideQuantifier),
+            Group grp => ContainsNestedQuantifier(grp.Inner, insideQuantifier),
+            LookaroundAssertion la => ContainsNestedQuantifier(la.Inner, insideQuantifier),
+            _ => false,
+        };
+    }
+
+    private static bool ContainsNestedQuantifierInList(IReadOnlyList<RegexNode> items, bool insideQuantifier)
+    {
+        foreach (RegexNode item in items)
+        {
+            if (ContainsNestedQuantifier(item, insideQuantifier))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Description

Adds `NestedQuantifierDetector` — an internal static class that walks the `RegexNode` AST to identify patterns at risk of catastrophic backtracking (ReDoS).

Returns `true` when a `Quantifier` node contains another `Quantifier` or `Alternation` anywhere in its subtree. The `Alternation` case is intentionally conservative: any alternation under a quantifier is flagged, including unambiguous ones like `(a|b)+`. This is documented by the test suite.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #386
Part of #366