### PR TITLE
[366.6] Mcp: expose ReDoSHunter in suggest-strategy tool

### DIFF
--- a/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
+++ b/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
@@ -148,4 +148,21 @@ public class StrategyToolsTests
         string result = StrategyTools.SuggestStrategy(typeName: "MyRecord", hasArbitraryAttribute: true);
         Assert.Contains("Generate.For<MyRecord>()", result);
     }
+
+    [Fact]
+    public void SuggestForType_ReDoS_ContainsReDoSHunter()
+    {
+        string result = StrategyTools.SuggestForType("ReDoS");
+        Assert.Contains("ReDoSHunter", result);
+    }
+
+    [Theory]
+    [InlineData("backtracking")]
+    [InlineData("catastrophic")]
+    [InlineData("adversarial")]
+    public void SuggestForType_ReDoSKeywords_ContainsReDoSHunter(string typeName)
+    {
+        string result = StrategyTools.SuggestForType(typeName);
+        Assert.Contains("ReDoSHunter", result);
+    }
 }

--- a/src/Conjecture.Mcp/Tools/StrategyTools.cs
+++ b/src/Conjecture.Mcp/Tools/StrategyTools.cs
@@ -17,8 +17,9 @@ internal static class StrategyTools
         "(DateTimeOffset, TimeSpan, DateOnly, TimeOnly), collections " +
         "(List<T>, IReadOnlySet<T>, IReadOnlyDictionary<K,V>), nullable types, value " +
         "tuples, enums, and custom types. Also handles regex-constrained strings via the " +
-        "Conjecture.Regex package: pass 'Regex' for pattern-matching strategies, or a " +
-        "description keyword such as 'email' for curated RegexGenerate helpers. " +
+        "Conjecture.Regex package: pass 'Regex' for pattern-matching strategies, 'ReDoS' or " +
+        "'backtracking' for adversarial ReDoS-hunting strategies, or a description keyword " +
+        "such as 'email' for curated RegexGenerate helpers. " +
         "For sealed abstract class hierarchies, use the suggest-strategy-for-sealed-hierarchy tool instead. " +
         "If the target type is decorated with `[Arbitrary]`, set `hasArbitraryAttribute: true` to get a `Generate.For<T>()` recommendation instead of manual composition.")]
     public static string SuggestStrategy(
@@ -140,6 +141,24 @@ internal static class StrategyTools
             ```csharp
             Generate.Email()
             // → Strategy<string> of valid email address strings
+            ```
+
+            Add the NuGet package: `Conjecture.Regex`
+            """,
+
+            "ReDoS" or "redos" or "backtracking" or "Backtracking" or "catastrophic" or "Catastrophic" or "adversarial" or "Adversarial" =>
+                """
+            Use `Generate.ReDoSHunter(pattern, maxMatchMs: 5)` from the `Conjecture.Regex` package to generate adversarial strings that trigger catastrophic backtracking:
+            ```csharp
+            Generate.ReDoSHunter(@"(a+)+$", maxMatchMs: 5)
+            // → Strategy<string> biased toward inputs that cause ReDoS timeouts
+            ```
+
+            Use with a timing assertion in your property:
+            ```csharp
+            var sw = Stopwatch.StartNew();
+            Regex.IsMatch(input, pattern);
+            Assert.True(sw.ElapsedMilliseconds < 100, $"Slow on: {input}");
             ```
 
             Add the NuGet package: `Conjecture.Regex`


### PR DESCRIPTION
## Description

Adds `ReDoSHunter` to the `suggest-strategy` MCP tool. The keywords `ReDoS`, `backtracking`, `catastrophic`, and `adversarial` (case-insensitive for each) now route to a `Generate.ReDoSHunter` suggestion including a usage example with a timing assertion. Also updates the `[Description]` attribute so MCP clients can discover the capability from the tool contract.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #391
Part of #366