### PR TITLE
[292.1] Add IanaZoneIds, WindowsZoneIds, and TimeZone strategies

### DIFF
--- a/src/Conjecture.Time.Tests/TimeGenerateTests.cs
+++ b/src/Conjecture.Time.Tests/TimeGenerateTests.cs
@@ -91,4 +91,64 @@ public class TimeGenerateExtensionsTests
 
         Assert.All(clocks, static c => Assert.IsType<FakeTimeProvider>(c));
     }
+
+    [Fact]
+    public void IanaZoneIds_AllValuesHaveIanaIds()
+    {
+        Strategy<string> strategy = Generate.IanaZoneIds();
+
+        IReadOnlyList<string> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, static id => TimeZoneInfo.FindSystemTimeZoneById(id));
+    }
+
+    [Fact]
+    public void IanaZoneIds_WithPreferDst_AllZonesSupportDst()
+    {
+        Strategy<string> strategy = Generate.IanaZoneIds(preferDst: true);
+
+        IReadOnlyList<string> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, static id =>
+        {
+            TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById(id);
+            Assert.True(tz.SupportsDaylightSavingTime, $"Zone '{id}' does not support DST");
+        });
+    }
+
+    [Fact]
+    public void WindowsZoneIds_AllValuesAreWindowsZoneIds()
+    {
+        Strategy<string> strategy = Generate.WindowsZoneIds();
+
+        IReadOnlyList<string> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, static id =>
+        {
+            TimeZoneInfo tz = TimeZoneInfo.FindSystemTimeZoneById(id);
+            Assert.False(tz.HasIanaId, $"Zone '{id}' has an IANA id, expected a Windows-style id");
+        });
+    }
+
+    [Fact]
+    public void TimeZone_WithPreferDst_AllZonesSupportDst()
+    {
+        Strategy<TimeZoneInfo> strategy = Generate.TimeZone(preferDst: true);
+
+        IReadOnlyList<TimeZoneInfo> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, static tz =>
+            Assert.True(tz.SupportsDaylightSavingTime, $"Zone '{tz.Id}' does not support DST"));
+    }
+
+    [Fact]
+    public void IanaZoneIds_ProducesVariety()
+    {
+        Strategy<string> strategy = Generate.IanaZoneIds();
+
+        IReadOnlyList<string> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        System.Collections.Generic.HashSet<string> distinct = [.. samples];
+        Assert.True(distinct.Count >= 3, $"Expected at least 3 distinct IANA zone IDs, got {distinct.Count}");
+    }
 }

--- a/src/Conjecture.Time/CrossPlatformTimeZones.cs
+++ b/src/Conjecture.Time/CrossPlatformTimeZones.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Time;
+
+internal static class CrossPlatformTimeZones
+{
+    internal static readonly string[] IanaIds =
+    [
+        "America/New_York", "America/Chicago", "America/Denver", "America/Los_Angeles",
+        "America/Sao_Paulo", "Europe/London", "Europe/Paris", "Europe/Berlin",
+        "Europe/Moscow", "Asia/Tokyo", "Asia/Shanghai", "Asia/Kolkata", "Asia/Dubai",
+        "Australia/Sydney", "Pacific/Auckland", "Pacific/Honolulu",
+        "Africa/Johannesburg", "UTC",
+    ];
+}

--- a/src/Conjecture.Time/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).IanaZoneIds(bool preferDst = false) -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).WindowsZoneIds() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).TimeZone(bool preferDst = false) -> Conjecture.Core.Strategy<System.TimeZoneInfo!>!

--- a/src/Conjecture.Time/TimeGenerateExtensions.cs
+++ b/src/Conjecture.Time/TimeGenerateExtensions.cs
@@ -13,12 +13,39 @@ public static class TimeGenerateExtensions
     // UTC at index 0 so SampledFrom shrinks toward it; deduplicated in case GetSystemTimeZones already includes UTC.
     private static readonly TimeZoneInfo[] SystemTimeZones = BuildSystemTimeZones();
 
