### PR TITLE
[293.4] Adds Iso4217Codes(), Amounts(), and RoundingModes() to MoneyGenerateExtensions

### DIFF
--- a/src/Conjecture.Money.Tests/MoneyGenerateTests.cs
+++ b/src/Conjecture.Money.Tests/MoneyGenerateTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Money.Internal;
+
+namespace Conjecture.Money.Tests;
+
+public class MoneyGenerateTests
+{
+    [Fact]
+    public void Iso4217Codes_NeverProducesUnknownCode()
+    {
+        Strategy<string> strategy = Generate.Iso4217Codes();
+        IReadOnlyList<string> samples = DataGen.Sample(strategy, count: 500, seed: 10UL);
+
+        Assert.All(samples, code =>
+            Assert.True(Iso4217Data.DecimalPlacesByCurrency.ContainsKey(code),
+                $"Code '{code}' is not in Iso4217Data"));
+    }
+
+    [Fact]
+    public void Amounts_Jpy_AlwaysProducesWholeNumbers()
+    {
+        Strategy<decimal> strategy = Generate.Amounts("JPY");
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 200, seed: 20UL);
+
+        Assert.All(samples, v =>
+            Assert.True(v % 1m == 0m, $"Value {v} is not a whole number"));
+    }
+
+    [Fact]
+    public void Amounts_Usd_AlwaysProducesAtMostTwoDecimalPlaces()
+    {
+        Strategy<decimal> strategy = Generate.Amounts("USD");
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 200, seed: 30UL);
+
+        Assert.All(samples, v =>
+            Assert.True(Math.Round(v, 2) == v,
+                $"Value {v} has more than 2 decimal places"));
+    }
+
+    [Fact]
+    public void Amounts_Bhd_AlwaysProducesAtMostThreeDecimalPlaces()
+    {
+        Strategy<decimal> strategy = Generate.Amounts("BHD");
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 200, seed: 40UL);
+
+        Assert.All(samples, v =>
+            Assert.True(Math.Round(v, 3) == v,
+                $"Value {v} has more than 3 decimal places"));
+    }
+
+    [Fact]
+    public void Amounts_WithMinMax_StaysWithinBounds()
+    {
+        decimal min = 1m;
+        decimal max = 5m;
+        Strategy<decimal> strategy = Generate.Amounts("USD", min: min, max: max);
+        IReadOnlyList<decimal> samples = DataGen.Sample(strategy, count: 200, seed: 50UL);
+
+        Assert.All(samples, v => Assert.InRange(v, min, max));
+    }
+
+    [Fact]
+    public void RoundingModes_ProducesEveryMidpointRoundingValueEventually()
+    {
+        Strategy<MidpointRounding> strategy = Generate.RoundingModes();
+        IReadOnlyList<MidpointRounding> samples = DataGen.Sample(strategy, count: 500, seed: 60UL);
+
+        HashSet<MidpointRounding> seen = [.. samples];
+        MidpointRounding[] allValues = Enum.GetValues<MidpointRounding>();
+
+        Assert.All(allValues, mode =>
+            Assert.Contains(mode, seen));
+    }
+
+    [Fact]
+    public void Amounts_UnknownCurrencyCode_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => Generate.Amounts("XYZ"));
+    }
+}

--- a/src/Conjecture.Money/MoneyGenerateExtensions.cs
+++ b/src/Conjecture.Money/MoneyGenerateExtensions.cs
@@ -28,5 +28,28 @@ public static class MoneyGenerateExtensions
 
             return DecimalStrategy.Create(min, max, scale);
         }
+
+        /// <summary>Returns a strategy that samples uniformly from all active ISO 4217 currency codes.</summary>
+        public static Strategy<string> Iso4217Codes()
+        {
+            return Generate.SampledFrom(Iso4217Data.DecimalPlacesByCurrency.Keys.ToArray());
+        }
+
+        /// <summary>Returns a strategy that generates a decimal amount for <paramref name="currencyCode"/> within [<paramref name="min"/>, <paramref name="max"/>].</summary>
+        public static Strategy<decimal> Amounts(string currencyCode, decimal min = 0m, decimal max = 10_000m)
+        {
+            if (!Iso4217Data.DecimalPlacesByCurrency.TryGetValue(currencyCode, out int scale))
+            {
+                throw new ArgumentException($"Unknown ISO 4217 currency code: '{currencyCode}'.", nameof(currencyCode));
+            }
+
+            return DecimalStrategy.Create(min, max, scale);
+        }
+
+        /// <summary>Returns a strategy that samples uniformly from all <see cref="MidpointRounding"/> values.</summary>
+        public static Strategy<MidpointRounding> RoundingModes()
+        {
+            return Generate.Enums<MidpointRounding>();
+        }
     }
 }

--- a/src/Conjecture.Money/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Money/PublicAPI.Unshipped.txt
@@ -2,3 +2,6 @@
 Conjecture.Core.MoneyGenerateExtensions
 Conjecture.Core.MoneyGenerateExtensions.extension(Conjecture.Core.Generate!)
 static Conjecture.Core.MoneyGenerateExtensions.extension(Conjecture.Core.Generate!).Decimal(decimal min, decimal max, int? scale = null) -> Conjecture.Core.Strategy<decimal>!
+static Conjecture.Core.MoneyGenerateExtensions.extension(Conjecture.Core.Generate!).Iso4217Codes() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Core.MoneyGenerateExtensions.extension(Conjecture.Core.Generate!).Amounts(string! currencyCode, decimal min = 0, decimal max = 10000) -> Conjecture.Core.Strategy<decimal>!
+static Conjecture.Core.MoneyGenerateExtensions.extension(Conjecture.Core.Generate!).RoundingModes() -> Conjecture.Core.Strategy<System.MidpointRounding>!


### PR DESCRIPTION
## Description

Adds three factory methods to the `extension(Generate)` block in `MoneyGenerateExtensions`:

- `Generate.Iso4217Codes()` — samples uniformly from all 141 active ISO 4217 alphabetic currency codes
- `Generate.Amounts(currencyCode, min, max)` — generates scaled decimal amounts using the currency's ISO 4217 minor unit; throws `ArgumentException` for unknown codes
- `Generate.RoundingModes()` — samples uniformly from all `MidpointRounding` enum values

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #407
Part of #293