### PR TITLE
[366.2] ReDoSHunterStrategy: adversarial string generation with timeout targeting

### DIFF
--- a/src/Conjecture.Regex/DelegatingStrategy.cs
+++ b/src/Conjecture.Regex/DelegatingStrategy.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Regex;
+
+/// <summary>Wraps an inner strategy and exposes it under a different label.</summary>
+internal sealed class DelegatingStrategy<T>(Strategy<T> inner, string label) : Strategy<T>(label)
+{
+    internal override T Generate(ConjectureData data)
+    {
+        return inner.Generate(data);
+    }
+}

--- a/src/Conjecture.Regex/MatchingStrategy.cs
+++ b/src/Conjecture.Regex/MatchingStrategy.cs
@@ -20,34 +20,6 @@ internal sealed class MatchingStrategy(
     RegexOptions regexOptions,
     RegexGenOptions genOptions) : Strategy<string>
 {
-    // Precomputed BMP candidates per Unicode category, built once at class init.
-    private static readonly Dictionary<System.Globalization.UnicodeCategory, char[]> BmpCandidates =
-        BuildBmpCandidates();
-
-    private static Dictionary<System.Globalization.UnicodeCategory, char[]> BuildBmpCandidates()
-    {
-        Dictionary<System.Globalization.UnicodeCategory, List<char>> buckets = [];
-        foreach (System.Globalization.UnicodeCategory cat in Enum.GetValues<System.Globalization.UnicodeCategory>())
-        {
-            buckets[cat] = [];
-        }
-
-        for (int cp = 0; cp <= 0xFFFF; cp++)
-        {
-            char c = (char)cp;
-            System.Globalization.UnicodeCategory cat = CharUnicodeInfo.GetUnicodeCategory(c);
-            buckets[cat].Add(c);
-        }
-
-        Dictionary<System.Globalization.UnicodeCategory, char[]> result = [];
-        foreach (KeyValuePair<System.Globalization.UnicodeCategory, List<char>> kv in buckets)
-        {
-            result[kv.Key] = [.. kv.Value];
-        }
-
-        return result;
-    }
-
     private readonly bool ignoreCase = (regexOptions & RegexOptions.IgnoreCase) != 0;
     private readonly bool singleline = (regexOptions & RegexOptions.Singleline) != 0;
     private readonly bool hasLookaround = ContainsLookaround(root);
@@ -533,49 +505,13 @@ internal sealed class MatchingStrategy(
         }
         else
         {
-            // Full BMP: precomputed candidate lists per category — avoids Assume-based rejection
-            // which exhausts the filter budget for sparse categories (e.g. \p{Lt}).
-            HashSet<System.Globalization.UnicodeCategory> targetCats = MapCategoryGroup(uc.Category);
-
-            // Merge candidate arrays for all target categories into one list.
-            List<char> allCandidates = [];
-            foreach (System.Globalization.UnicodeCategory cat in targetCats)
-            {
-                if (BmpCandidates.TryGetValue(cat, out char[]? catChars))
-                {
-                    allCandidates.AddRange(catChars);
-                }
-            }
-
-            if (uc.Negated)
-            {
-                // Build complement: all BMP chars not in targetCats.
-                List<char> complement = [];
-                foreach (KeyValuePair<System.Globalization.UnicodeCategory, char[]> kv in BmpCandidates)
-                {
-                    if (!targetCats.Contains(kv.Key))
-                    {
-                        complement.AddRange(kv.Value);
-                    }
-                }
-
-                allCandidates = complement;
-            }
-
-            if (allCandidates.Count == 0)
-            {
-                sb.Append('a');
-                return;
-            }
-
-            char picked = ctx.Generate(Conjecture.Core.Generate.SampledFrom(allCandidates));
-            sb.Append(picked);
+            RegexNodeGenerator.GenerateUnicodeCategory(ctx, uc, sb);
         }
     }
 
     private static char[] BuildAsciiCandidatesForGroup(string category, bool negated)
     {
-        HashSet<System.Globalization.UnicodeCategory> targetCats = MapCategoryGroup(category);
+        HashSet<System.Globalization.UnicodeCategory> targetCats = RegexNodeGenerator.MapCategoryGroup(category);
         List<char> result = [];
         for (int i = 0; i < 128; i++)
         {
@@ -590,79 +526,5 @@ internal sealed class MatchingStrategy(
         }
 
         return [.. result];
-    }
-
-    private static HashSet<System.Globalization.UnicodeCategory> MapCategoryGroup(string name)
-    {
-        return name switch
-        {
-            "L" => [
-                System.Globalization.UnicodeCategory.UppercaseLetter,
-                System.Globalization.UnicodeCategory.LowercaseLetter,
-                System.Globalization.UnicodeCategory.TitlecaseLetter,
-                System.Globalization.UnicodeCategory.ModifierLetter,
-                System.Globalization.UnicodeCategory.OtherLetter,
-            ],
-            "Lu" => [System.Globalization.UnicodeCategory.UppercaseLetter],
-            "Ll" => [System.Globalization.UnicodeCategory.LowercaseLetter],
-            "Lt" => [System.Globalization.UnicodeCategory.TitlecaseLetter],
-            "Lm" => [System.Globalization.UnicodeCategory.ModifierLetter],
-            "Lo" => [System.Globalization.UnicodeCategory.OtherLetter],
-            "N" => [
-                System.Globalization.UnicodeCategory.DecimalDigitNumber,
-                System.Globalization.UnicodeCategory.LetterNumber,
-                System.Globalization.UnicodeCategory.OtherNumber,
-            ],
-            "Nd" => [System.Globalization.UnicodeCategory.DecimalDigitNumber],
-            "Nl" => [System.Globalization.UnicodeCategory.LetterNumber],
-            "No" => [System.Globalization.UnicodeCategory.OtherNumber],
-            "P" => [
-                System.Globalization.UnicodeCategory.ConnectorPunctuation,
-                System.Globalization.UnicodeCategory.DashPunctuation,
-                System.Globalization.UnicodeCategory.OpenPunctuation,
-                System.Globalization.UnicodeCategory.ClosePunctuation,
-                System.Globalization.UnicodeCategory.InitialQuotePunctuation,
-                System.Globalization.UnicodeCategory.FinalQuotePunctuation,
-                System.Globalization.UnicodeCategory.OtherPunctuation,
-            ],
-            "Pc" => [System.Globalization.UnicodeCategory.ConnectorPunctuation],
-            "Pd" => [System.Globalization.UnicodeCategory.DashPunctuation],
-            "Ps" => [System.Globalization.UnicodeCategory.OpenPunctuation],
-            "Pe" => [System.Globalization.UnicodeCategory.ClosePunctuation],
-            "Pi" => [System.Globalization.UnicodeCategory.InitialQuotePunctuation],
-            "Pf" => [System.Globalization.UnicodeCategory.FinalQuotePunctuation],
-            "Po" => [System.Globalization.UnicodeCategory.OtherPunctuation],
-            "S" => [
-                System.Globalization.UnicodeCategory.MathSymbol,
-                System.Globalization.UnicodeCategory.CurrencySymbol,
-                System.Globalization.UnicodeCategory.ModifierSymbol,
-                System.Globalization.UnicodeCategory.OtherSymbol,
-            ],
-            "Sm" => [System.Globalization.UnicodeCategory.MathSymbol],
-            "Sc" => [System.Globalization.UnicodeCategory.CurrencySymbol],
-            "Sk" => [System.Globalization.UnicodeCategory.ModifierSymbol],
-            "So" => [System.Globalization.UnicodeCategory.OtherSymbol],
-            "Z" => [
-                System.Globalization.UnicodeCategory.SpaceSeparator,
-                System.Globalization.UnicodeCategory.LineSeparator,
-                System.Globalization.UnicodeCategory.ParagraphSeparator,
-            ],
-            "Zs" => [System.Globalization.UnicodeCategory.SpaceSeparator],
-            "Zl" => [System.Globalization.UnicodeCategory.LineSeparator],
-            "Zp" => [System.Globalization.UnicodeCategory.ParagraphSeparator],
-            "C" => [
-                System.Globalization.UnicodeCategory.Control,
-                System.Globalization.UnicodeCategory.Format,
-                System.Globalization.UnicodeCategory.Surrogate,
-                System.Globalization.UnicodeCategory.PrivateUse,
-                System.Globalization.UnicodeCategory.OtherNotAssigned,
-            ],
-            "Cc" => [System.Globalization.UnicodeCategory.Control],
-            "Cf" => [System.Globalization.UnicodeCategory.Format],
-            "Cs" => [System.Globalization.UnicodeCategory.Surrogate],
-            "Co" => [System.Globalization.UnicodeCategory.PrivateUse],
-            "Cn" => [System.Globalization.UnicodeCategory.OtherNotAssigned],
-            _ => throw new ArgumentOutOfRangeException(nameof(name), name, "Unknown Unicode category name."),
-        };
     }
 }

