### PR TITLE
[366.7] Docs: how-to guide for auditing a regex for ReDoS

### DIFF
--- a/docs/site/articles/explanation/regex-catastrophic-backtracking.md
+++ b/docs/site/articles/explanation/regex-catastrophic-backtracking.md
@@ -1,0 +1,78 @@
+# Why nested quantifiers cause catastrophic backtracking
+
+Catastrophic backtracking is a class of ReDoS (Regular Expression Denial of Service)
+vulnerability where a regex engine takes exponential time on certain inputs. Understanding why
+it happens explains why `Generate.ReDoSHunter` generates the strings it does.
+
+## How backtracking engines work
+
+Most regex engines — including .NET's default NFA engine — work by trying a path through the
+pattern and backtracking if it fails. For simple patterns this is fast, but for patterns with
+ambiguous repetition the engine must explore exponentially many paths before it can declare no
+match.
+
+## The nested-quantifier case
+
+Consider the pattern `(a+)+$` and the input `"aaaa!"`.
+
+The outer `+` repeats the group `(a+)` one or more times. The inner `a+` matches one or more
+`a`s. Together they can match `"aaaa"` in many different ways:
+
+| Outer iterations | Inner lengths |
+|---|---|
+| 1 group | `[4]` |
+| 2 groups | `[1,3]`, `[2,2]`, `[3,1]` |
+| 3 groups | `[1,1,2]`, `[1,2,1]`, `[2,1,1]` |
+| 4 groups | `[1,1,1,1]` |
+
+For `n` input characters there are 2^(n-1) ways to partition them. When the engine reaches `!`
+and the `$` anchor fails, it must try every partition before concluding the string does not
+match — 2^(n-1) attempts in total.
+
+With n=30 (thirty `a`s followed by `!`), that is over 500 million backtrack steps. On a modern
+CPU this takes several seconds to minutes; with n=50 the heat death of the universe is a more
+realistic estimate.
+
+## The alternation case
+
+Ambiguous alternation has the same effect. For `(a|aa)+$` with input `"aaa!"`:
+
+The engine can match each character as either `a` (single) or the first character of `aa`
+(pair). The number of ways grows with the Fibonacci sequence — exponential growth, though slower
+than the pure-quantifier case.
+
+## Why property-based testing finds these faster than manual audit
+
+Manual auditing requires the developer to construct the worst-case input by hand. For complex
+patterns this is non-trivial — the pathological input depends on the specific ambiguity structure
+of the pattern, which is hard to reason about directly.
+
+`Generate.ReDoSHunter` automates this by:
+
+1. **Walking the AST** to find nested-quantifier sub-trees.
+2. **Biasing repetition counts** toward their maximum, generating longer strings with more
+   ambiguous paths.
+3. **Appending a non-matching suffix** (`\0`) to force the engine to exhaust all backtracking
+   paths rather than returning on first match.
+4. **Feeding timing signals** back to Conjecture's hill-climbing loop, steering the engine toward
+   progressively slower inputs.
+5. **Shrinking** via the standard IR-native passes, converging to the shortest string that still
+   triggers the slowdown.
+
+The result is a minimal, reproducible pathological input — typically found in tens of seconds,
+not hours of manual analysis.
+
+## How to protect against catastrophic backtracking
+
+| Fix | When to use |
+|---|---|
+| `RegexOptions.NonBacktracking` | Drop-in replacement for patterns where full NFA semantics are not required. The NFA engine cannot exhibit catastrophic backtracking by design. |
+| Possessive quantifiers / atomic groups | Prevent the engine from reconsidering already-matched characters. Useful when `NonBacktracking` changes match semantics. |
+| Rewrite the pattern | Remove the ambiguity. `(a+)+$` can be rewritten as `a+$` — single quantifier, no ambiguity. |
+| Timeout + retry limit | `MatchTimeout` on the `Regex` instance provides a safety net but is not a fix — it just limits the damage. |
+
+## See also
+
+- [How to audit a regex for catastrophic backtracking](../how-to/audit-regex-for-redos.md)
+- [Reference: `Generate.ReDoSHunter`](../reference/regex-strategies.md#generateredoshunter)
+- [How Conjecture.Regex works](regex-engine.md)

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -19,3 +19,5 @@ items:
     href: mtp-model.md
   - name: How Conjecture.Regex works
     href: regex-engine.md
+  - name: Why nested quantifiers cause catastrophic backtracking
+    href: regex-catastrophic-backtracking.md

--- a/docs/site/articles/how-to/audit-regex-for-redos.md
+++ b/docs/site/articles/how-to/audit-regex-for-redos.md
@@ -1,0 +1,138 @@
+# How to audit a regex for catastrophic backtracking
+
+Use `Generate.ReDoSHunter` to generate adversarial strings that expose
+[catastrophic backtracking](../explanation/regex-catastrophic-backtracking.md) in a regex — then
+shrink the failure to the smallest possible pathological input.
+
+## Install
+
+```bash
+dotnet add package Conjecture.Regex
+```
+
+## Write the property
+
+Wrap `Generate.ReDoSHunter` in a property that measures how long the regex takes on each
+generated string:
+
+```csharp
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Conjecture.Core;
+using Conjecture.Regex;
+
+[Property]
+public bool UserInputPattern_DoesNotBacktrackCatastrophically()
+{
+    string input = DataGen.SampleOne(Generate.ReDoSHunter(@"(a+)+$", maxMatchMs: 50));
+
+    Stopwatch sw = Stopwatch.StartNew();
+    Regex.IsMatch(input, @"(a+)+$");
+    sw.Stop();
+
+    return sw.ElapsedMilliseconds < 50;
+}
+```
+
+Conjecture generates strings adversarially biased toward inputs that exhaust the backtracking
+engine. When the property fails, the shrunk counterexample is the shortest string that still
+causes the slowdown.
+
+## Choose a `maxMatchMs` budget
+
+`maxMatchMs` controls the internal engine-level timeout used to confirm whether a candidate is
+genuinely pathological:
+
+| Scenario | Recommended value |
+|---|---|
+| Tight CI budget (fast feedback) | `5`–`10` ms |
+| Standard CI | `25`–`50` ms (default: `5`) |
+| Noisy environment / low-frequency audit | `100`–`200` ms |
+
+The value should be lower than the threshold you assert in your property — the strategy uses it
+internally to identify slow candidates, not to gate the property itself.
+
+> [!TIP]
+> Start with `maxMatchMs: 5`. If you see false positives on a loaded CI machine, increase to
+> `25` or `50`. The built-in confirmation logic (3 trials, ≥ 2 hits) already guards against
+> spurious single-run timeouts.
+
+## Interpret a failure
+
+When the property fails, the counterexample output will show something like:
+
+```
+Falsified after 12 tests
+Counterexample: "aaaaaaaaaa\0"
+Shrunk from: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\0"
+```
+
+The `\0` suffix is appended by the strategy to force the trailing `$` anchor to fail — this is
+what triggers catastrophic backtracking. The shrunk string is the minimal input where the pattern
+exceeds your timing budget.
+
+To reproduce the failure manually:
+
+```csharp
+Regex r = new(@"(a+)+$", RegexOptions.None, TimeSpan.FromMilliseconds(50));
+r.IsMatch("aaaaaaaaaa\0"); // throws RegexMatchTimeoutException
+```
+
+## Verify the pattern is genuinely vulnerable
+
+Not every slow regex is catastrophically vulnerable. Check the shrunk counterexample:
+
+1. **Length** — a genuinely vulnerable pattern slows down super-linearly. If the failure
+   disappears when you double the string length (by repeating the example), it is likely a
+   coincidence.
+2. **Structure** — the shrunk string will usually look like `aaa...\0` or similar, tracing the
+   ambiguous repetition structure of the pattern.
+3. **Fix** — switch to `RegexOptions.NonBacktracking` to confirm the pattern is safe there:
+
+```csharp
+// Safe: NonBacktracking engine cannot exhibit catastrophic backtracking
+Regex safe = new(@"(a+)+$", RegexOptions.NonBacktracking);
+safe.IsMatch("aaaaaaaaaa\0"); // returns quickly
+```
+
+## Audit a regex used in production
+
+Pass a compiled `Regex` instance to share the same options:
+
+```csharp
+[GeneratedRegex(@"^([a-zA-Z0-9_]+\.)*[a-zA-Z0-9_]+$")]
+private static partial Regex HostnamePattern();
+
+[Property]
+public bool HostnamePattern_IsNotVulnerableToReDoS()
+{
+    string input = DataGen.SampleOne(
+        Generate.ReDoSHunter(HostnamePattern(), maxMatchMs: 25));
+
+    Stopwatch sw = Stopwatch.StartNew();
+    HostnamePattern().IsMatch(input);
+    sw.Stop();
+
+    return sw.ElapsedMilliseconds < 25;
+}
+```
+
+## Handle `RegexOptions.NonBacktracking`
+
+When the regex uses `RegexOptions.NonBacktracking`, `Generate.ReDoSHunter` automatically falls
+back to `Generate.Matching` with the diagnostic label `"redos:non-backtracking"`. The property
+will still run but will never find a catastrophic input — which is the correct result, since the
+NFA engine cannot exhibit catastrophic backtracking by design:
+
+```csharp
+Regex safe = new(@"(a+)+$", RegexOptions.NonBacktracking);
+Strategy<string> strategy = Generate.ReDoSHunter(safe, maxMatchMs: 5);
+
+Console.WriteLine(strategy.Label); // "redos:non-backtracking"
+```
+
+## See also
+
+- [Reference: `Generate.ReDoSHunter`](../reference/regex-strategies.md#generateredoshunter)
+- [Explanation: Why nested quantifiers cause catastrophic backtracking](../explanation/regex-catastrophic-backtracking.md)
+- [How to test a regex validator](test-regex-validator.md)

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -39,5 +39,7 @@ items:
     href: use-mcp-server.md
   - name: Test a regex validator
     href: test-regex-validator.md
+  - name: Audit a regex for catastrophic backtracking
+    href: audit-regex-for-redos.md
   - name: Troubleshoot
     href: troubleshoot.md

--- a/docs/site/articles/reference/regex-strategies.md
+++ b/docs/site/articles/reference/regex-strategies.md
@@ -138,15 +138,84 @@ are not recognised.
 
 ---
 
-## Upcoming
+## `Generate.ReDoSHunter`
 
-**`Generate.ReDoSHunter`** — adversarial timing generation for detecting catastrophic
-backtracking — is planned for v0.15.0. See [issue #366](https://github.com/kommundsen/Conjecture/issues/366).
+```csharp
+Strategy<string> Generate.ReDoSHunter(string pattern, int maxMatchMs = 5)
+Strategy<string> Generate.ReDoSHunter(Regex regex,   int maxMatchMs = 5)
+```
+
+Returns a strategy that generates adversarial strings designed to trigger catastrophic
+backtracking in `pattern` or `regex`. Use this to audit a regex for
+[ReDoS vulnerabilities](../explanation/regex-catastrophic-backtracking.md) in property-based tests.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `pattern` | `string` | — | A .NET regex pattern. Compiled and cached internally. |
+| `regex` | `Regex` | — | A pre-compiled `Regex` instance. `RegexOptions` are read from the instance. |
+| `maxMatchMs` | `int` | `5` | Internal engine-level timeout in milliseconds. Candidates that exceed this budget on ≥ 2 of 3 trials are marked as interesting, driving Conjecture's hill-climbing loop toward slower inputs. |
+
+### How it works
+
+The strategy walks the `RegexNode` AST looking for nested-quantifier sub-trees (e.g. `(a+)+`,
+`(a|aa)*`). When found, repetition-count draws for those nodes are biased toward the maximum to
+maximise the number of partial-match backtracks. A `\0` suffix is appended to each candidate to
+force trailing anchors (`$`) to fail, ensuring the engine must exhaust all backtracking paths
+rather than returning on first match.
+
+Targeting (`ctx.Target`) feeds elapsed wall-time back to Conjecture's hill-climbing loop on
+every non-timeout run, steering the engine toward progressively slower inputs. A candidate is
+only marked interesting after ≥ 2 out of 3 timed trials result in a `RegexMatchTimeoutException`
+— this guards against spurious single-run timeouts in noisy environments.
+
+IR-native shrinking (no custom `IShrinkPass` required) then minimises the byte buffer, converging
+toward the shortest string that still triggers the timeout.
+
+### Strategy labels
+
+The `Label` property reflects which code path was taken:
+
+| Label | Meaning |
+|---|---|
+| `"redos:hunter"` | Adversarial synthesis active — nested quantifiers found. |
+| `"redos:no-nested-quantifiers"` | No nested quantifiers detected; falls back to `Generate.Matching`. |
+| `"redos:non-backtracking"` | `RegexOptions.NonBacktracking` detected; falls back to `Generate.Matching`. The NFA engine cannot exhibit catastrophic backtracking by design. |
+
+### `RegexOptions` handling
+
+| Option | Behaviour |
+|---|---|
+| `NonBacktracking` | Falls back to `Generate.Matching` with label `"redos:non-backtracking"`. |
+| `Compiled` | No special handling — compiled regexes use the same backtracking engine. |
+| All others | Passed through unchanged. |
+
+### Example
+
+```csharp
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Conjecture.Core;
+using Conjecture.Regex;
+
+[Property]
+public bool UserInput_RegexIsNotVulnerableToReDoS()
+{
+    string input = DataGen.SampleOne(Generate.ReDoSHunter(@"(a+)+$", maxMatchMs: 25));
+
+    Stopwatch sw = Stopwatch.StartNew();
+    Regex.IsMatch(input, @"(a+)+$");
+    sw.Stop();
+
+    return sw.ElapsedMilliseconds < 25;
+}
+```
 
 ---
 
 ## See also
 
+- [How to audit a regex for catastrophic backtracking](../how-to/audit-regex-for-redos.md)
 - [How to test a regex validator](../how-to/test-regex-validator.md)
 - [Explanation: How Conjecture.Regex works](../explanation/regex-engine.md)
+- [Explanation: Why nested quantifiers cause catastrophic backtracking](../explanation/regex-catastrophic-backtracking.md)
 - [Reference: String strategies](string-strategies.md)


### PR DESCRIPTION
## Description

Adds documentation for `Generate.ReDoSHunter` across three Diátaxis layers:

- **How-to** (`audit-regex-for-redos.md`): step-by-step guide — writing the property, choosing `maxMatchMs`, interpreting failures, verifying genuine vulnerability, and handling `NonBacktracking`
- **Reference** (`regex-strategies.md`): replaces the "Upcoming" stub with full `Generate.ReDoSHunter` API docs — both overloads, parameter semantics, strategy labels, `RegexOptions` handling, and an example
- **Explanation** (`regex-catastrophic-backtracking.md`): why nested quantifiers and ambiguous alternation cause exponential backtracking, and how `ReDoSHunter` finds minimal pathological inputs faster than manual audit

Both `toc.yml` files updated to surface the new pages.

## Type of change

- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #392
Part of #366