### PR TITLE
[292.3] Add DateOnly and TimeOnly boundary strategies

### DIFF
--- a/src/Conjecture.Time.Tests/DateOnlyStrategyTests.cs
+++ b/src/Conjecture.Time.Tests/DateOnlyStrategyTests.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Time;
+
+namespace Conjecture.Time.Tests;
+
+public class DateOnlyStrategyTests
+{
+    [Fact]
+    public void DateOnlys_ValuesAreWithinMinMax()
+    {
+        DateOnly min = new(2020, 1, 1);
+        DateOnly max = new(2025, 12, 31);
+        Strategy<DateOnly> strategy = Generate.DateOnlyValues(min, max);
+
+        IReadOnlyList<DateOnly> samples = DataGen.Sample(strategy, count: 50, seed: 1UL);
+
+        Assert.All(samples, d =>
+        {
+            Assert.True(d >= min, $"{d} is before min {min}");
+            Assert.True(d <= max, $"{d} is after max {max}");
+        });
+    }
+
+    [Fact]
+    public void NearMonthBoundary_ValuesAreOnLastOrFirstDay()
+    {
+        Strategy<DateOnly> strategy = Generate.DateOnlyValues().NearMonthBoundary();
+
+        IReadOnlyList<DateOnly> samples = DataGen.Sample(strategy, count: 50, seed: 1UL);
+
+        Assert.All(samples, d =>
+        {
+            bool isFirst = d.Day == 1;
+            bool isLast = d.Day == DateTime.DaysInMonth(d.Year, d.Month);
+            Assert.True(isFirst || isLast, $"{d} is not a first or last day of the month");
+        });
+    }
+
+    [Fact]
+    public void NearLeapDay_ValuesAreWithinOneDayOfFeb29()
+    {
+        Strategy<DateOnly> strategy = Generate.DateOnlyValues().NearLeapDay();
+
+        IReadOnlyList<DateOnly> samples = DataGen.Sample(strategy, count: 50, seed: 1UL);
+
+        Assert.All(samples, d =>
+        {
+            DateTime sampleDt = d.ToDateTime(TimeOnly.MinValue);
+            double minDistance = FindMinDistanceToLeapDay(sampleDt);
+            Assert.True(minDistance <= 1.0, $"{d} is {minDistance} days from the nearest Feb 29");
+        });
+    }
+
+    private static double FindMinDistanceToLeapDay(DateTime dt)
+    {
+        double minDays = double.MaxValue;
+        int startYear = dt.Year - 4;
+        int endYear = dt.Year + 4;
+
+        for (int y = startYear; y <= endYear; y++)
+        {
+            if (DateTime.IsLeapYear(y))
+            {
+                DateTime leapDay = new(y, 2, 29);
+                double diff = Math.Abs((dt - leapDay).TotalDays);
+                if (diff < minDays)
+                {
+                    minDays = diff;
+                }
+            }
+        }
+
+        return minDays;
+    }
+}