--- a/src/Conjecture.Regex/ReDoSHunterStrategy.cs
+++ b/src/Conjecture.Regex/ReDoSHunterStrategy.cs
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+using DotNetRegex = System.Text.RegularExpressions.Regex;
+
+namespace Conjecture.Regex;
+
+internal sealed class ReDoSHunterStrategy(
+    RegexNode root,
+    DotNetRegex regex,
+    int maxMatchMs) : Strategy<string>("redos:hunter")
+{
+    private const int AdversarialCap = 32;
+    private const int Trials = 3;
+    private const int HitsRequired = 2;
+
+    private readonly Strategy<string>? fallback = BuildFallback(root, regex);
+    private readonly DotNetRegex timedRegex = new(
+        regex.ToString(),
+        regex.Options,
+        TimeSpan.FromMilliseconds(maxMatchMs));
+
+    private static Strategy<string>? BuildFallback(RegexNode root, DotNetRegex regex)
+    {
+        return regex.Options.HasFlag(RegexOptions.NonBacktracking)
+            ? new DelegatingStrategy<string>(Conjecture.Core.Generate.Matching(regex), "redos:non-backtracking")
+            : !NestedQuantifierDetector.HasNestedQuantifiers(root)
+            ? new DelegatingStrategy<string>(Conjecture.Core.Generate.Matching(regex), "redos:no-nested-quantifiers")
+            : (Strategy<string>?)null;
+    }
+
+    internal override string Generate(ConjectureData data)
+    {
+        return fallback is not null
+            ? fallback.Generate(data)
+            : Conjecture.Core.Generate.Compose<string>(ctx =>
+        {
+            StringBuilder sb = new();
+            Dictionary<int, string> captures = [];
+            Dictionary<string, string> namedCaptures = [];
+            RegexNodeGenerator.GenerateNode(ctx, root, sb, captures, namedCaptures, SelectCount);
+            string candidate = sb.ToString();
+
+            int hits = 0;
+            Stopwatch sw = new();
+            for (int trial = 0; trial < Trials; trial++)
+            {
+                sw.Restart();
+                try
+                {
+                    timedRegex.IsMatch(candidate);
+                    sw.Stop();
+                    ctx.Target(sw.Elapsed.TotalMilliseconds, "timing");
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    hits++;
+                }
+            }
+
+            if (hits >= HitsRequired)
+            {
+                data.MarkInteresting();
+            }
+
+            return candidate;
+        }).Generate(data);
+    }
+
+    private static int SelectCount(IGeneratorContext ctx, Quantifier q)
+    {
+        bool innerHasQuantifier = q.Inner switch
+        {
+            Quantifier => true,
+            Group grp => ContainsQuantifier(grp.Inner),
+            _ => false,
+        };
+
+        int maxCount = q.Max ?? (q.Min + AdversarialCap);
+
+        return innerHasQuantifier
+            ? maxCount
+            : ctx.Generate(Conjecture.Core.Generate.Integers<int>(q.Min, maxCount));
+    }
+
+    private static bool ContainsQuantifier(RegexNode node)
+    {
+        return node switch
+        {
+            Quantifier => true,
+            Group grp => ContainsQuantifier(grp.Inner),
+            Sequence seq => ContainsQuantifierInList(seq.Items),
+            Alternation alt => ContainsQuantifierInList(alt.Arms),
+            _ => false,
+        };
+    }
+
+    private static bool ContainsQuantifierInList(IReadOnlyList<RegexNode> items)
+    {
+        foreach (RegexNode item in items)
+        {
+            if (ContainsQuantifier(item))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Conjecture.Regex/RegexNodeGenerator.cs
+++ b/src/Conjecture.Regex/RegexNodeGenerator.cs
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Regex;
+
+/// <summary>
+/// Shared regex node dispatch logic used by both <see cref="MatchingStrategy"/> and
+/// <see cref="ReDoSHunterStrategy"/>.  The only behavioural difference — how many
+/// repetitions a <see cref="Quantifier"/> produces — is injected as a delegate.
+/// </summary>
+internal static class RegexNodeGenerator
+{
+    // Precomputed BMP candidates per Unicode category, shared across all users.
+    internal static readonly Dictionary<System.Globalization.UnicodeCategory, char[]> BmpCandidates =
+        BuildBmpCandidates();
+
+    private static Dictionary<System.Globalization.UnicodeCategory, char[]> BuildBmpCandidates()
+    {
+        Dictionary<System.Globalization.UnicodeCategory, List<char>> buckets = [];
+        foreach (System.Globalization.UnicodeCategory cat in Enum.GetValues<System.Globalization.UnicodeCategory>())
+        {
+            buckets[cat] = [];
+        }
+
+        for (int cp = 0; cp <= 0xFFFF; cp++)
+        {
+            char c = (char)cp;
+            System.Globalization.UnicodeCategory cat = CharUnicodeInfo.GetUnicodeCategory(c);
+            buckets[cat].Add(c);
+        }
+
+        Dictionary<System.Globalization.UnicodeCategory, char[]> result = [];
+        foreach (KeyValuePair<System.Globalization.UnicodeCategory, List<char>> kv in buckets)
+        {
+            result[kv.Key] = [.. kv.Value];
+        }
+
+        return result;
+    }
+
+    internal static void GenerateNode(
+        IGeneratorContext ctx,
+        RegexNode node,
+        StringBuilder sb,
+        Dictionary<int, string> captures,
+        Dictionary<string, string> namedCaptures,
+        Func<IGeneratorContext, Quantifier, int> selectCount)
+    {
+        switch (node)
+        {
+            case Literal lit:
+                sb.Append(lit.Ch);
+                break;
+
+            case CharClass cc:
+                {
+                    IReadOnlyList<CharRange> ranges = cc.Negated
+                        ? CharRangeHelpers.ComplementRanges(cc.Ranges, '\u0000', '\uFFFF')
+                        : cc.Ranges;
+                    char ch = CharRangeHelpers.SampleFromRanges(ranges, ctx);
+                    sb.Append(ch);
+                    break;
+                }
+
+            case Quantifier q:
+                {
+                    int count = selectCount(ctx, q);
+                    for (int i = 0; i < count; i++)
+                    {
+                        GenerateNode(ctx, q.Inner, sb, captures, namedCaptures, selectCount);
+                    }
+
+                    break;
+                }
+
+            case Alternation alt:
+                {
+                    int idx = ctx.Generate(Conjecture.Core.Generate.Integers<int>(0, alt.Arms.Count - 1));
+                    GenerateNode(ctx, alt.Arms[idx], sb, captures, namedCaptures, selectCount);
+                    break;
+                }
+
+            case Sequence seq:
+                foreach (RegexNode item in seq.Items)
+                {
+                    GenerateNode(ctx, item, sb, captures, namedCaptures, selectCount);
+                }
+
+                break;
+
+            case Group grp:
+                {
+                    int startPos = sb.Length;
+                    GenerateNode(ctx, grp.Inner, sb, captures, namedCaptures, selectCount);
+                    string captured = sb.ToString(startPos, sb.Length - startPos);
+                    if (grp.CaptureIndex.HasValue)
+                    {
+                        captures[grp.CaptureIndex.Value] = captured;
+                    }
+
+                    if (grp.Name is not null)
+                    {
+                        namedCaptures[grp.Name] = captured;
+                    }
+
+                    break;
+                }
+
+            case Anchor:
+                break;
+
+            case Dot:
+                {
+                    int cp = ctx.Generate(Conjecture.Core.Generate.Integers<int>(0x00, 0xFF));
+                    sb.Append((char)cp);
+                    break;
+                }
+
+            case UnicodeCategory uc:
+                GenerateUnicodeCategory(ctx, uc, sb);
+                break;
+
+            case Backreference br:
+                sb.Append(captures.TryGetValue(br.Index, out string? text) ? text : string.Empty);
+                break;
+
+            case NamedBackreference nbr:
+                sb.Append(namedCaptures.TryGetValue(nbr.Name, out string? namedText) ? namedText : string.Empty);
+                break;
+
+            case LookaroundAssertion:
+                break;
+
+            default:
+                throw new NotSupportedException($"Unsupported node type: {node.GetType().Name}");
+        }
+    }
+
+    internal static void GenerateUnicodeCategory(IGeneratorContext ctx, UnicodeCategory uc, StringBuilder sb)
+    {
+        if (!CandidateCache.TryGetValue((uc.Category, uc.Negated), out char[]? candidates) || candidates.Length == 0)
+        {
+            sb.Append('a');
+            return;
+        }
+
+        char picked = ctx.Generate(Conjecture.Core.Generate.SampledFrom(candidates));
+        sb.Append(picked);
+    }
+
+    private static readonly Dictionary<string, HashSet<System.Globalization.UnicodeCategory>> CategoryGroupCache =
+        BuildCategoryGroupCache();
+
+    private static Dictionary<string, HashSet<System.Globalization.UnicodeCategory>> BuildCategoryGroupCache()
+    {
+        Dictionary<string, HashSet<System.Globalization.UnicodeCategory>> cache = [];
+        string[] keys =
+        [
+            "L", "Lu", "Ll", "Lt", "Lm", "Lo",
+            "N", "Nd", "Nl", "No",
+            "P", "Pc", "Pd", "Ps", "Pe", "Pi", "Pf", "Po",
+            "S", "Sm", "Sc", "Sk", "So",
+            "Z", "Zs", "Zl", "Zp",
+            "C", "Cc", "Cf", "Cs", "Co", "Cn",
+        ];
+        foreach (string key in keys)
+        {
+            cache[key] = MapCategoryGroupCore(key);
+        }
+
+        return cache;
+    }
+
+    internal static readonly Dictionary<(string category, bool negated), char[]> CandidateCache =
+        BuildCandidateCache();
+
+    private static Dictionary<(string category, bool negated), char[]> BuildCandidateCache()
+    {
+        Dictionary<(string, bool), char[]> cache = [];
+        string[] keys =
+        [
+            "L", "Lu", "Ll", "Lt", "Lm", "Lo",
+            "N", "Nd", "Nl", "No",
+            "P", "Pc", "Pd", "Ps", "Pe", "Pi", "Pf", "Po",
+            "S", "Sm", "Sc", "Sk", "So",
+            "Z", "Zs", "Zl", "Zp",
+            "C", "Cc", "Cf", "Cs", "Co", "Cn",
+        ];
+        foreach (string key in keys)
+        {
+            HashSet<System.Globalization.UnicodeCategory> targetCats = MapCategoryGroupCore(key);
+            List<char> positive = [];
+            List<char> complement = [];
+            foreach (KeyValuePair<System.Globalization.UnicodeCategory, char[]> kv in BmpCandidates)
+            {
+                if (targetCats.Contains(kv.Key))
+                {
+                    positive.AddRange(kv.Value);
+                }
+                else
+                {
+                    complement.AddRange(kv.Value);
+                }
+            }
+
+            cache[(key, false)] = [.. positive];
+            cache[(key, true)] = [.. complement];
+        }
+
+        return cache;
+    }
+
+    internal static HashSet<System.Globalization.UnicodeCategory> MapCategoryGroup(string name) =>
+        CategoryGroupCache.TryGetValue(name, out HashSet<System.Globalization.UnicodeCategory>? cats)
+            ? cats
+            : throw new ArgumentOutOfRangeException(nameof(name), name, "Unknown Unicode category name.");
+
+    private static HashSet<System.Globalization.UnicodeCategory> MapCategoryGroupCore(string name)
+    {
+        return name switch
+        {
+            "L" => [
+                System.Globalization.UnicodeCategory.UppercaseLetter,
+                System.Globalization.UnicodeCategory.LowercaseLetter,
+                System.Globalization.UnicodeCategory.TitlecaseLetter,
+                System.Globalization.UnicodeCategory.ModifierLetter,
+                System.Globalization.UnicodeCategory.OtherLetter,
+            ],
+            "Lu" => [System.Globalization.UnicodeCategory.UppercaseLetter],
+            "Ll" => [System.Globalization.UnicodeCategory.LowercaseLetter],
+            "Lt" => [System.Globalization.UnicodeCategory.TitlecaseLetter],
+            "Lm" => [System.Globalization.UnicodeCategory.ModifierLetter],
+            "Lo" => [System.Globalization.UnicodeCategory.OtherLetter],
+            "N" => [
+                System.Globalization.UnicodeCategory.DecimalDigitNumber,
+                System.Globalization.UnicodeCategory.LetterNumber,
+                System.Globalization.UnicodeCategory.OtherNumber,
+            ],
+            "Nd" => [System.Globalization.UnicodeCategory.DecimalDigitNumber],
+            "Nl" => [System.Globalization.UnicodeCategory.LetterNumber],
+            "No" => [System.Globalization.UnicodeCategory.OtherNumber],
+            "P" => [
+                System.Globalization.UnicodeCategory.ConnectorPunctuation,
+                System.Globalization.UnicodeCategory.DashPunctuation,
+                System.Globalization.UnicodeCategory.OpenPunctuation,
+                System.Globalization.UnicodeCategory.ClosePunctuation,
+                System.Globalization.UnicodeCategory.InitialQuotePunctuation,
+                System.Globalization.UnicodeCategory.FinalQuotePunctuation,
+                System.Globalization.UnicodeCategory.OtherPunctuation,
+            ],
+            "Pc" => [System.Globalization.UnicodeCategory.ConnectorPunctuation],
+            "Pd" => [System.Globalization.UnicodeCategory.DashPunctuation],
+            "Ps" => [System.Globalization.UnicodeCategory.OpenPunctuation],
+            "Pe" => [System.Globalization.UnicodeCategory.ClosePunctuation],
+            "Pi" => [System.Globalization.UnicodeCategory.InitialQuotePunctuation],
+            "Pf" => [System.Globalization.UnicodeCategory.FinalQuotePunctuation],
+            "Po" => [System.Globalization.UnicodeCategory.OtherPunctuation],
+            "S" => [
+                System.Globalization.UnicodeCategory.MathSymbol,
+                System.Globalization.UnicodeCategory.CurrencySymbol,
+                System.Globalization.UnicodeCategory.ModifierSymbol,
+                System.Globalization.UnicodeCategory.OtherSymbol,
+            ],
+            "Sm" => [System.Globalization.UnicodeCategory.MathSymbol],
+            "Sc" => [System.Globalization.UnicodeCategory.CurrencySymbol],
+            "Sk" => [System.Globalization.UnicodeCategory.ModifierSymbol],
+            "So" => [System.Globalization.UnicodeCategory.OtherSymbol],
+            "Z" => [
+                System.Globalization.UnicodeCategory.SpaceSeparator,
+                System.Globalization.UnicodeCategory.LineSeparator,
+                System.Globalization.UnicodeCategory.ParagraphSeparator,
+            ],
+            "Zs" => [System.Globalization.UnicodeCategory.SpaceSeparator],
+            "Zl" => [System.Globalization.UnicodeCategory.LineSeparator],
+            "Zp" => [System.Globalization.UnicodeCategory.ParagraphSeparator],
+            "C" => [
+                System.Globalization.UnicodeCategory.Control,
+                System.Globalization.UnicodeCategory.Format,
+                System.Globalization.UnicodeCategory.Surrogate,
+                System.Globalization.UnicodeCategory.PrivateUse,
+                System.Globalization.UnicodeCategory.OtherNotAssigned,
+            ],
+            "Cc" => [System.Globalization.UnicodeCategory.Control],
+            "Cf" => [System.Globalization.UnicodeCategory.Format],
+            "Cs" => [System.Globalization.UnicodeCategory.Surrogate],
+            "Co" => [System.Globalization.UnicodeCategory.PrivateUse],
+            "Cn" => [System.Globalization.UnicodeCategory.OtherNotAssigned],
+            _ => throw new ArgumentOutOfRangeException(nameof(name), name, "Unknown Unicode category name."),
+        };
+    }
+}


### PR DESCRIPTION
## Description

Adds `ReDoSHunterStrategy` — an internal strategy that generates adversarial strings biased toward triggering catastrophic backtracking in regexes with nested quantifiers.

- Quantifier nodes containing an inner quantifier have their repetition count pinned to the upper bound (cap 32 for unbounded), maximising partial-match backtrack depth
- 3 timing trials per candidate; `data.MarkInteresting()` fires if ≥2 exceed `Regex.MatchTimeout` — filters out noisy single timeouts
- Falls back to `Generate.Matching` for `NonBacktracking` regexes and patterns with no nested quantifiers (via `NestedQuantifierDetector`), with diagnostic labels
- Extracts `RegexNodeGenerator` as a shared static AST dispatch class used by both `MatchingStrategy` and `ReDoSHunterStrategy`, with pre-built BMP/category candidate caches to eliminate per-call allocation
- Adds `DelegatingStrategy<T>` for wrapping a strategy under an alternative label

## Type of change

- [x] New feature / strategy
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #387
Part of #366