### PR TITLE
[378.4] C# 14 polish pass: index syntax and collection expressions

### DIFF
--- a/src/Conjecture.Interactive.Tests/StrategyExtensionsInteractiveShrinkTraceTests.cs
+++ b/src/Conjecture.Interactive.Tests/StrategyExtensionsInteractiveShrinkTraceTests.cs
@@ -40,7 +40,7 @@ public class StrategyExtensionsInteractiveShrinkTraceTests
 
         ShrinkTraceResult<int> result = strategy.ShrinkTrace(seed, static x => x >= 10);
 
-        int finalValue = result.Steps[result.Steps.Count - 1].Value;
+        int finalValue = result.Steps[^1].Value;
         Assert.True(finalValue >= 10, $"Final shrunk value {finalValue} should satisfy the failing property (>= 10).");
     }
 


### PR DESCRIPTION
## Description

C# 14 polish pass — mechanical sweep for index-from-end syntax (`^1`) and collection expression opportunities.

Only one site qualified: `result.Steps[result.Steps.Count - 1]` in the shrink-trace test, now `result.Steps[^1]`. All production-code candidates listed in the issue use `Length - 1` as arithmetic arguments to range methods (not array indexers), so they're correctly excluded. The one `Array.Empty<int>()` test site can't use `[]` because the generic type isn't inferable from context.

No production code changed; no behaviour change.

## Type of change

- [x] Refactor (no behavior change)

## Checklist

- [x] `dotnet test src/` passes
- [x] Follows `.editorconfig` code style

Closes #377
Part of #378