### PR TITLE
[378.2] Convert classic extension-method classes to C# 14 extension blocks

### DIFF
--- a/src/Conjecture.Analyzers/CON101Analyzer.cs
+++ b/src/Conjecture.Analyzers/CON101Analyzer.cs
@@ -34,7 +34,7 @@ internal sealed class CON101Analyzer : DiagnosticAnalyzer
 
     private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context)
     {
-        var invocation = (InvocationExpressionSyntax)context.Node;
+        InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
         {
@@ -46,13 +46,7 @@ internal sealed class CON101Analyzer : DiagnosticAnalyzer
             return;
         }
 
-        SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(invocation);
-        if (symbolInfo.Symbol is not IMethodSymbol method)
-        {
-            return;
-        }
-
-        if (method.ContainingType.ToDisplayString() != "Conjecture.Core.StrategyExtensions")
+        if (!IsStrategyReceiver(context.SemanticModel, memberAccess))
         {
             return;
         }
@@ -80,6 +74,51 @@ internal sealed class CON101Analyzer : DiagnosticAnalyzer
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation()));
         }
+    }
+
+    private static bool IsStrategyReceiver(SemanticModel model, MemberAccessExpressionSyntax memberAccess)
+    {
+        ITypeSymbol? receiverType = model.GetTypeInfo(memberAccess.Expression).Type;
+        if (IsStrategyType(receiverType))
+        {
+            return true;
+        }
+
+        SymbolInfo symbolInfo = model.GetSymbolInfo(memberAccess);
+        if (symbolInfo.Symbol is IMethodSymbol sym && IsStrategyExtensionsContaining(sym.ContainingType))
+        {
+            return true;
+        }
+
+        foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
+        {
+            if (candidate is IMethodSymbol cm && IsStrategyExtensionsContaining(cm.ContainingType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsStrategyType(ITypeSymbol? type)
+    {
+        return type is INamedTypeSymbol named &&
+               named.Name == "Strategy" &&
+               named.IsGenericType &&
+               named.ContainingNamespace.ToDisplayString() == "Conjecture.Core";
+    }
+
+    private static bool IsStrategyExtensionsContaining(INamedTypeSymbol type)
+    {
+        if (type.ToDisplayString() == "Conjecture.Core.StrategyExtensions")
+        {
+            return true;
+        }
+
+        // C# 14 extension block: method's containing type is the extension group nested inside StrategyExtensions
+        return type.ContainingType is not null &&
+               type.ContainingType.ToDisplayString() == "Conjecture.Core.StrategyExtensions";
     }
 
     private static bool IsHighRejection(ExpressionSyntax body, SyntaxNodeAnalysisContext context)

--- a/src/Conjecture.Core/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Shipped.txt
@@ -34,17 +34,18 @@ Conjecture.Core.Strategy<T>
 Conjecture.Core.Strategy<T>.Label.get -> string?
 Conjecture.Core.Strategy<T>.Strategy(string? label = null) -> void
 Conjecture.Core.StrategyExtensions
-static Conjecture.Core.StrategyExtensions.Select<TSource, TResult>(this Conjecture.Core.Strategy<TSource>! source, System.Func<TSource, TResult>! selector) -> Conjecture.Core.Strategy<TResult>!
-static Conjecture.Core.StrategyExtensions.SelectMany<TSource, TResult>(this Conjecture.Core.Strategy<TSource>! source, System.Func<TSource, Conjecture.Core.Strategy<TResult>!>! selector) -> Conjecture.Core.Strategy<TResult>!
-static Conjecture.Core.StrategyExtensions.SelectMany<TSource, TCollection, TResult>(this Conjecture.Core.Strategy<TSource>! source, System.Func<TSource, Conjecture.Core.Strategy<TCollection>!>! collectionSelector, System.Func<TSource, TCollection, TResult>! resultSelector) -> Conjecture.Core.Strategy<TResult>!
-static Conjecture.Core.StrategyExtensions.Where<T>(this Conjecture.Core.Strategy<T>! source, System.Func<T, bool>! predicate) -> Conjecture.Core.Strategy<T>!
-static Conjecture.Core.StrategyExtensions.Zip<TFirst, TSecond>(this Conjecture.Core.Strategy<TFirst>! first, Conjecture.Core.Strategy<TSecond>! second) -> Conjecture.Core.Strategy<(TFirst, TSecond)>!
-static Conjecture.Core.StrategyExtensions.Zip<TFirst, TSecond, TResult>(this Conjecture.Core.Strategy<TFirst>! first, Conjecture.Core.Strategy<TSecond>! second, System.Func<TFirst, TSecond, TResult>! resultSelector) -> Conjecture.Core.Strategy<TResult>!
+Conjecture.Core.StrategyExtensions.extension<T>(Conjecture.Core.Strategy<T>!)
+Conjecture.Core.StrategyExtensions.extension<T>(Conjecture.Core.Strategy<T>!).Select<TResult>(System.Func<T, TResult>! selector) -> Conjecture.Core.Strategy<TResult>!
+Conjecture.Core.StrategyExtensions.extension<T>(Conjecture.Core.Strategy<T>!).Where(System.Func<T, bool>! predicate) -> Conjecture.Core.Strategy<T>!
+Conjecture.Core.StrategyExtensions.extension<T>(Conjecture.Core.Strategy<T>!).SelectMany<TResult>(System.Func<T, Conjecture.Core.Strategy<TResult>!>! selector) -> Conjecture.Core.Strategy<TResult>!
+Conjecture.Core.StrategyExtensions.extension<T>(Conjecture.Core.Strategy<T>!).SelectMany<TCollection, TResult>(System.Func<T, Conjecture.Core.Strategy<TCollection>!>! collectionSelector, System.Func<T, TCollection, TResult>! resultSelector) -> Conjecture.Core.Strategy<TResult>!
+Conjecture.Core.StrategyExtensions.extension<T>(Conjecture.Core.Strategy<T>!).Zip<TSecond>(Conjecture.Core.Strategy<TSecond>! second) -> Conjecture.Core.Strategy<(T, TSecond)>!
+Conjecture.Core.StrategyExtensions.extension<T>(Conjecture.Core.Strategy<T>!).Zip<TSecond, TResult>(Conjecture.Core.Strategy<TSecond>! second, System.Func<T, TSecond, TResult>! resultSelector) -> Conjecture.Core.Strategy<TResult>!
+Conjecture.Core.StrategyExtensions.extension<T>(Conjecture.Core.Strategy<T>!).WithLabel(string! label) -> Conjecture.Core.Strategy<T>!
 static Conjecture.Core.Generate.Strings(int minLength = 0, int maxLength = 20, int minCodepoint = 32, int maxCodepoint = 126, string? alphabet = null) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.Generate.Text(int minLength = 0, int maxLength = 20) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.Generate.Nullable<T>(Conjecture.Core.Strategy<T>! inner) -> Conjecture.Core.Strategy<T?>!
-static Conjecture.Core.StrategyExtensions.OrNull<T>(this Conjecture.Core.Strategy<T>! source) -> Conjecture.Core.Strategy<T?>!
-static Conjecture.Core.StrategyExtensions.WithLabel<T>(this Conjecture.Core.Strategy<T>! source, string! label) -> Conjecture.Core.Strategy<T>!
+Conjecture.Core.StrategyExtensions.extension<T>(Conjecture.Core.Strategy<T>!).OrNull() -> Conjecture.Core.Strategy<T?>!
 static Conjecture.Core.Generate.Tuples<T1, T2>(Conjecture.Core.Strategy<T1>! first, Conjecture.Core.Strategy<T2>! second) -> Conjecture.Core.Strategy<(T1, T2)>!
 static Conjecture.Core.Generate.Tuples<T1, T2, T3>(Conjecture.Core.Strategy<T1>! first, Conjecture.Core.Strategy<T2>! second, Conjecture.Core.Strategy<T3>! third) -> Conjecture.Core.Strategy<(T1, T2, T3)>!
 static Conjecture.Core.Generate.Tuples<T1, T2, T3, T4>(Conjecture.Core.Strategy<T1>! first, Conjecture.Core.Strategy<T2>! second, Conjecture.Core.Strategy<T3>! third, Conjecture.Core.Strategy<T4>! fourth) -> Conjecture.Core.Strategy<(T1, T2, T3, T4)>!

--- a/src/Conjecture.Core/StrategyExtensions.cs
+++ b/src/Conjecture.Core/StrategyExtensions.cs
@@ -11,87 +11,84 @@ namespace Conjecture.Core;
 /// <summary>LINQ-style extension methods for composing strategies.</summary>
 public static class StrategyExtensions
 {
-    /// <summary>Projects each generated value through <paramref name="selector"/>.</summary>
-    public static Strategy<TResult> Select<TSource, TResult>(
-        this Strategy<TSource> source, Func<TSource, TResult> selector)
+    extension<T>(Strategy<T> source)
     {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(selector);
-        return new SelectStrategy<TSource, TResult>(source, selector);
+        /// <summary>Projects each generated value through <paramref name="selector"/>.</summary>
+        public Strategy<TResult> Select<TResult>(Func<T, TResult> selector)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(selector);
+            return new SelectStrategy<T, TResult>(source, selector);
+        }
+
+        /// <summary>Filters generated values to those satisfying <paramref name="predicate"/>.</summary>
+        public Strategy<T> Where(Func<T, bool> predicate)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(predicate);
+            return new WhereStrategy<T>(source, predicate);
+        }
+
+        /// <summary>Projects each generated value to a strategy and flattens the result.</summary>
+        public Strategy<TResult> SelectMany<TResult>(Func<T, Strategy<TResult>> selector)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(selector);
+            return new SelectManyStrategy<T, TResult, TResult>(source, selector, (_, r) => r);
+        }
+
+        /// <summary>Projects each generated value to a strategy, flattens, and applies a result selector (enables C# query syntax).</summary>
+        public Strategy<TResult> SelectMany<TCollection, TResult>(
+            Func<T, Strategy<TCollection>> collectionSelector,
+            Func<T, TCollection, TResult> resultSelector)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(collectionSelector);
+            ArgumentNullException.ThrowIfNull(resultSelector);
+            return new SelectManyStrategy<T, TCollection, TResult>(source, collectionSelector, resultSelector);
+        }
+
+        /// <summary>Combines two strategies into a strategy of tuples.</summary>
+        public Strategy<(T, TSecond)> Zip<TSecond>(Strategy<TSecond> second)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(second);
+            return new ZipStrategy<T, TSecond, (T, TSecond)>(source, second, (a, b) => (a, b));
+        }
+
+        /// <summary>Combines two strategies using a result selector.</summary>
+        public Strategy<TResult> Zip<TSecond, TResult>(Strategy<TSecond> second, Func<T, TSecond, TResult> resultSelector)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(second);
+            ArgumentNullException.ThrowIfNull(resultSelector);
+            return new ZipStrategy<T, TSecond, TResult>(source, second, resultSelector);
+        }
+
+        /// <summary>Annotates the strategy with a label used in counterexample output.</summary>
+        public Strategy<T> WithLabel(string label)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(label);
+            return new LabeledStrategy<T>(source, label);
+        }
+
+        /// <summary>Projects each generated value through a direct generator that receives both the source value and the data stream. Internal hot-path overload — avoids per-Generate Strategy allocation.</summary>
+        internal Strategy<TResult> SelectMany<TResult>(Func<T, ConjectureData, TResult> directGenerator)
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            ArgumentNullException.ThrowIfNull(directGenerator);
+            return new SelectManyDirectStrategy<T, TResult>(source, directGenerator);
+        }
     }
 
