### PR TITLE
[293.6] Documents Conjecture.Money how-to, reference, and explanation

### DIFF
--- a/docs/site/articles/explanation/money-decimal-arithmetic.md
+++ b/docs/site/articles/explanation/money-decimal-arithmetic.md
@@ -1,0 +1,52 @@
+# Why Conjecture.Money uses decimal arithmetic
+
+This page explains three design choices in `Conjecture.Money`: why `decimal` instead of `double`, why an embedded ISO 4217 snapshot instead of runtime discovery, and how shrinking works for money properties.
+
+## Why `decimal` instead of `double` for money testing
+
+`double` is a binary floating-point type. Binary fractions cannot represent most decimal fractions exactly: `0.1 + 0.2` evaluates to `0.30000000000000004` in binary floating-point arithmetic. A property that tests `tax == gross * 0.2m` would fail spuriously if `gross` were a `double` — not because the business logic is wrong, but because the arithmetic model is wrong.
+
+`decimal` is a decimal floating-point type (base 10, 28 significant digits). `0.1m + 0.2m` is exactly `0.3m`. This makes `decimal` the natural choice for money tests:
+
+- Generated amounts have exact decimal representations.
+- Arithmetic on amounts produces exact decimal results.
+- Shrinking can target exact representable values (e.g. `0.05m` for a 5-cent edge case) rather than the nearest binary approximation.
+
+The practical difference: a counterexample shrunk to `0.10m` is immediately actionable. The same counterexample expressed as `0.1000000000000000055511151231257827021181583404541015625` is not.
+
+## Why an embedded ISO 4217 snapshot
+
+An alternative design would query a live ISO 4217 source — a bundled XML file, a NuGet metadata package, or an HTTP endpoint — at runtime. Each option has a failure mode that is unacceptable in a testing library:
+
+| Source | Failure mode |
+|---|---|
+| Bundled XML (separate asset) | Breaks when the asset is stripped by publish trimming or embedding is misconfigured |
+| NuGet metadata package | Version skew: the metadata package and the strategy package may disagree on the code list |
+| HTTP endpoint | Tests fail in offline environments (CI, air-gapped, developer laptop on a plane) |
+
+The embedded snapshot approach means:
+- **Determinism.** The same snapshot is used in every test run, on every machine, in every CI environment. A property that was green yesterday is green today even if the ISO committee added or removed a code overnight.
+- **No runtime dependencies.** No file I/O, no HTTP, no separate asset file.
+- **Fast.** The `FrozenDictionary` is initialised once at application startup and never touched again.
+
+The trade-off is that the snapshot must be updated when ISO 4217 changes. Currency changes are infrequent (a few per decade) and typically involve countries replacing their currency during monetary union events. When an update is needed, the change is a one-line edit to `Iso4217Data.cs` and a new minor version of the package.
+
+## How shrinking works for money properties
+
+`Conjecture.Money` does not implement a custom shrinker. Instead, it relies on the Core engine's `NumericAwareShrinkPass`, which manipulates the **choice-sequence IR** — the sequence of integer draws made during generation.
+
+When `Generate.Amounts("USD")` generates a value, it internally:
+
+1. Scales the `[0, 10000]` range to integer space: `[0, 1_000_000]` (scale 2 → ×100).
+2. Draws a `long` from `Generate.Integers<long>(0, 1_000_000)`.
+3. Divides the drawn integer by `100m` to recover the decimal.
+
+The shrink pass sees the `long` draw and reduces it toward `0` by the standard integer shrink rules. Dividing a smaller integer by `100m` produces a smaller decimal. No money-specific shrinker is needed.
+
+The practical result: a counterexample generated at `9843.27m` will shrink toward `0.00m`, passing through values like `4921.63m`, `2460.81m`, `1230.40m`, … until the smallest failing value is found. The shrunk counterexample is always a valid representable USD amount with exactly 2 decimal places.
+
+## See also
+
+- [Reference: Money strategies](../reference/money-strategies.md)
+- [How to test monetary and decimal arithmetic](../how-to/use-money-strategies.md)
+- [Explanation: Shrinking](shrinking.md)

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -19,5 +19,7 @@ items:
     href: mtp-model.md
   - name: How Conjecture.Regex works
     href: regex-engine.md