+    private static readonly TimeZoneInfo[] CrossPlatformZones = BuildCrossPlatformZones();
+    private static readonly string[] IanaDstIds = BuildIanaDstIds();
+    private static readonly string[] WindowsIds = BuildWindowsIds();
+    private static readonly TimeZoneInfo[] CrossPlatformDstZones = BuildCrossPlatformDstZones();
+
     extension(Generate)
     {
         /// <summary>Returns a strategy that picks uniformly from the system time zones, shrinking toward UTC.</summary>
         public static Strategy<TimeZoneInfo> TimeZones()
         {
             return Generate.SampledFrom(TimeGenerateExtensions.SystemTimeZones);
+        }
+
+        /// <summary>Returns a strategy that samples IANA timezone IDs from a cross-platform-safe subset.</summary>
+        public static Strategy<string> IanaZoneIds(bool preferDst = false)
+        {
+            return preferDst
+                ? Generate.SampledFrom(TimeGenerateExtensions.IanaDstIds)
+                : Generate.SampledFrom(CrossPlatformTimeZones.IanaIds);
+        }
+
+        /// <summary>Returns a strategy that samples Windows timezone IDs from a cross-platform-safe subset.</summary>
+        public static Strategy<string> WindowsZoneIds()
+        {
+            return Generate.SampledFrom(TimeGenerateExtensions.WindowsIds);
+        }
+
+        /// <summary>Returns a strategy that samples TimeZoneInfo from the cross-platform-safe subset, optionally filtering to DST zones.</summary>
+        public static Strategy<TimeZoneInfo> TimeZone(bool preferDst = false)
+        {
+            return preferDst
+                ? Generate.SampledFrom(TimeGenerateExtensions.CrossPlatformDstZones)
+                : Generate.SampledFrom(TimeGenerateExtensions.CrossPlatformZones);
         }
 
         /// <summary>
@@ -50,6 +77,58 @@ public static class TimeGenerateExtensions
                 return clocks;
             });
         }
+    }
+
+    private static string[] BuildIanaDstIds()
+    {
+        List<string> result = [];
+        foreach (TimeZoneInfo tz in CrossPlatformZones)
+        {
+            if (tz.SupportsDaylightSavingTime)
+            {
+                result.Add(tz.Id);
+            }
+        }
+        return [.. result];
+    }
+
+    private static string[] BuildWindowsIds()
+    {
+        HashSet<string> seen = [];
+        List<string> result = [];
+        foreach (string ianaId in CrossPlatformTimeZones.IanaIds)
+        {
+            if (TimeZoneInfo.TryConvertIanaIdToWindowsId(ianaId, out string? winId)
+                && winId != ianaId
+                && seen.Add(winId))
+            {
+                result.Add(winId);
+            }
+        }
+        return [.. result];
+    }
+
+    private static TimeZoneInfo[] BuildCrossPlatformZones()
+    {
+        List<TimeZoneInfo> result = [];
+        foreach (string id in CrossPlatformTimeZones.IanaIds)
+        {
+            result.Add(TimeZoneInfo.FindSystemTimeZoneById(id));
+        }
+        return [.. result];
+    }
+
+    private static TimeZoneInfo[] BuildCrossPlatformDstZones()
+    {
+        List<TimeZoneInfo> result = [];
+        foreach (TimeZoneInfo tz in CrossPlatformZones)
+        {
+            if (tz.SupportsDaylightSavingTime)
+            {
+                result.Add(tz);
+            }
+        }
+        return [.. result];
     }
 
     private static TimeZoneInfo[] BuildSystemTimeZones()


### PR DESCRIPTION
## Description

Adds three new cross-platform-safe timezone strategies to `Conjecture.Time`:

- `Generate.IanaZoneIds(preferDst)` — samples IANA timezone IDs from a curated ~18-entry subset verified on .NET 8+ across Windows, Linux, and macOS. When `preferDst = true`, restricts to DST-supporting zones.
- `Generate.WindowsZoneIds()` — converts the same curated IANA subset to Windows zone IDs (e.g. `"Eastern Standard Time"`), skipping dual-format IDs like `"UTC"` and deduplicating zones that share a Windows name.
- `Generate.TimeZone(preferDst)` — samples `TimeZoneInfo` objects from the curated subset. When `preferDst = true`, restricts to DST-supporting zones.

The curated set is defined in the new `CrossPlatformTimeZones` internal class. All three strategies shrink toward UTC / non-DST entries by virtue of `SampledFrom` index reduction.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #411
Part of #292