-    /// <summary>Filters generated values to those satisfying <paramref name="predicate"/>.</summary>
-    public static Strategy<T> Where<T>(this Strategy<T> source, Func<T, bool> predicate)
+    extension<T>(Strategy<T> source) where T : struct
     {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
-        return new WhereStrategy<T>(source, predicate);
-    }
-
-    /// <summary>Projects each generated value to a strategy and flattens the result.</summary>
-    public static Strategy<TResult> SelectMany<TSource, TResult>(
-        this Strategy<TSource> source,
-        Func<TSource, Strategy<TResult>> selector)
-    {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(selector);
-        return new SelectManyStrategy<TSource, TResult, TResult>(source, selector, (_, r) => r);
-    }
-
-    /// <summary>Projects each generated value to a strategy, flattens, and applies a result selector (enables C# query syntax).</summary>
-    public static Strategy<TResult> SelectMany<TSource, TCollection, TResult>(
-        this Strategy<TSource> source,
-        Func<TSource, Strategy<TCollection>> collectionSelector,
-        Func<TSource, TCollection, TResult> resultSelector)
-    {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(collectionSelector);
-        ArgumentNullException.ThrowIfNull(resultSelector);
-        return new SelectManyStrategy<TSource, TCollection, TResult>(source, collectionSelector, resultSelector);
-    }
-
-    /// <summary>Combines two strategies into a strategy of tuples.</summary>
-    public static Strategy<(TFirst, TSecond)> Zip<TFirst, TSecond>(
-        this Strategy<TFirst> first, Strategy<TSecond> second)
-    {
-        ArgumentNullException.ThrowIfNull(first);
-        ArgumentNullException.ThrowIfNull(second);
-        return new ZipStrategy<TFirst, TSecond, (TFirst, TSecond)>(first, second, (a, b) => (a, b));
-    }
-
-    /// <summary>Combines two strategies using a result selector.</summary>
-    public static Strategy<TResult> Zip<TFirst, TSecond, TResult>(
-        this Strategy<TFirst> first, Strategy<TSecond> second, Func<TFirst, TSecond, TResult> resultSelector)
-    {
-        ArgumentNullException.ThrowIfNull(first);
-        ArgumentNullException.ThrowIfNull(second);
-        ArgumentNullException.ThrowIfNull(resultSelector);
-        return new ZipStrategy<TFirst, TSecond, TResult>(first, second, resultSelector);
-    }
-
-    /// <summary>Wraps the strategy so it may also produce null, with ~10% null probability.</summary>
-    public static Strategy<T?> OrNull<T>(this Strategy<T> source) where T : struct
-    {
-        ArgumentNullException.ThrowIfNull(source);
-        return new NullableStrategy<T>(source);
-    }
-
-    /// <summary>Annotates the strategy with a label used in counterexample output.</summary>
-    public static Strategy<T> WithLabel<T>(this Strategy<T> source, string label)
-    {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(label);
-        return new LabeledStrategy<T>(source, label);
-    }
-
-    /// <summary>Projects each generated value through a direct generator that receives both the source value and the data stream. Internal hot-path overload — avoids per-Generate Strategy allocation.</summary>
-    internal static Strategy<TResult> SelectMany<TSource, TResult>(
-        this Strategy<TSource> source,
-        Func<TSource, ConjectureData, TResult> directGenerator)
-    {
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(directGenerator);
-        return new SelectManyDirectStrategy<TSource, TResult>(source, directGenerator);
+        /// <summary>Wraps the strategy so it may also produce null, with ~10% null probability.</summary>
+        public Strategy<T?> OrNull()
+        {
+            ArgumentNullException.ThrowIfNull(source);
+            return new NullableStrategy<T>(source);
+        }
     }
 }
