### PR TITLE
[293.2] DecimalStrategy + Generate.Decimal(): scaled decimal generation

### DIFF
--- a/src/Conjecture.Money.Tests/MoneyGenerateExtensionsTests.cs
+++ b/src/Conjecture.Money.Tests/MoneyGenerateExtensionsTests.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Money;
+
+namespace Conjecture.Money.Tests;
+
+public class MoneyGenerateExtensionsTests
+{
+    [Fact]
+    public void Decimal_GeneratedValuesAreWithinBounds()
+    {
+        decimal min = -1000m;
+        decimal max = 1000m;
+        Strategy<decimal> strategy = Generate.Decimal(min, max);
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 100, seed: 42UL);
+
+        Assert.All(samples, v => Assert.InRange(v, min, max));
+    }
+
+    [Fact]
+    public void Decimal_Scale2_AllValuesHaveAtMostTwoDecimalPlaces()
+    {
+        Strategy<decimal> strategy = Generate.Decimal(0m, 100m, scale: 2);
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 100, seed: 1UL);
+
+        Assert.All(samples, v =>
+        {
+            int actualScale = (decimal.GetBits(v)[3] >> 16) & 0x1F;
+            Assert.True(actualScale <= 2, $"Value {v} has scale {actualScale}, expected <= 2");
+        });
+    }
+
+    [Fact]
+    public void Decimal_Scale0_AllValuesAreWholeNumbers()
+    {
+        Strategy<decimal> strategy = Generate.Decimal(0m, 1000m, scale: 0);
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 100, seed: 2UL);
+
+        Assert.All(samples, v => Assert.Equal(Math.Truncate(v), v));
+    }
+
+    [Fact]
+    public void Decimal_MinEqualsMax_AlwaysReturnsThatValue()
+    {
+        Strategy<decimal> strategy = Generate.Decimal(42.5m, 42.5m);
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 20, seed: 3UL);
+
+        Assert.All(samples, v => Assert.Equal(42.5m, v));
+    }
+
+    [Fact]
+    public void Decimal_DefaultScale_ValuesSpanFullRange()
+    {
+        Strategy<decimal> strategy = Generate.Decimal(-1000m, 1000m);
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 1000, seed: 4UL);
+
+        bool anyMoreThanTwoPlaces = samples.Any(v => ((decimal.GetBits(v)[3] >> 16) & 0x1F) > 2);
+        Assert.True(anyMoreThanTwoPlaces, "Expected at least one value with more than 2 decimal places when no scale is specified");
+    }
+
+    [Fact]
+    public void Decimal_AllSampledValuesAreWithinBoundsForNarrowRange()
+    {
+        decimal min = 10m;
+        decimal max = 10.01m;
+        Strategy<decimal> strategy = Generate.Decimal(min, max);
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 50, seed: 5UL);
+
+        Assert.All(samples, v => Assert.InRange(v, min, max));
+    }
+}

--- a/src/Conjecture.Money/Internal/DecimalStrategy.cs
+++ b/src/Conjecture.Money/Internal/DecimalStrategy.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+namespace Conjecture.Money.Internal;
+
+internal static class DecimalStrategy
+{
+    private const int DefaultScale = 6;
+
+    internal static Strategy<decimal> Create(decimal min, decimal max, int? scale)
+    {
+        int effectiveScale = scale ?? DefaultScale;
+        decimal multiplier = DecimalPow10(effectiveScale);
+        decimal scaledMin = Math.Truncate(min * multiplier);
+        decimal scaledMax = Math.Truncate(max * multiplier);
+
+        if (scaledMin > scaledMax)
+        {
+            scaledMax = scaledMin;
+        }
+
+        if (scaledMin < (decimal)long.MinValue || scaledMax > (decimal)long.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(min),
+                "The combination of min, max, and scale produces a range that exceeds the supported precision. Reduce the range or scale.");
+        }
+
+        long iMin = (long)scaledMin;
+        long iMax = (long)scaledMax;
+        Strategy<long> inner = Generate.Integers<long>(iMin, iMax);
+
+        return Generate.Compose<decimal>(ctx =>
+        {
+            long raw = ctx.Generate(inner);
+            decimal result = (decimal)raw / multiplier;
+
+            return scale.HasValue
+                ? Math.Round(result, scale.Value, MidpointRounding.AwayFromZero)
+                : result;
+        });
+    }
+
+    private static decimal DecimalPow10(int exponent)
+    {
+        decimal result = 1m;
+        for (int i = 0; i < exponent; i++)
+        {
+            result *= 10m;
+        }
+
+        return result;
+    }
+}

--- a/src/Conjecture.Money/MoneyGenerateExtensions.cs
+++ b/src/Conjecture.Money/MoneyGenerateExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Money.Internal;
+
+namespace Conjecture.Core;
+
+/// <summary>Extension methods on <see cref="Generate"/> for monetary value generation.</summary>
+public static class MoneyGenerateExtensions
+{
+    extension(Generate)
+    {
+        /// <summary>Returns a strategy that generates <see cref="decimal"/> values within [<paramref name="min"/>, <paramref name="max"/>], optionally rounded to <paramref name="scale"/> decimal places.</summary>
+        public static Strategy<decimal> Decimal(
+            decimal min,
+            decimal max,
+            int? scale = null)
+        {
+            if (min > max)
+            {
+                throw new ArgumentException("min must be less than or equal to max.", nameof(min));
+            }
+
+            if (scale is < 0 or > 28)
+            {
+                throw new ArgumentOutOfRangeException(nameof(scale), scale, "scale must be between 0 and 28.");
+            }
+
+            return DecimalStrategy.Create(min, max, scale);
+        }
+    }
+}

--- a/src/Conjecture.Money/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Money/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Conjecture.Core.MoneyGenerateExtensions
+Conjecture.Core.MoneyGenerateExtensions.extension(Conjecture.Core.Generate!)
+static Conjecture.Core.MoneyGenerateExtensions.extension(Conjecture.Core.Generate!).Decimal(decimal min, decimal max, int? scale = null) -> Conjecture.Core.Strategy<decimal>!


### PR DESCRIPTION
## Description

Adds `Generate.Decimal(min, max, scale?)` to `Conjecture.Money` via a C# 14 `extension(Generate)` block in `Conjecture.Core` namespace.

`DecimalStrategy` maps the decimal range to a `long` integer domain by multiplying by `10^scale`, draws from `Generate.Integers<long>`, then divides back — giving `NumericAwareShrinkPass` free shrinking with no custom pass required.

Key design choices:
- `DecimalPow10` uses a pure `decimal` loop instead of `Math.Pow` to avoid double-precision loss for scale ≥ 16
- Overflow guard: throws `ArgumentOutOfRangeException` when the scaled range exceeds `long` bounds, with a descriptive message
- Default scale of 6 when `null` gives 6 decimal places of precision

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #405
Part of #293