### PR TITLE
[292.2] Add WithKinds() DateTimeKind-fuzzing extension

### DIFF
--- a/src/Conjecture.Time.Tests/DateTimeExtensionsTests.cs
+++ b/src/Conjecture.Time.Tests/DateTimeExtensionsTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Time;
+
+namespace Conjecture.Time.Tests;
+
+public class DateTimeExtensionsTests
+{
+    [Fact]
+    public void WithKinds_ValueHasSpecifiedKind()
+    {
+        Strategy<(DateTime Value, DateTimeKind Kind)> strategy = Generate.DateTimes().WithKinds();
+
+        IReadOnlyList<(DateTime Value, DateTimeKind Kind)> samples = DataGen.Sample(strategy, count: 30, seed: 1UL);
+
+        Assert.All(samples, tuple => Assert.Equal(tuple.Kind, tuple.Value.Kind));
+    }
+
+    [Fact]
+    public void WithKinds_AllThreeKindsAreGenerated()
+    {
+        Strategy<(DateTime Value, DateTimeKind Kind)> strategy = Generate.DateTimes().WithKinds();
+
+        IReadOnlyList<(DateTime Value, DateTimeKind Kind)> samples = DataGen.Sample(strategy, count: 30, seed: 1UL);
+
+        System.Collections.Generic.HashSet<DateTimeKind> kinds = [.. samples.Select(static t => t.Kind)];
+        Assert.Contains(DateTimeKind.Utc, kinds);
+        Assert.Contains(DateTimeKind.Local, kinds);
+        Assert.Contains(DateTimeKind.Unspecified, kinds);
+    }
+
+    [Fact]
+    public void WithKinds_ShrinksToUtcKind()
+    {
+        Strategy<(DateTime Value, DateTimeKind Kind)> strategy = Generate.DateTimes().WithKinds();
+
+        // Seed 0 produces minimum IR values; OneOf index 0 = Utc, so the minimal
+        // generated tuple must carry DateTimeKind.Utc.
+        (_, DateTimeKind kind) = DataGen.SampleOne(strategy, seed: 0UL);
+
+        Assert.Equal(DateTimeKind.Utc, kind);
+    }
+
+    [Fact]
+    public void WithKinds_PreservesDateTimeValue()
+    {
+        Strategy<(DateTime Value, DateTimeKind Kind)> strategy = Generate.DateTimes().WithKinds();
+
+        IReadOnlyList<(DateTime Value, DateTimeKind Kind)> samples = DataGen.Sample(strategy, count: 30, seed: 2UL);
+
+        Assert.All(samples, tuple =>
+        {
+            long expectedTicks = tuple.Value.Ticks;
+            long actualTicks = DateTime.SpecifyKind(tuple.Value, DateTimeKind.Unspecified).Ticks;
+            Assert.Equal(expectedTicks, actualTicks);
+        });
+    }
+}

--- a/src/Conjecture.Time/DateTimeExtensions.cs
+++ b/src/Conjecture.Time/DateTimeExtensions.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+namespace Conjecture.Time;
+
+/// <summary>Extension methods on <see cref="Strategy{T}"/> for <see cref="DateTime"/> test value generation.</summary>
+public static class DateTimeExtensions
+{
+    extension(Strategy<DateTime> s)
+    {
+        /// <summary>
+        /// Returns a strategy that pairs each generated <see cref="DateTime"/> with a randomly chosen <see cref="DateTimeKind"/>,
+        /// covering all three kinds uniformly. Shrinks toward <see cref="DateTimeKind.Utc"/> (index 0 in the underlying OneOf call).
+        /// </summary>
+        public Strategy<(DateTime Value, DateTimeKind Kind)> WithKinds()
+        {
+            return Generate.OneOf(
+                s.Select(static dt => (DateTime.SpecifyKind(dt, DateTimeKind.Utc), DateTimeKind.Utc)),
+                s.Select(static dt => (DateTime.SpecifyKind(dt, DateTimeKind.Local), DateTimeKind.Local)),
+                s.Select(static dt => (DateTime.SpecifyKind(dt, DateTimeKind.Unspecified), DateTimeKind.Unspecified)));
+        }
+    }
+}

--- a/src/Conjecture.Time/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Conjecture.Time.DateTimeExtensions
+Conjecture.Time.DateTimeExtensions.extension(Conjecture.Core.Strategy<System.DateTime>!)
+Conjecture.Time.DateTimeExtensions.extension(Conjecture.Core.Strategy<System.DateTime>!).WithKinds() -> Conjecture.Core.Strategy<(System.DateTime Value, System.DateTimeKind Kind)>!
 static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).IanaZoneIds(bool preferDst = false) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).WindowsZoneIds() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).TimeZone(bool preferDst = false) -> Conjecture.Core.Strategy<System.TimeZoneInfo!>!


### PR DESCRIPTION
## Description

Adds `WithKinds()` as a C# 14 extension method on `Strategy<DateTime>` in the new `DateTimeExtensions` class.

Each call returns `Strategy<(DateTime Value, DateTimeKind Kind)>` where:
- The kind is selected independently from the DateTime value via `Generate.OneOf` over three arms (Utc, Local, Unspecified)
- The DateTime is stamped with the chosen kind via `DateTime.SpecifyKind` (ticks are unchanged)
- Shrinks toward `DateTimeKind.Utc` (index 0 in OneOf)

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #412
Part of #292