-

--- a/src/Conjecture.Interactive/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Interactive/PublicAPI.Shipped.txt
@@ -7,11 +7,12 @@ Conjecture.Interactive.ShrinkStep<T>.Value.init -> void
 Conjecture.Interactive.ShrinkTraceResult<T>
 Conjecture.Interactive.ShrinkTraceResult<T>.Steps.get -> System.Collections.Generic.IReadOnlyList<Conjecture.Interactive.ShrinkStep<T>>!
 Conjecture.Interactive.StrategyExtensionsInteractive
-static Conjecture.Interactive.StrategyExtensionsInteractive.Histogram<T>(this Conjecture.Core.Strategy<T>! strategy, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null) -> string!
-static Conjecture.Interactive.StrategyExtensionsInteractive.Histogram<T>(this Conjecture.Core.Strategy<T>! strategy, System.Func<T, double>! selector, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null) -> string!
-static Conjecture.Interactive.StrategyExtensionsInteractive.Preview<T>(this Conjecture.Core.Strategy<T>! strategy, int count = 20, ulong? seed = null) -> string!
-static Conjecture.Interactive.StrategyExtensionsInteractive.SampleTable<T>(this Conjecture.Core.Strategy<T>! strategy, int count = 10, ulong? seed = null) -> string!
-static Conjecture.Interactive.StrategyExtensionsInteractive.ShrinkTrace<T>(this Conjecture.Core.Strategy<T>! strategy, ulong seed, System.Func<T, bool>! failingProperty) -> Conjecture.Interactive.ShrinkTraceResult<T>!
+Conjecture.Interactive.StrategyExtensionsInteractive.extension<T>(Conjecture.Core.Strategy<T>!)
+Conjecture.Interactive.StrategyExtensionsInteractive.extension<T>(Conjecture.Core.Strategy<T>!).Preview(int count = 20, ulong? seed = null) -> string!
+Conjecture.Interactive.StrategyExtensionsInteractive.extension<T>(Conjecture.Core.Strategy<T>!).SampleTable(int count = 10, ulong? seed = null) -> string!
+Conjecture.Interactive.StrategyExtensionsInteractive.extension<T>(Conjecture.Core.Strategy<T>!).ShrinkTrace(ulong seed, System.Func<T, bool>! failingProperty) -> Conjecture.Interactive.ShrinkTraceResult<T>!
+Conjecture.Interactive.StrategyExtensionsInteractive.extension<T>(Conjecture.Core.Strategy<T>!).Histogram(System.Func<T, double>! selector, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null) -> string!
+Conjecture.Interactive.StrategyExtensionsInteractive.extension<T>(Conjecture.Core.Strategy<T>!).Histogram(int sampleSize = 1000, int bucketCount = 20, ulong? seed = null) -> string!
 Conjecture.Interactive.ShrinkTraceResult<T>.ShrinkTraceResult(System.Collections.Generic.IReadOnlyList<Conjecture.Interactive.ShrinkStep<T>>! steps, string! text) -> void
 Conjecture.Interactive.ShrinkTraceResult<T>.Text.get -> string!
 Conjecture.Interactive.TextHistogram

