### PR TITLE
[378.3] Add params ReadOnlySpan overload to Generate.OneOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+### Added
+
+**Core** (`Conjecture.Core`)
+- `Generate.OneOf<T>(params ReadOnlySpan<Strategy<T>> strategies)` — span overload that avoids heap-array allocation at inline call sites (`Generate.OneOf(a, b, c)`). The array overload is retained for ABI compatibility and collection-passed call sites.
+
 ### Changed
 
 **Time** (`Conjecture.Time`)

--- a/src/Conjecture.Benchmarks/OneOfBenchmarks.cs
+++ b/src/Conjecture.Benchmarks/OneOfBenchmarks.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using BenchmarkDotNet.Attributes;
+
+using Conjecture.Core;
+
+namespace Conjecture.Benchmarks;
+
+/// <summary>Compares params-array vs params-span call sites for Generate.OneOf.</summary>
+[MemoryDiagnoser]
+[SimpleJob]
+public class OneOfBenchmarks
+{
+    private static readonly Strategy<int> S1 = Generate.Just(1);
+    private static readonly Strategy<int> S2 = Generate.Just(2);
+    private static readonly Strategy<int> S3 = Generate.Just(3);
+    private static readonly Strategy<int> S4 = Generate.Just(4);
+    private static readonly Strategy<int> S5 = Generate.Just(5);
+    private static readonly Strategy<int> S6 = Generate.Just(6);
+    private static readonly Strategy<int>[] ArrayOf3 = [S1, S2, S3];
+    private static readonly Strategy<int>[] ArrayOf6 = [S1, S2, S3, S4, S5, S6];
+
+    [Params(2, 3, 6)]
+    public int ArgCount { get; set; }
+
+    [Benchmark(Baseline = true)]
+    public Strategy<int> ArrayOverload()
+    {
+        return ArgCount switch
+        {
+            2 => Generate.OneOf(ArrayOf3[..2]),
+            3 => Generate.OneOf(ArrayOf3),
+            _ => Generate.OneOf(ArrayOf6),
+        };
+    }
+
+    [Benchmark]
+    public Strategy<int> SpanOverload()
+    {
+        return ArgCount switch
+        {
+            2 => Generate.OneOf(S1, S2),
+            3 => Generate.OneOf(S1, S2, S3),
+            _ => Generate.OneOf(S1, S2, S3, S4, S5, S6),
+        };
+    }
+}

--- a/src/Conjecture.Core.Tests/Strategies/OneOfStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/OneOfStrategyTests.cs
@@ -58,4 +58,74 @@ public class OneOfStrategyTests
     {
         Assert.Throws<ArgumentException>(() => Generate.OneOf<int>());
     }
+
+    [Fact]
+    public void OneOf_SpanOverload_ReturnsOnlyValuesFromSuppliedStrategies()
+    {
+        Strategy<int> strategy = Generate.OneOf(Generate.Just(1), Generate.Just(2));
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 50; i++)
+        {
+            int value = strategy.Generate(data);
+            Assert.True(value == 1 || value == 2, $"Unexpected value: {value}");
+        }
+    }
+
+    [Fact]
+    public void OneOf_SpanOverload_ThreeArgs_CoversAllBranches()
+    {
+        Strategy<int> strategy = Generate.OneOf(Generate.Just(1), Generate.Just(2), Generate.Just(3));
+        ConjectureData data = MakeData();
+        HashSet<int> seen = [];
+
+        for (int i = 0; i < 1000; i++)
+        {
+            seen.Add(strategy.Generate(data));
+        }
+
+        Assert.Contains(1, seen);
+        Assert.Contains(2, seen);
+        Assert.Contains(3, seen);
+    }
+
+    [Fact]
+    public void OneOf_SpanOverload_SixArgs_CoversAllBranches()
+    {
+        Strategy<int> strategy = Generate.OneOf(
+            Generate.Just(1),
+            Generate.Just(2),
+            Generate.Just(3),
+            Generate.Just(4),
+            Generate.Just(5),
+            Generate.Just(6));
+        ConjectureData data = MakeData();
+        HashSet<int> seen = [];
+
+        for (int i = 0; i < 1000; i++)
+        {
+            seen.Add(strategy.Generate(data));
+        }
+
+        for (int expected = 1; expected <= 6; expected++)
+        {
+            Assert.Contains(expected, seen);
+        }
+    }
+
+    [Fact]
+    public void OneOf_SpanOverload_EmptySpan_ThrowsArgumentException()
+    {
+        ReadOnlySpan<Strategy<int>> span = ReadOnlySpan<Strategy<int>>.Empty;
+        bool threw = false;
+        try
+        {
+            Generate.OneOf(span);
+        }
+        catch (ArgumentException)
+        {
+            threw = true;
+        }
+        Assert.True(threw, "Expected ArgumentException for empty span.");
+    }
 }

--- a/src/Conjecture.Core/Gen.cs
+++ b/src/Conjecture.Core/Gen.cs
@@ -42,6 +42,18 @@ public static class Generate
         return new OneOfStrategy<T>(strategies);
     }
 
+    /// <summary>Returns a strategy that picks uniformly among <paramref name="strategies"/>. Stack-allocated call sites avoid heap-array allocation.</summary>
+    public static Strategy<T> OneOf<T>(params ReadOnlySpan<Strategy<T>> strategies)
+    {
+        if (strategies.IsEmpty)
+        {
+            throw new ArgumentException("At least one strategy is required.", nameof(strategies));
+        }
+
+        Strategy<T>[] copy = strategies.ToArray();
+        return new OneOfStrategy<T>(copy);
+    }
+
     /// <summary>Returns a strategy that picks uniformly from <paramref name="values"/>.</summary>
     public static Strategy<T> SampledFrom<T>(IReadOnlyList<T> values)
     {

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Conjecture.Core.Generate.OneOf<T>(params System.ReadOnlySpan<Conjecture.Core.Strategy<T>!> strategies) -> Conjecture.Core.Strategy<T>!


### PR DESCRIPTION
## Description

Adds a `params ReadOnlySpan<Strategy<T>>` overload to `Generate.OneOf<T>`. The compiler prefers the span overload for inline call sites (`Generate.OneOf(a, b, c)`), avoiding the heap array that `params Strategy<T>[]` allocates. The array overload is retained unchanged for ABI compatibility and collection-passed call sites.

The span overload copies via `ToArray()` before passing to `OneOfStrategy<T>`, which stores the array by reference for shrinking.

`OneOfBenchmarks` is added to verify the allocation win at 2, 3, and 6 inline args.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #376
Part of #378