### PR TITLE
[292.4] Add WithPrecision and WithStrippedOffset to DateTimeOffsetExtensions

### DIFF
--- a/src/Conjecture.Time.Tests/DateTimeOffsetExtensionsTests.cs
+++ b/src/Conjecture.Time.Tests/DateTimeOffsetExtensionsTests.cs
@@ -162,4 +162,67 @@ public class DateTimeOffsetExtensionsTests
 
         Assert.False(ReferenceEquals(input, result));
     }
+
+    [Fact]
+    public void WithPrecision_Milliseconds_TicksAreRoundedToMillisecond()
+    {
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets().WithPrecision(TimeSpan.FromMilliseconds(1));
+
+        IReadOnlyList<DateTimeOffset> samples = DataGen.Sample(strategy, count: 30, seed: 1UL);
+
+        Assert.All(samples, value => Assert.Equal(0L, value.Ticks % TimeSpan.TicksPerMillisecond));
+    }
+
+    [Fact]
+    public void WithPrecision_Seconds_TicksAreRoundedToSecond()
+    {
+        Strategy<DateTimeOffset> strategy = Generate.DateTimeOffsets().WithPrecision(TimeSpan.FromSeconds(1));
+
+        IReadOnlyList<DateTimeOffset> samples = DataGen.Sample(strategy, count: 30, seed: 1UL);
+
+        Assert.All(samples, value => Assert.Equal(0L, value.Ticks % TimeSpan.TicksPerSecond));
+    }
+
+    [Fact]
+    public void WithStrippedOffset_StrippedValueHasZeroOffset()
+    {
+        Strategy<(DateTimeOffset Original, DateTimeOffset Stripped)> strategy =
+            Generate.DateTimeOffsets().WithStrippedOffset();
+
+        IReadOnlyList<(DateTimeOffset Original, DateTimeOffset Stripped)> samples =
+            DataGen.Sample(strategy, count: 30, seed: 1UL);
+
+        Assert.All(samples, result => Assert.Equal(TimeSpan.Zero, result.Stripped.Offset));
+    }
+
+    [Fact]
+    public void WithStrippedOffset_OriginalPreservesOffset()
+    {
+        Strategy<(DateTimeOffset Original, DateTimeOffset Stripped)> strategy =
+            Generate.DateTimeOffsets().WithStrippedOffset();
+
+        IReadOnlyList<(DateTimeOffset Original, DateTimeOffset Stripped)> samples =
+            DataGen.Sample(strategy, count: 30, seed: 1UL);
+
+        Assert.Contains(samples, result => result.Original.Offset != TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void WithStrippedOffset_TickValuesMatch()
+    {
+        Strategy<(DateTimeOffset Original, DateTimeOffset Stripped)> strategy =
+            Generate.DateTimeOffsets().WithStrippedOffset();
+
+        IReadOnlyList<(DateTimeOffset Original, DateTimeOffset Stripped)> samples =
+            DataGen.Sample(strategy, count: 30, seed: 1UL);
+
+        Assert.All(samples, result => Assert.Equal(result.Original.Ticks, result.Stripped.Ticks));
+    }
+
+    [Fact]
+    public void WithPrecision_ZeroPrecision_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(static () =>
+            Generate.DateTimeOffsets().WithPrecision(TimeSpan.Zero));
+    }
 }

--- a/src/Conjecture.Time/DateTimeOffsetExtensions.cs
+++ b/src/Conjecture.Time/DateTimeOffsetExtensions.cs
@@ -90,6 +90,37 @@ public static class DateTimeOffsetExtensions
                 return transition.AddTicks(jitterTicks);
             });
         }
+
+        /// <summary>
+        /// Returns a strategy that truncates each generated value to <paramref name="precision"/>,
+        /// simulating provider-imposed precision stripping (e.g. SQL Server datetime2(3) rounds to milliseconds).
+        /// </summary>
+        public Strategy<DateTimeOffset> WithPrecision(TimeSpan precision)
+        {
+            if (precision.Ticks <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precision), precision, "precision must be positive.");
+            }
+
+            return s.Select(dto => new DateTimeOffset(dto.Ticks - dto.Ticks % precision.Ticks, dto.Offset));
+        }
+
+        /// <summary>
+        /// Returns a strategy that pairs each generated value with its offset-stripped counterpart (Offset → Zero),
+        /// simulating providers that lose the UTC offset on roundtrip.
+        /// </summary>
+        public Strategy<(DateTimeOffset Original, DateTimeOffset Stripped)> WithStrippedOffset()
+        {
+            return Generate.Compose<(DateTimeOffset Original, DateTimeOffset Stripped)>(ctx =>
+            {
+                DateTimeOffset dto = ctx.Generate(s);
+                int offsetMinutes = ctx.Generate(Generate.Integers<int>(-840, 840));
+                TimeSpan offset = TimeSpan.FromMinutes(offsetMinutes);
+                DateTimeOffset original = new(dto.Ticks, offset);
+                DateTimeOffset stripped = new(dto.Ticks, TimeSpan.Zero);
+                return (original, stripped);
+            });
+        }
     }
 
     private static TimeZoneInfo PickZoneWithRules(IGeneratorContext ctx)

--- a/src/Conjecture.Time/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ Conjecture.Time.DateOnlyExtensions
 Conjecture.Time.DateOnlyExtensions.extension(Conjecture.Core.Strategy<System.DateOnly>!)
 Conjecture.Time.DateOnlyExtensions.extension(Conjecture.Core.Strategy<System.DateOnly>!).NearMonthBoundary() -> Conjecture.Core.Strategy<System.DateOnly>!
 Conjecture.Time.DateOnlyExtensions.extension(Conjecture.Core.Strategy<System.DateOnly>!).NearLeapDay() -> Conjecture.Core.Strategy<System.DateOnly>!
+Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).WithPrecision(System.TimeSpan precision) -> Conjecture.Core.Strategy<System.DateTimeOffset>!
+Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).WithStrippedOffset() -> Conjecture.Core.Strategy<(System.DateTimeOffset Original, System.DateTimeOffset Stripped)>!
 Conjecture.Time.TimeOnlyExtensions
 Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!)
 Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!).NearMidnight() -> Conjecture.Core.Strategy<System.TimeOnly>!


### PR DESCRIPTION
## Description

Adds two DB roundtrip property helpers to the `Strategy<DateTimeOffset>` extension block:

- `WithPrecision(TimeSpan precision)` — truncates each generated value to the given tick precision, simulating provider-imposed stripping (e.g. SQL Server `datetime2(3)` rounds to millisecond boundaries). Throws `ArgumentOutOfRangeException` for non-positive precision.
- `WithStrippedOffset()` — returns `Strategy<(DateTimeOffset Original, DateTimeOffset Stripped)>` where `Stripped` has the same ticks as `Original` but `Offset = Zero`, simulating providers that lose the UTC offset on roundtrip.

These are composable building blocks for properties that verify DB roundtrip fidelity.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #414
Part of #292