--- a/src/Conjecture.Interactive/StrategyExtensionsInteractive.cs
+++ b/src/Conjecture.Interactive/StrategyExtensionsInteractive.cs
@@ -17,190 +17,192 @@ public static class StrategyExtensionsInteractive
     private const int PreviewMaxCount = 100;
     private const int SampleTableMaxCount = 50;
 
-    /// <summary>Renders up to <paramref name="count"/> sampled values as a comma-separated string.</summary>
-    public static string Preview<T>(this Strategy<T> strategy, int count = 20, ulong? seed = null)
+    extension<T>(Strategy<T> strategy)
     {
-        bool capped = count > PreviewMaxCount;
-        int effective = capped ? PreviewMaxCount : count;
-        IReadOnlyList<T> samples = DataGen.Sample(strategy, effective, seed);
-
-        StringBuilder sb = new();
-        for (int i = 0; i < samples.Count; i++)
+        /// <summary>Renders up to <paramref name="count"/> sampled values as a comma-separated string.</summary>
+        public string Preview(int count = 20, ulong? seed = null)
         {
-            if (i > 0)
+            bool capped = count > PreviewMaxCount;
+            int effective = capped ? PreviewMaxCount : count;
+            IReadOnlyList<T> samples = DataGen.Sample(strategy, effective, seed);
+
+            StringBuilder sb = new();
+            for (int i = 0; i < samples.Count; i++)
             {
-                sb.Append(", ");
+                if (i > 0)
+                {
+                    sb.Append(", ");
+                }
+
+                sb.Append(samples[i]?.ToString() ?? "");
             }
 
-            sb.Append(samples[i]?.ToString() ?? "");
-        }
-
-        if (capped)
-        {
-            sb.AppendLine();
-            sb.Append("(Showing ");
-            sb.Append(PreviewMaxCount);
-            sb.Append(" values, capped from ");
-            sb.Append(count);
-            sb.Append(')');
-        }
-
-        return sb.ToString();
-    }
-
-    /// <summary>Renders up to <paramref name="count"/> sampled values in a two-column text table.</summary>
-    public static string SampleTable<T>(this Strategy<T> strategy, int count = 10, ulong? seed = null)
-    {
-        bool capped = count > SampleTableMaxCount;
-        int effective = capped ? SampleTableMaxCount : count;
-        IReadOnlyList<T> samples = DataGen.Sample(strategy, effective, seed);
-
-        // Compute column widths.
-        int indexWidth = Math.Max(1, samples.Count.ToString().Length);
-        int valueWidth = 5; // minimum "Value" header length
-        string[] values = new string[samples.Count];
-        for (int i = 0; i < samples.Count; i++)
-        {
-            values[i] = samples[i]?.ToString() ?? "";
-            if (values[i].Length > valueWidth)
+            if (capped)
             {
-                valueWidth = values[i].Length;
+                sb.AppendLine();
+                sb.Append("(Showing ");
+                sb.Append(PreviewMaxCount);
+                sb.Append(" values, capped from ");
+                sb.Append(count);
+                sb.Append(')');
             }
+
+            return sb.ToString();
         }
 
-        StringBuilder sb = new();
-        sb.Append(new string(' ', indexWidth));
-        sb.Append(" # │ Value");
-        sb.AppendLine();
-        sb.Append(new string('─', indexWidth + 2));
-        sb.Append('┼');
-        sb.Append(new string('─', valueWidth + 2));
-        for (int i = 0; i < samples.Count; i++)
+        /// <summary>Renders up to <paramref name="count"/> sampled values in a two-column text table.</summary>
+        public string SampleTable(int count = 10, ulong? seed = null)
         {
-            sb.AppendLine();
-            sb.Append(i.ToString().PadLeft(indexWidth + 2));
-            sb.Append(" │ ");
-            sb.Append(values[i]);
-        }
+            bool capped = count > SampleTableMaxCount;
+            int effective = capped ? SampleTableMaxCount : count;
+            IReadOnlyList<T> samples = DataGen.Sample(strategy, effective, seed);
 
-        if (capped)
-        {
-            sb.AppendLine();
-            sb.Append("(Showing ");
-            sb.Append(SampleTableMaxCount);
-            sb.Append(" values, capped from ");
-            sb.Append(count);
-            sb.Append(')');
-        }
-
-        return sb.ToString();
-    }
-
-    /// <summary>Runs a shrink trace for <paramref name="strategy"/> starting from <paramref name="seed"/>, recording each accepted reduction.</summary>
-    public static ShrinkTraceResult<T> ShrinkTrace<T>(
-        this Strategy<T> strategy,
-        ulong seed,
-        Func<T, bool> failingProperty)
-    {
-        SplittableRandom rng = new(seed);
-        ConjectureData initialData = ConjectureData.ForGeneration(rng.Split());
-        T initialValue = strategy.Generate(initialData);
-
-        if (!failingProperty(initialValue))
-        {
-            throw new ArgumentException("Property must fail on the generated value to produce a shrink trace.");
-        }
-
-        List<ShrinkStep<T>> steps = [new(initialValue)];
-
-        ValueTask<Status> IsInteresting(IReadOnlyList<IRNode> nodes)
-        {
-            try
+            // Compute column widths.
+            int indexWidth = Math.Max(1, samples.Count.ToString().Length);
+            int valueWidth = 5; // minimum "Value" header length
+            string[] values = new string[samples.Count];
+            for (int i = 0; i < samples.Count; i++)
             {
-                ConjectureData data = ConjectureData.ForRecord(nodes);
-                T value = strategy.Generate(data);
-                if (data.Status == Status.Overrun)
+                values[i] = samples[i]?.ToString() ?? "";
+                if (values[i].Length > valueWidth)
+                {
+                    valueWidth = values[i].Length;
+                }
+            }
+
+            StringBuilder sb = new();
+            sb.Append(new string(' ', indexWidth));
+            sb.Append(" # │ Value");
+            sb.AppendLine();
+            sb.Append(new string('─', indexWidth + 2));
+            sb.Append('┼');
+            sb.Append(new string('─', valueWidth + 2));
+            for (int i = 0; i < samples.Count; i++)
+            {
+                sb.AppendLine();
+                sb.Append(i.ToString().PadLeft(indexWidth + 2));
+                sb.Append(" │ ");
+                sb.Append(values[i]);
+            }
+
+            if (capped)
+            {
+                sb.AppendLine();
+                sb.Append("(Showing ");
+                sb.Append(SampleTableMaxCount);
+                sb.Append(" values, capped from ");
+                sb.Append(count);
+                sb.Append(')');
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>Runs a shrink trace for <paramref name="strategy"/> starting from <paramref name="seed"/>, recording each accepted reduction.</summary>
+        public ShrinkTraceResult<T> ShrinkTrace(ulong seed, Func<T, bool> failingProperty)
+        {
+            SplittableRandom rng = new(seed);
+            ConjectureData initialData = ConjectureData.ForGeneration(rng.Split());
+            T initialValue = strategy.Generate(initialData);
+
+            if (!failingProperty(initialValue))
+            {
+                throw new ArgumentException("Property must fail on the generated value to produce a shrink trace.");
+            }
+
+            List<ShrinkStep<T>> steps = [new(initialValue)];
+
+            ValueTask<Status> IsInteresting(IReadOnlyList<IRNode> nodes)
+            {
+                try
+                {
+                    ConjectureData data = ConjectureData.ForRecord(nodes);
+                    T value = strategy.Generate(data);
+                    if (data.Status == Status.Overrun)
+                    {
+                        return ValueTask.FromResult(Status.Overrun);
+                    }
+
+                    if (failingProperty(value))
+                    {
+                        steps.Add(new(value));
+                        return ValueTask.FromResult(Status.Interesting);
+                    }
+
+                    return ValueTask.FromResult(Status.Valid);
+                }
+                catch (UnsatisfiedAssumptionException)
+                {
+                    return ValueTask.FromResult(Status.Invalid);
+                }
+                catch (InvalidOperationException)
                 {
                     return ValueTask.FromResult(Status.Overrun);
                 }
+            }
 
-                if (failingProperty(value))
+            Shrinker.ShrinkAsync(initialData.IRNodes, IsInteresting).GetAwaiter().GetResult();
+
+            // Compute column widths.
+            int stepWidth = Math.Max(4, steps.Count.ToString().Length); // "Step" header
+            int valueWidth = 5; // "Value" header
+            string[] rendered = new string[steps.Count];
+            for (int i = 0; i < steps.Count; i++)
+            {
+                rendered[i] = steps[i].Value?.ToString() ?? "";
+                if (rendered[i].Length > valueWidth)
                 {
-                    steps.Add(new(value));
-                    return ValueTask.FromResult(Status.Interesting);
+                    valueWidth = rendered[i].Length;
                 }
-
-                return ValueTask.FromResult(Status.Valid);
             }
-            catch (UnsatisfiedAssumptionException)
-            {
-                return ValueTask.FromResult(Status.Invalid);
-            }
-            catch (InvalidOperationException)
-            {
-                return ValueTask.FromResult(Status.Overrun);
-            }
-        }
 
-        Shrinker.ShrinkAsync(initialData.IRNodes, IsInteresting).GetAwaiter().GetResult();
-
-        // Compute column widths.
-        int stepWidth = Math.Max(4, steps.Count.ToString().Length); // "Step" header
-        int valueWidth = 5; // "Value" header
-        string[] rendered = new string[steps.Count];
-        for (int i = 0; i < steps.Count; i++)
-        {
-            rendered[i] = steps[i].Value?.ToString() ?? "";
-            if (rendered[i].Length > valueWidth)
-            {
-                valueWidth = rendered[i].Length;
-            }
-        }
-
-        StringBuilder sb = new();
-        sb.Append("Step".PadLeft(stepWidth));
-        sb.Append(" │ Value");
-        sb.AppendLine();
-        sb.Append(new string('─', stepWidth));
-        sb.Append('┼');
-        sb.Append(new string('─', valueWidth + 2));
-        for (int i = 0; i < steps.Count; i++)
-        {
+            StringBuilder sb = new();
+            sb.Append("Step".PadLeft(stepWidth));
+            sb.Append(" │ Value");
             sb.AppendLine();
-            sb.Append(i.ToString().PadLeft(stepWidth));
-            sb.Append(" │ ");
-            sb.Append(rendered[i]);
+            sb.Append(new string('─', stepWidth));
+            sb.Append('┼');
+            sb.Append(new string('─', valueWidth + 2));
+            for (int i = 0; i < steps.Count; i++)
+            {
+                sb.AppendLine();
+                sb.Append(i.ToString().PadLeft(stepWidth));
+                sb.Append(" │ ");
+                sb.Append(rendered[i]);
+            }
+
+            return new ShrinkTraceResult<T>(steps, sb.ToString());
         }
 
-        return new ShrinkTraceResult<T>(steps, sb.ToString());
+        /// <summary>Renders a text histogram of sampled values projected by <paramref name="selector"/>.</summary>
+        public string Histogram(Func<T, double> selector, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null)
+        {
+            IReadOnlyList<T> samples = DataGen.Sample(strategy, sampleSize, seed);
+            List<double> doubles = new(samples.Count);
+            foreach (T value in samples)
+            {
+                doubles.Add(selector(value));
+            }
+
+            return TextHistogram.Render(doubles, bucketCount);
+        }
     }
 
 #pragma warning disable RS0026 // multiple overloads with optional parameters
-    /// <summary>Renders a text histogram of sampled values from <paramref name="strategy"/>.</summary>
-    public static string Histogram<T>(this Strategy<T> strategy, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null)
-        where T : IConvertible
+    extension<T>(Strategy<T> strategy) where T : IConvertible
     {
-        IReadOnlyList<T> samples = DataGen.Sample(strategy, sampleSize, seed);
-        List<double> doubles = new(samples.Count);
-        foreach (T value in samples)
+        /// <summary>Renders a text histogram of sampled values from <paramref name="strategy"/>.</summary>
+        public string Histogram(int sampleSize = 1000, int bucketCount = 20, ulong? seed = null)
         {
-            doubles.Add(Convert.ToDouble(value));
+            IReadOnlyList<T> samples = DataGen.Sample(strategy, sampleSize, seed);
+            List<double> doubles = new(samples.Count);
+            foreach (T value in samples)
+            {
+                doubles.Add(Convert.ToDouble(value));
+            }
+
+            return TextHistogram.Render(doubles, bucketCount);
         }
-
-        return TextHistogram.Render(doubles, bucketCount);
-    }
-
-    /// <summary>Renders a text histogram of sampled values projected by <paramref name="selector"/>.</summary>
-    public static string Histogram<T>(this Strategy<T> strategy, Func<T, double> selector, int sampleSize = 1000, int bucketCount = 20, ulong? seed = null)
-    {
-        IReadOnlyList<T> samples = DataGen.Sample(strategy, sampleSize, seed);
-        List<double> doubles = new(samples.Count);
-        foreach (T value in samples)
-        {
-            doubles.Add(selector(value));
-        }
-
-        return TextHistogram.Render(doubles, bucketCount);
     }
 #pragma warning restore RS0026
 }

--- a/src/Conjecture.LinqPad/PublicAPI.Shipped.txt
+++ b/src/Conjecture.LinqPad/PublicAPI.Shipped.txt
@@ -5,4 +5,5 @@ Conjecture.LinqPad.StrategyCustomMemberProvider<T>.GetNames() -> System.Collecti
 Conjecture.LinqPad.StrategyCustomMemberProvider<T>.GetTypes() -> System.Collections.Generic.IEnumerable<System.Type!>!
 Conjecture.LinqPad.StrategyCustomMemberProvider<T>.GetValues() -> System.Collections.Generic.IEnumerable<object?>!
 Conjecture.LinqPad.StrategyLinqPadExtensions
-static Conjecture.LinqPad.StrategyLinqPadExtensions.ShrinkTraceHtml<T>(this Conjecture.Core.Strategy<T>! strategy, int seed, System.Func<T, bool>! failingProperty) -> object!
+Conjecture.LinqPad.StrategyLinqPadExtensions.extension<T>(Conjecture.Core.Strategy<T>!)
+Conjecture.LinqPad.StrategyLinqPadExtensions.extension<T>(Conjecture.Core.Strategy<T>!).ShrinkTraceHtml(int seed, System.Func<T, bool>! failingProperty) -> object!

--- a/src/Conjecture.LinqPad/StrategyLinqPadExtensions.cs
+++ b/src/Conjecture.LinqPad/StrategyLinqPadExtensions.cs
@@ -14,18 +14,20 @@ namespace Conjecture.LinqPad;
 /// <summary>LINQPad extension methods for shrink trace visualisation.</summary>
 public static class StrategyLinqPadExtensions
 {
-    /// <summary>Runs a shrink trace and returns an HTML table as a LINQPad raw-HTML object.</summary>
-    public static object ShrinkTraceHtml<T>(
-        this Strategy<T> strategy, int seed, Func<T, bool> failingProperty)
+    extension<T>(Strategy<T> strategy)
     {
-        ShrinkTraceResult<T> result = StrategyExtensionsInteractive.ShrinkTrace(strategy, SeedHelpers.ToUlong(seed), failingProperty);
-        List<T> values = new(result.Steps.Count);
-        foreach (ShrinkStep<T> step in result.Steps)
+        /// <summary>Runs a shrink trace and returns an HTML table as a LINQPad raw-HTML object.</summary>
+        public object ShrinkTraceHtml(int seed, Func<T, bool> failingProperty)
         {
-            values.Add(step.Value);
-        }
+            ShrinkTraceResult<T> result = strategy.ShrinkTrace(SeedHelpers.ToUlong(seed), failingProperty);
+            List<T> values = new(result.Steps.Count);
+            foreach (ShrinkStep<T> step in result.Steps)
+            {
+                values.Add(step.Value);
+            }
 
-        string html = HtmlShrinkTrace.Render(values);
-        return Util.RawHtml(html);
+            string html = HtmlShrinkTrace.Render(values);
+            return Util.RawHtml(html);
+        }
     }
 }

