### PR TITLE
[293.5] Adds Conjecture.Money strategy suggestions to suggest-strategy MCP tool

### DIFF
--- a/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
+++ b/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
@@ -165,4 +165,61 @@ public class StrategyToolsTests
         string result = StrategyTools.SuggestForType(typeName);
         Assert.Contains("ReDoSHunter", result);
     }
+
+    [Fact]
+    public void SuggestForType_Decimal_ContainsGenerateDecimal()
+    {
+        string result = StrategyTools.SuggestForType("decimal");
+        Assert.Contains("Generate.Decimal(", result);
+    }
+
+    [Fact]
+    public void SuggestForType_Decimal_MentionsConjectureMoney()
+    {
+        string result = StrategyTools.SuggestForType("decimal");
+        Assert.Contains("Conjecture.Money", result);
+    }
+
+    [Theory]
+    [InlineData("currency")]
+    [InlineData("currencies")]
+    [InlineData("currencyCode")]
+    [InlineData("ISO4217")]
+    [InlineData("ISO 4217")]
+    public void SuggestForType_CurrencyKeyword_ContainsIso4217Codes(string typeName)
+    {
+        string result = StrategyTools.SuggestForType(typeName);
+        Assert.Contains("Generate.Iso4217Codes()", result);
+    }
+
+    [Fact]
+    public void SuggestForType_CurrencyKeyword_ContainsAmounts()
+    {
+        string result = StrategyTools.SuggestForType("currency");
+        Assert.Contains("Generate.Amounts(", result);
+    }
+
+    [Fact]
+    public void SuggestForType_MidpointRounding_ContainsRoundingModes()
+    {
+        string result = StrategyTools.SuggestForType("MidpointRounding");
+        Assert.Contains("Generate.RoundingModes()", result);
+    }
+
+    [Theory]
+    [InlineData("money")]
+    [InlineData("amount")]
+    [InlineData("price")]
+    public void SuggestForType_MoneyKeyword_ContainsAmounts(string typeName)
+    {
+        string result = StrategyTools.SuggestForType(typeName);
+        Assert.Contains("Generate.Amounts(", result);
+    }
+
+    [Fact]
+    public void SuggestForType_RoundingKeyword_ContainsRoundingModes()
+    {
+        string result = StrategyTools.SuggestForType("rounding");
+        Assert.Contains("Generate.RoundingModes()", result);
+    }
 }

--- a/src/Conjecture.Mcp/Tools/StrategyTools.cs
+++ b/src/Conjecture.Mcp/Tools/StrategyTools.cs
@@ -164,6 +164,70 @@ internal static class StrategyTools
             Add the NuGet package: `Conjecture.Regex`
             """,
 
+            "decimal" =>
+                """
+            Use `Generate.Decimal(min, max, scale)` for scaled decimal values:
+            ```csharp
+            Generate.Decimal(min: 0m, max: 1000m, scale: 2)
+            // → Strategy<decimal> with at most 2 decimal places
+            ```
+
+            For currency amounts, use the `Conjecture.Money` package:
+            ```csharp
+            using Conjecture.Money;
+
+            Generate.Amounts("USD")
+            // → Strategy<decimal> of valid currency amounts in USD
+            ```
+
+            Add the NuGet package: `Conjecture.Money`
+            """,
+
+            "currency" or "currencies" or "currencyCode" or "ISO4217" or "iso4217" or "ISO 4217" =>
+                """
+            Use `Generate.Iso4217Codes()` to sample currency codes, and `Generate.Amounts(currencyCode)` for amounts:
+            ```csharp
+            using Conjecture.Money;
+
+            Generate.Iso4217Codes()
+            // → Strategy<string> of ISO 4217 currency codes, e.g. "USD", "EUR", "GBP"
+
+            Generate.Amounts("USD")
+            // → Strategy<decimal> of valid currency amounts for the given currency code
+            ```
+
+            Add the NuGet package: `Conjecture.Money`
+            """,
+
+            "MidpointRounding" or "rounding" =>
+                """
+            Use `Generate.RoundingModes()` to sample `MidpointRounding` values:
+            ```csharp
+            using Conjecture.Money;
+
+            Generate.RoundingModes()
+            // → Strategy<MidpointRounding>
+            ```
+
+            Add the NuGet package: `Conjecture.Money`
+            """,
+
+            "money" or "amount" or "price" =>
+                """
+            Use `Generate.Amounts(currencyCode)` from the `Conjecture.Money` package:
+            ```csharp
+            using Conjecture.Money;
+
+            Generate.Amounts("USD")
+            // → Strategy<decimal> of valid currency amounts in USD
+
+            Generate.Iso4217Codes()
+            // → Strategy<string> of ISO 4217 currency codes if you need to vary the currency
+            ```
+
+            Add the NuGet package: `Conjecture.Money`
+            """,
+
             _ when typeName.StartsWith("List<", StringComparison.Ordinal) =>
                 SuggestList(InnerType(typeName)),
 


### PR DESCRIPTION
## Description

Updates the `suggest-strategy` MCP tool to recommend `Conjecture.Money` strategies when the user's context involves money, currency, or decimal arithmetic.

New keyword handlers in `StrategyTools.SuggestForType`:
- `"decimal"` → suggests `Generate.Decimal()` and cross-references `Conjecture.Money`
- `"currency"`, `"currencies"`, `"currencyCode"`, `"ISO4217"`, `"ISO 4217"`, `"iso4217"` → suggests `Generate.Iso4217Codes()` and `Generate.Amounts()`
- `"money"`, `"amount"`, `"price"` → suggests `Generate.Amounts()`
- `"MidpointRounding"`, `"rounding"` → suggests `Generate.RoundingModes()`

All suggestions include the `using Conjecture.Money;` import hint.

## Type of change

- [x] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #408
Part of #293