### PR TITLE
[366.3] RegexGenerateExtensions: expose ReDoSHunter via Generate extension block

### DIFF
--- a/src/Conjecture.Regex/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Regex/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).ReDoSHunter(string! pattern, int maxMatchMs = 5) -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).ReDoSHunter(System.Text.RegularExpressions.Regex! regex, int maxMatchMs = 5) -> Conjecture.Core.Strategy<string!>!

--- a/src/Conjecture.Regex/RegexGenerateExtensions.cs
+++ b/src/Conjecture.Regex/RegexGenerateExtensions.cs
@@ -51,6 +51,17 @@ public static class RegexGenerateExtensions
         {
             return new NotMatchingStrategy(regex, regex.ToString(), options);
         }
+
+        /// <summary>Returns a strategy that generates strings that may trigger ReDoS for <paramref name="pattern"/>.</summary>
+        public static Strategy<string> ReDoSHunter(string pattern, int maxMatchMs = 5)
+            => Generate.ReDoSHunter(GetOrAddCached(pattern), maxMatchMs);
+
+        /// <summary>Returns a strategy that generates strings that may trigger ReDoS for <paramref name="regex"/>.</summary>
+        public static Strategy<string> ReDoSHunter(DotNetRegex regex, int maxMatchMs = 5)
+        {
+            RegexNode root = RegexParser.Parse(regex.ToString(), regex.Options);
+            return new ReDoSHunterStrategy(root, regex, maxMatchMs);
+        }
 #pragma warning restore RS0026
 
         /// <summary>Returns a strategy that generates strings matching <see cref="KnownRegex.Email"/>.</summary>


### PR DESCRIPTION
## Description

Adds two `ReDoSHunter` overloads to `RegexGenerateExtensions` inside the C# 14 `extension(Generate)` block — one accepting a `string` pattern and one accepting a compiled `Regex`. Registers the new public API signatures in `PublicAPI.Unshipped.txt`.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #388
Part of #366