--- a/src/Conjecture.TestingPlatform/ConjectureTestingPlatformExtensions.cs
+++ b/src/Conjecture.TestingPlatform/ConjectureTestingPlatformExtensions.cs
@@ -10,17 +10,18 @@ namespace Conjecture.TestingPlatform;
 /// <summary>Extension methods for registering Conjecture with the Microsoft Testing Platform.</summary>
 public static class ConjectureTestingPlatformExtensions
 {
-    /// <summary>Registers the Conjecture property-based test framework with the test application builder.</summary>
-    /// <param name="builder">The test application builder.</param>
-    /// <returns>The same <paramref name="builder"/> instance for chaining.</returns>
-    public static ITestApplicationBuilder RegisterConjectureFramework(
-        this ITestApplicationBuilder builder)
+    extension(ITestApplicationBuilder builder)
     {
-        builder.CommandLine.AddProvider(static () => new ConjectureCommandLineOptions());
-        builder.RegisterTestFramework(
-            _ => new PropertyTestFrameworkCapabilities(),
-            (_, services) => new PropertyTestFramework(services));
-        return builder;
+        /// <summary>Registers the Conjecture property-based test framework with the test application builder.</summary>
+        /// <returns>The same builder instance for chaining.</returns>
+        public ITestApplicationBuilder RegisterConjectureFramework()
+        {
+            builder.CommandLine.AddProvider(static () => new ConjectureCommandLineOptions());
+            builder.RegisterTestFramework(
+                _ => new PropertyTestFrameworkCapabilities(),
+                (_, services) => new PropertyTestFramework(services));
+            return builder;
+        }
     }
 
     /// <summary>
@@ -29,6 +30,8 @@ public static class ConjectureTestingPlatformExtensions
     /// <c>TestingPlatformBuilderHook</c> item is ignored. The <paramref name="args"/> parameter is
     /// part of the mandated signature but is not used here.
     /// </summary>
-    public static void AddExtensions(ITestApplicationBuilder builder, string[] args) =>
+    public static void AddExtensions(ITestApplicationBuilder builder, string[] args)
+    {
         builder.RegisterConjectureFramework();
+    }
 }

