### PR TITLE
[293.1] Scaffold: Conjecture.Money project and test project

### DIFF
--- a/src/Conjecture.Money.Tests/Conjecture.Money.Tests.csproj
+++ b/src/Conjecture.Money.Tests/Conjecture.Money.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Money\Conjecture.Money.csproj" />
+    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.Money/Conjecture.Money.csproj
+++ b/src/Conjecture.Money/Conjecture.Money.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Conjecture.Money.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.Money/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Money/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.Money/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Money/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.Money/README.md
+++ b/src/Conjecture.Money/README.md
@@ -1,0 +1,39 @@
+# Conjecture.Money
+
+Monetary strategies for [Conjecture.NET](https://github.com/kommundsen/Conjecture) property-based testing. Provides ISO 4217 currency codes, decimal amount generation, and rounding mode strategies for deterministic financial tests.
+
+## Install
+
+```
+dotnet add package Conjecture.Money
+```
+
+## Usage
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Money;
+
+// Generate valid ISO 4217 currency codes
+Strategy<string> currencies = Generate.Iso4217Codes();
+
+// Generate monetary amounts for a given currency
+Strategy<decimal> amounts = Generate.Amounts(min: 0m, max: 1_000_000m, scale: 2);
+
+// Generate rounding modes
+Strategy<MidpointRounding> rounding = Generate.RoundingModes();
+```
+
+## API
+
+| Method | Returns | Description |
+|---|---|---|
+| `Generate.Iso4217Codes()` | `Strategy<string>` | Active ISO 4217 alphabetic currency codes, shrinks toward `"USD"` |
+| `Generate.Amounts(min, max, scale)` | `Strategy<decimal>` | Scaled decimal amounts within bounds |
+| `Generate.Decimal(min, max, scale)` | `Strategy<decimal>` | General-purpose scaled decimal generation |
+| `Generate.RoundingModes()` | `Strategy<MidpointRounding>` | All `MidpointRounding` enum values |
+
+## Links
+
+- [GitHub](https://github.com/kommundsen/Conjecture)
+- [License](https://github.com/kommundsen/Conjecture/blob/main/LICENSE-MIT.txt)

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -37,4 +37,6 @@
   <Project Path="Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj" />
   <Project Path="Conjecture.FSharp.Expecto/Conjecture.FSharp.Expecto.fsproj" />
   <Project Path="Conjecture.FSharp.Expecto.Tests/Conjecture.FSharp.Expecto.Tests.fsproj" />
+  <Project Path="Conjecture.Money/Conjecture.Money.csproj" />
+  <Project Path="Conjecture.Money.Tests/Conjecture.Money.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
## Description

Scaffolds the `Conjecture.Money` satellite package following the `Conjecture.Regex` / `Conjecture.Time` template:

- `Conjecture.Money.csproj` — `net10.0`, `Conjecture.Core` reference, `PublicApiAnalyzers`, `InternalsVisibleTo` for tests, `README.md` packed
- `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` — empty baselines (`#nullable enable` only)
- `README.md` — package description with API table
- `Conjecture.Money.Tests.csproj` — references `Conjecture.Money` and `Conjecture.Xunit`
- Both projects added to `Conjecture.slnx`

Build is clean (`dotnet build src/` — 0 errors, 0 warnings).

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] Follows `.editorconfig` code style

Closes #404
Part of #293