### PR TITLE
[366.5] ReDoSBenchmarks: BenchmarkDotNet detection latency suite

### DIFF
--- a/src/Conjecture.Benchmarks/Conjecture.Benchmarks.csproj
+++ b/src/Conjecture.Benchmarks/Conjecture.Benchmarks.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+    <ProjectReference Include="..\Conjecture.Regex\Conjecture.Regex.csproj" />
     <ProjectReference Include="..\Conjecture.Generators\Conjecture.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="true" />

--- a/src/Conjecture.Benchmarks/ReDoSBenchmarks.cs
+++ b/src/Conjecture.Benchmarks/ReDoSBenchmarks.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Linq;
+
+using BenchmarkDotNet.Attributes;
+
+using Conjecture.Core;
+
+using DotNetRegex = System.Text.RegularExpressions.Regex;
+
+namespace Conjecture.Benchmarks;
+
+[MemoryDiagnoser]
+[SimpleJob]
+public class ReDoSBenchmarks
+{
+    private static readonly DotNetRegex NestedQuantifier = new(@"(a+)+$");
+    private static readonly DotNetRegex AlternationLoop = new(@"([a-zA-Z]+)*$");
+    private static readonly DotNetRegex NestedAlternation = new(@"(a|aa)+$");
+
+    [Params(5, 25, 100)]
+    public int MaxMatchMs { get; set; }
+
+    [Benchmark]
+    public string? NestedQuantifier_FindPathologicalInput()
+        => DataGen.Sample(Generate.ReDoSHunter(NestedQuantifier, MaxMatchMs), count: 1, seed: 42UL)
+               .FirstOrDefault();
+
+    [Benchmark]
+    public string? AlternationLoop_FindPathologicalInput()
+        => DataGen.Sample(Generate.ReDoSHunter(AlternationLoop, MaxMatchMs), count: 1, seed: 42UL)
+               .FirstOrDefault();
+
+    [Benchmark]
+    public string? NestedAlternation_FindPathologicalInput()
+        => DataGen.Sample(Generate.ReDoSHunter(NestedAlternation, MaxMatchMs), count: 1, seed: 42UL)
+               .FirstOrDefault();
+}


### PR DESCRIPTION
## Description

Adds `ReDoSBenchmarks` to `Conjecture.Benchmarks`, measuring time-to-first-finding for three OWASP-representative vulnerable patterns (`(a+)+$`, `([a-zA-Z]+)*$`, `(a|aa)+$`) across three `MaxMatchMs` budgets (5, 25, 100 ms). Also adds `Conjecture.Regex` as a project reference to the benchmarks project.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #390
Part of #366