--- a/src/Conjecture.Time.Tests/TimeOnlyStrategyTests.cs
+++ b/src/Conjecture.Time.Tests/TimeOnlyStrategyTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Time;
+
+namespace Conjecture.Time.Tests;
+
+public class TimeOnlyStrategyTests
+{
+    [Fact]
+    public void TimeOnlys_ValuesAreWithinMinMax()
+    {
+        TimeOnly min = new(8, 0);
+        TimeOnly max = new(18, 0);
+        Strategy<TimeOnly> strategy = Generate.TimeOnlyValues(min, max);
+
+        IReadOnlyList<TimeOnly> samples = DataGen.Sample(strategy, count: 50, seed: 1UL);
+
+        Assert.All(samples, t =>
+        {
+            Assert.True(t >= min, $"{t} is before min {min}");
+            Assert.True(t <= max, $"{t} is after max {max}");
+        });
+    }
+
+    [Fact]
+    public void NearMidnight_ValuesAreWithin30SecondsOfMidnight()
+    {
+        Strategy<TimeOnly> strategy = Generate.TimeOnlyValues().NearMidnight();
+        long threshold = 30 * TimeSpan.TicksPerSecond;
+
+        IReadOnlyList<TimeOnly> samples = DataGen.Sample(strategy, count: 50, seed: 1UL);
+
+        Assert.All(samples, t =>
+        {
+            bool nearStart = t.Ticks <= threshold;
+            bool nearEnd = t.Ticks >= TimeOnly.MaxValue.Ticks - threshold;
+            Assert.True(nearStart || nearEnd, $"{t} is not within 30 seconds of midnight");
+        });
+    }
+
+    [Fact]
+    public void NearNoon_ValuesAreWithin30SecondsOfNoon()
+    {
+        Strategy<TimeOnly> strategy = Generate.TimeOnlyValues().NearNoon();
+        TimeOnly noon = new(12, 0, 0);
+        long threshold = 30 * TimeSpan.TicksPerSecond;
+
+        IReadOnlyList<TimeOnly> samples = DataGen.Sample(strategy, count: 50, seed: 1UL);
+
+        Assert.All(samples, t =>
+        {
+            long diff = Math.Abs(t.Ticks - noon.Ticks);
+            Assert.True(diff <= threshold, $"{t} is not within 30 seconds of noon");
+        });
+    }
+
+    [Fact]
+    public void NearEndOfDay_ValuesAreWithin30SecondsOfEndOfDay()
+    {
+        Strategy<TimeOnly> strategy = Generate.TimeOnlyValues().NearEndOfDay();
+        TimeOnly threshold = new(23, 59, 29);
+
+        IReadOnlyList<TimeOnly> samples = DataGen.Sample(strategy, count: 50, seed: 1UL);
+
+        Assert.All(samples, t =>
+            Assert.True(t.Ticks >= threshold.Ticks, $"{t} is not within 30 seconds of end of day"));
+    }
+}

--- a/src/Conjecture.Time/DateOnlyExtensions.cs
+++ b/src/Conjecture.Time/DateOnlyExtensions.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+namespace Conjecture.Time;
+
+/// <summary>Extension methods on <see cref="Strategy{T}"/> for <see cref="DateOnly"/> test value generation.</summary>
+public static class DateOnlyExtensions
+{
+    extension(Strategy<DateOnly> s)
+    {
+        /// <summary>
+        /// Returns a strategy that generates dates that are the last or first day of any month.
+        /// Generates a year (2000–2099), a month (1–12), then picks either day=1 or day=DaysInMonth(year,month).
+        /// </summary>
+        public Strategy<DateOnly> NearMonthBoundary()
+        {
+            Strategy<int> yearStrategy = Generate.Integers(2000, 2099);
+            Strategy<int> monthStrategy = Generate.Integers(1, 12);
+            Strategy<int> edgeStrategy = Generate.Integers(0, 1);
+
+            return Generate.Compose<DateOnly>(ctx =>
+            {
+                int year = ctx.Generate(yearStrategy);
+                int month = ctx.Generate(monthStrategy);
+                int edge = ctx.Generate(edgeStrategy);
+                int day = edge == 0 ? 1 : DateTime.DaysInMonth(year, month);
+                return new DateOnly(year, month, day);
+            });
+        }
+
+        /// <summary>
+        /// Returns a strategy that generates dates within ±1 day of Feb 29 in leap years (1970–2400).
+        /// Uses <c>ctx.Assume</c> to filter to leap years, matching the pattern of
+        /// <see cref="DateTimeOffsetExtensions.NearLeapYear"/>.
+        /// </summary>
+        public Strategy<DateOnly> NearLeapDay()
+        {
+            Strategy<int> yearStrategy = Generate.Integers(1970, 2400);
+            Strategy<int> offsetStrategy = Generate.Integers(-1, 1);
+
+            return Generate.Compose<DateOnly>(ctx =>
+            {
+                int year = ctx.Generate(yearStrategy);
+                ctx.Assume(DateTime.IsLeapYear(year));
+                int offset = ctx.Generate(offsetStrategy);
+                return new DateOnly(year, 2, 29).AddDays(offset);
+            });
+        }
+    }
+}

--- a/src/Conjecture.Time/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Unshipped.txt
@@ -5,3 +5,12 @@ Conjecture.Time.DateTimeExtensions.extension(Conjecture.Core.Strategy<System.Dat
 static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).IanaZoneIds(bool preferDst = false) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).WindowsZoneIds() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).TimeZone(bool preferDst = false) -> Conjecture.Core.Strategy<System.TimeZoneInfo!>!