--- a/src/Conjecture.TestingPlatform/PublicAPI.Shipped.txt
+++ b/src/Conjecture.TestingPlatform/PublicAPI.Shipped.txt
@@ -20,5 +20,6 @@ Conjecture.TestingPlatform.PropertyAttribute.TargetingProportion.set -> void
 Conjecture.TestingPlatform.PropertyAttribute.UseDatabase.get -> bool
 Conjecture.TestingPlatform.PropertyAttribute.UseDatabase.set -> void
 Conjecture.TestingPlatform.ConjectureTestingPlatformExtensions
-static Conjecture.TestingPlatform.ConjectureTestingPlatformExtensions.RegisterConjectureFramework(this Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder) -> Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!
+Conjecture.TestingPlatform.ConjectureTestingPlatformExtensions.extension(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!)
+Conjecture.TestingPlatform.ConjectureTestingPlatformExtensions.extension(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!).RegisterConjectureFramework() -> Microsoft.Testing.Platform.Builder.ITestApplicationBuilder!
 static Conjecture.TestingPlatform.ConjectureTestingPlatformExtensions.AddExtensions(Microsoft.Testing.Platform.Builder.ITestApplicationBuilder! builder, string![]! args) -> void


### PR DESCRIPTION
## Description

Converts 4 files from classic `this`-parameter extension methods to C# 14 `extension(...)` block syntax, bringing them in line with `StrategyExtensionProperties` and `DateTimeOffsetExtensions` which already use the new syntax.

Files converted:
- `StrategyExtensions` — core LINQ combinators (`Select`, `Where`, `SelectMany`, `Zip`, `OrNull`, `WithLabel`)
- `StrategyExtensionsInteractive` — `Preview`, `SampleTable`, `ShrinkTrace`, `Histogram`
- `StrategyLinqPadExtensions` — `ShrinkTraceHtml`
- `ConjectureTestingPlatformExtensions` — `RegisterConjectureFramework`

No behavior changes. All call sites unchanged.

## Type of change

- [x] Refactor (no behavior change)

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #375
Part of #378