+  - name: Why decimal for money testing
+    href: money-decimal-arithmetic.md
   - name: Why nested quantifiers cause catastrophic backtracking
     href: regex-catastrophic-backtracking.md

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -31,6 +31,8 @@ items:
     href: use-cli-tool.md
   - name: Use time strategies
     href: use-time-strategies.md
+  - name: Use money strategies
+    href: use-money-strategies.md
   - name: Use Gen.auto for F# records and unions
     href: use-fsharp-gen-auto.md
   - name: Explore strategies interactively

--- a/docs/site/articles/how-to/use-money-strategies.md
+++ b/docs/site/articles/how-to/use-money-strategies.md
@@ -1,0 +1,82 @@
+# How to test monetary and decimal arithmetic
+
+Generate currency codes, scaled decimal amounts, and rounding modes with `Conjecture.Money`.
+
+## Install
+
+```bash
+dotnet add package Conjecture.Money
+```
+
+## Test rounding-mode sensitivity
+
+Run a property across every `MidpointRounding` value to check that your calculation is consistent:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Money;
+
+[Property]
+public bool TaxCalculation_SameResultRegardlessOfRoundingMode(decimal gross)
+{
+    // Arrange
+    decimal grossAmount = DataGen.SampleOne(Generate.Amounts("USD", min: 0m, max: 100_000m));
+    MidpointRounding mode = DataGen.SampleOne(Generate.RoundingModes());
+
+    // Act
+    decimal tax = CalculateTax(grossAmount, mode);
+
+    // Assert — tax must always be non-negative and not exceed the gross
+    return tax >= 0m && tax <= grossAmount;
+}
+```
+
+`Generate.RoundingModes()` samples all six `MidpointRounding` enum values uniformly, so a single property run exercises every rounding mode.
+
+## Test currency-aware amount generation
+
+Generate matched currency-code / amount pairs to verify currency-agnostic logic:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Money;
+
+[Property]
+public bool Formatter_NeverThrowsForAnyActiveCurrency()
+{
+    string code = DataGen.SampleOne(Generate.Iso4217Codes());
+    decimal amount = DataGen.SampleOne(Generate.Amounts(code));
+
+    // Act — should not throw
+    string formatted = MoneyFormatter.Format(amount, code);
+
+    return formatted.Length > 0;
+}
+```
+
+`Generate.Amounts(code)` automatically uses the correct minor-unit scale for the currency (0 for JPY, 2 for USD, 3 for BHD), so generated amounts are always representable.
+
+## Test an allocator's invariants
+
+Use `Generate.Decimal` with `Generate.Integers` to verify that an allocation algorithm sums correctly:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Money;
+
+[Property]
+public bool Allocator_SumsToOriginalAmount()
+{
+    decimal total = DataGen.SampleOne(Generate.Amounts("USD", min: 1m, max: 10_000m));
+    int parts = DataGen.SampleOne(Generate.Integers<int>(2, 10));
+
+    decimal[] allocated = Allocator.Split(total, parts);
+
+    return allocated.Sum() == total && allocated.All(a => a >= 0m);
+}
+```
+
+## See also
+
+- [Reference: Money strategies](../reference/money-strategies.md) — full API surface
+- [Explanation: Why decimal for money testing](../explanation/money-decimal-arithmetic.md) — design rationale

--- a/docs/site/articles/reference/money-strategies.md
+++ b/docs/site/articles/reference/money-strategies.md
@@ -1,0 +1,70 @@
+# Money strategies reference
+
+Strategies in the `Conjecture.Money` package for generating currency codes, scaled decimal amounts, and rounding modes.
+
+> [!NOTE]
+> Requires the `Conjecture.Money` NuGet package. The `using Conjecture.Money;` import activates the extension methods on `Generate`.
+
+## `Generate.Iso4217Codes()`
+
+```csharp
+Strategy<string> Generate.Iso4217Codes()
+```
+
+Samples uniformly from all 141 active ISO 4217 alphabetic currency codes (e.g. `"USD"`, `"EUR"`, `"JPY"`, `"BHD"`). Shrinks toward `"AED"` (lexicographically first active code).
+
+Withdrawn codes (e.g. `DEM`, `FRF`, `ITL`) are excluded. The list is an embedded snapshot; it does not change at runtime.
+
+## `Generate.Amounts(string currencyCode, decimal min = 0m, decimal max = 10_000m)`
+
+```csharp
+Strategy<decimal> Generate.Amounts(string currencyCode, decimal min = 0m, decimal max = 10_000m)
+```
+
+Generates decimal amounts within `[min, max]`, scaled to the minor-unit decimal places for the given ISO 4217 currency:
+
+| Minor units | Example currencies |
+|---|---|
+| 0 | JPY, KRW, VND |
+| 2 | USD, EUR, GBP (and most others) |
+| 3 | BHD, KWD, OMR, TND |
+
+Throws `ArgumentException` if `currencyCode` is not an active ISO 4217 code.
+
+## `Generate.Decimal(decimal min, decimal max, int? scale = null)`
+
+```csharp
+Strategy<decimal> Generate.Decimal(decimal min, decimal max, int? scale = null)
+```
+
+Generates `decimal` values within `[min, max]`, optionally rounded to `scale` decimal places (0–28).
+
+When `scale` is null the default precision of 6 decimal places is used. Shrinks toward zero.
+
+Throws `ArgumentException` if `min > max`. Throws `ArgumentOutOfRangeException` if `scale` is outside `[0, 28]` or if the combination of range and scale exceeds `long` precision.
+
+## `Generate.RoundingModes()`
+
+```csharp
+Strategy<MidpointRounding> Generate.RoundingModes()
+```
+
+Samples uniformly from all `System.MidpointRounding` enum values:
+- `AwayFromZero`
+- `ToEven`
+- `ToNegativeInfinity`
+- `ToPositiveInfinity`
+- `ToZero`
+- `TowardZero`
+
+## ISO 4217 snapshot
+
+The embedded snapshot covers 141 active codes as of 2026:
+- **17 at 0 decimal places:** BIF, CLP, DJF, GNF, ISK, JPY, KMF, KRW, MGA, PYG, RWF, UGX, VND, VUV, XAF, XOF, XPF
+- **117 at 2 decimal places:** AED, AFN, ALL, AMD, …, USD, EUR, GBP, …, ZWL
+- **7 at 3 decimal places:** BHD, IQD, JOD, KWD, LYD, OMR, TND
+
+## See also
+
+- [How to test monetary and decimal arithmetic](../how-to/use-money-strategies.md)
+- [Explanation: Why decimal for money testing](../explanation/money-decimal-arithmetic.md)

--- a/docs/site/articles/reference/toc.yml
+++ b/docs/site/articles/reference/toc.yml
@@ -17,6 +17,8 @@ items:
     href: time-strategies.md
   - name: Regex strategies
     href: regex-strategies.md
+  - name: Money strategies
+    href: money-strategies.md
   - name: Formatters
     href: formatters.md
   - name: Telemetry


### PR DESCRIPTION
## Description

Adds documentation for `Conjecture.Money` across all three Diátaxis layers:

- **How-to** (`use-money-strategies.md`): Three guides — test rounding-mode sensitivity with `RoundingModes()`, test currency-aware generation with `Iso4217Codes()` + `Amounts()`, and test allocator invariants with `Generate.Decimal` + `Generate.Integers`.
- **Reference** (`money-strategies.md`): Full API surface for `Iso4217Codes()`, `Amounts()`, `Decimal()`, and `RoundingModes()`, including the ISO 4217 snapshot scope and minor-unit table.
- **Explanation** (`money-decimal-arithmetic.md`): Why `decimal` instead of `double`, why an embedded snapshot over runtime discovery, and how Core's `NumericAwareShrinkPass` handles money shrinking without a custom shrinker.

TOC entries added to all three sections.

## Type of change

- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #409
Part of #293