+Conjecture.Time.DateOnlyExtensions
+Conjecture.Time.DateOnlyExtensions.extension(Conjecture.Core.Strategy<System.DateOnly>!)
+Conjecture.Time.DateOnlyExtensions.extension(Conjecture.Core.Strategy<System.DateOnly>!).NearMonthBoundary() -> Conjecture.Core.Strategy<System.DateOnly>!
+Conjecture.Time.DateOnlyExtensions.extension(Conjecture.Core.Strategy<System.DateOnly>!).NearLeapDay() -> Conjecture.Core.Strategy<System.DateOnly>!
+Conjecture.Time.TimeOnlyExtensions
+Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!)
+Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!).NearMidnight() -> Conjecture.Core.Strategy<System.TimeOnly>!
+Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!).NearNoon() -> Conjecture.Core.Strategy<System.TimeOnly>!
+Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!).NearEndOfDay() -> Conjecture.Core.Strategy<System.TimeOnly>!

--- a/src/Conjecture.Time/TimeOnlyExtensions.cs
+++ b/src/Conjecture.Time/TimeOnlyExtensions.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+namespace Conjecture.Time;
+
+/// <summary>Extension methods on <see cref="Strategy{T}"/> for <see cref="TimeOnly"/> test value generation.</summary>
+public static class TimeOnlyExtensions
+{
+    extension(Strategy<TimeOnly> s)
+    {
+        /// <summary>
+        /// Returns a strategy that generates times within 30 seconds of midnight (00:00:00).
+        /// Covers both [0, 30s] and [23:59:30, MaxValue].
+        /// </summary>
+        public Strategy<TimeOnly> NearMidnight()
+        {
+            long threshold = 30 * TimeSpan.TicksPerSecond;
+            Strategy<TimeOnly> nearStart = Generate.TimeOnlyValues(TimeOnly.MinValue, new TimeOnly(threshold));
+            Strategy<TimeOnly> nearEnd = Generate.TimeOnlyValues(new TimeOnly(TimeOnly.MaxValue.Ticks - threshold), TimeOnly.MaxValue);
+            return Generate.OneOf(nearStart, nearEnd);
+        }
+
+        /// <summary>
+        /// Returns a strategy that generates times within 30 seconds of noon (12:00:00).
+        /// Range: [11:59:30, 12:00:30].
+        /// </summary>
+        public Strategy<TimeOnly> NearNoon()
+        {
+            long noonTicks = new TimeOnly(12, 0, 0).Ticks;
+            long threshold = 30 * TimeSpan.TicksPerSecond;
+            return Generate.TimeOnlyValues(new TimeOnly(noonTicks - threshold), new TimeOnly(noonTicks + threshold));
+        }
+
+        /// <summary>
+        /// Returns a strategy that generates times within 30 seconds of end of day (23:59:59).
+        /// Range: [23:59:29, TimeOnly.MaxValue].
+        /// </summary>
+        public Strategy<TimeOnly> NearEndOfDay()
+        {
+            long threshold = 30 * TimeSpan.TicksPerSecond;
+            return Generate.TimeOnlyValues(new TimeOnly(TimeOnly.MaxValue.Ticks - threshold), TimeOnly.MaxValue);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds boundary-biased extension methods on `Strategy<DateOnly>` and `Strategy<TimeOnly>`:

**DateOnlyExtensions:**
- `NearMonthBoundary()` — generates dates that are the first or last day of any month (year 2000–2099)
- `NearLeapDay()` — generates dates within ±1 day of Feb 29 in a leap year (1970–2400), using `ctx.Assume(DateTime.IsLeapYear(year))` consistent with `DateTimeOffsetExtensions.NearLeapYear`

**TimeOnlyExtensions:**
- `NearMidnight()` — generates times within 30 seconds of 00:00:00, covering both sides of the clock via `Generate.OneOf`
- `NearNoon()` — generates times within 30 seconds of 12:00:00
- `NearEndOfDay()` — generates times within 30 seconds of 23:59:59

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #413
Part of #292