### PR TITLE
[292.5] Adds RecurringEventSample, RecurringEvents strategy, and NearDstTransition extension

### DIFF
--- a/src/Conjecture.Time.Tests/RecurringEventStrategyTests.cs
+++ b/src/Conjecture.Time.Tests/RecurringEventStrategyTests.cs
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Time;
+
+namespace Conjecture.Time.Tests;
+
+public class RecurringEventStrategyTests
+{
+    [Fact]
+    public void RecurringEvents_OccurrencesAreWithinWindow()
+    {
+        TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        Strategy<RecurringEventSample> strategy = Generate.RecurringEvents(
+            static current => current + TimeSpan.FromHours(1),
+            zone,
+            TimeSpan.FromHours(24));
+
+        IReadOnlyList<RecurringEventSample> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, sample => Assert.All(sample.Occurrences, occ => Assert.True(
+                    occ >= sample.WindowStart && occ <= sample.WindowEnd,
+                    $"Occurrence {occ} is outside window [{sample.WindowStart}, {sample.WindowEnd}]")));
+    }
+
+    [Fact]
+    public void RecurringEvents_OccurrencesAreMonotonicallyIncreasing()
+    {
+        TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        Strategy<RecurringEventSample> strategy = Generate.RecurringEvents(
+            static current => current + TimeSpan.FromHours(1),
+            zone,
+            TimeSpan.FromHours(24));
+
+        IReadOnlyList<RecurringEventSample> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, sample =>
+        {
+            for (int i = 1; i < sample.Occurrences.Count; i++)
+            {
+                Assert.True(
+                    sample.Occurrences[i] > sample.Occurrences[i - 1],
+                    $"Occurrence at index {i} ({sample.Occurrences[i]}) is not after previous ({sample.Occurrences[i - 1]})");
+            }
+        });
+    }
+
+    [Fact]
+    public void RecurringEvents_WithHourlySchedule_OccurrencesAreOneHourApart()
+    {
+        TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        Strategy<RecurringEventSample> strategy = Generate.RecurringEvents(
+            static current => current + TimeSpan.FromHours(1),
+            zone,
+            TimeSpan.FromHours(24));
+
+        RecurringEventSample sample = DataGen.SampleOne(strategy, seed: 1UL);
+
+        if (sample.Occurrences.Count < 2)
+        {
+            return;
+        }
+
+        for (int i = 1; i < sample.Occurrences.Count; i++)
+        {
+            TimeSpan gap = sample.Occurrences[i] - sample.Occurrences[i - 1];
+            Assert.Equal(TimeSpan.FromHours(1), gap);
+        }
+    }
+
+    [Fact]
+    public void NearDstTransition_WindowOverlapsDstChange()
+    {
+        TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        Strategy<RecurringEventSample> strategy = Generate.RecurringEvents(
+                static current => current + TimeSpan.FromHours(1),
+                zone,
+                TimeSpan.FromHours(24))
+            .NearDstTransition();
+
+        IReadOnlyList<RecurringEventSample> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, sample =>
+        {
+            bool hasTransition = false;
+            TimeZoneInfo.AdjustmentRule[] rules = sample.Zone.GetAdjustmentRules();
+            foreach (TimeZoneInfo.AdjustmentRule rule in rules)
+            {
+                // Check spring-forward transition
+                DateTimeOffset springForward = GetTransitionOffset(rule, rule.DaylightTransitionStart, sample.WindowStart.Year, sample.Zone);
+                if (springForward >= sample.WindowStart && springForward <= sample.WindowEnd)
+                {
+                    hasTransition = true;
+                    break;
+                }
+
+                // Check fall-back transition
+                DateTimeOffset fallBack = GetTransitionOffset(rule, rule.DaylightTransitionEnd, sample.WindowStart.Year, sample.Zone);
+                if (fallBack >= sample.WindowStart && fallBack <= sample.WindowEnd)
+                {
+                    hasTransition = true;
+                    break;
+                }
+            }
+
+            Assert.True(hasTransition, $"Window [{sample.WindowStart}, {sample.WindowEnd}] does not overlap any DST transition in zone '{sample.Zone.Id}'");
+        });
+    }
+
+    [Fact]
+    public void RecurringEvents_EmptyOccurrences_WhenNextOccurrenceAlwaysReturnsNull()
+    {
+        TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+        Strategy<RecurringEventSample> strategy = Generate.RecurringEvents(
+            static _ => (DateTimeOffset?)null,
+            zone,
+            TimeSpan.FromHours(24));
+
+        IReadOnlyList<RecurringEventSample> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, sample => Assert.Empty(sample.Occurrences));
+    }
+
+    private static DateTimeOffset GetTransitionOffset(
+        TimeZoneInfo.AdjustmentRule rule,
+        TimeZoneInfo.TransitionTime transition,
+        int year,
+        TimeZoneInfo zone)
+    {
+        DateTime transitionDate = GetTransitionDate(transition, year);
+        return new DateTimeOffset(transitionDate, zone.GetUtcOffset(transitionDate));
+    }
+
+    private static DateTime GetTransitionDate(TimeZoneInfo.TransitionTime transition, int year)
+    {
+        if (transition.IsFixedDateRule)
+        {
+            return new DateTime(year, transition.Month, transition.Day) + transition.TimeOfDay.TimeOfDay;
+        }
+
+        // Floating date: find the Nth occurrence of DayOfWeek in the month
+        int startDay = transition.Week == 5 ? DateTime.DaysInMonth(year, transition.Month) : 1;
+        DateTime candidate = new(year, transition.Month, startDay);
+        int daysUntil = ((int)transition.DayOfWeek - (int)candidate.DayOfWeek + 7) % 7;
+        candidate = candidate.AddDays(daysUntil);
+        if (transition.Week < 5)
+        {
+            candidate = candidate.AddDays(7 * (transition.Week - 1));
+        }
+        else
+        {
+            // "Week 5" means last occurrence
+            while (candidate.Month == transition.Month && candidate.AddDays(7).Month == transition.Month)
+            {
+                candidate = candidate.AddDays(7);
+            }
+        }
+        return candidate + transition.TimeOfDay.TimeOfDay;
+    }
+}

--- a/src/Conjecture.Time/DateTimeOffsetExtensions.cs
+++ b/src/Conjecture.Time/DateTimeOffsetExtensions.cs
@@ -97,12 +97,9 @@ public static class DateTimeOffsetExtensions
         /// </summary>
         public Strategy<DateTimeOffset> WithPrecision(TimeSpan precision)
         {
-            if (precision.Ticks <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(precision), precision, "precision must be positive.");
-            }
-
-            return s.Select(dto => new DateTimeOffset(dto.Ticks - dto.Ticks % precision.Ticks, dto.Offset));
+            return precision.Ticks <= 0
+                ? throw new ArgumentOutOfRangeException(nameof(precision), precision, "precision must be positive.")
+                : s.Select(dto => new DateTimeOffset(dto.Ticks - dto.Ticks % precision.Ticks, dto.Offset));
         }
 
         /// <summary>
@@ -135,75 +132,7 @@ public static class DateTimeOffsetExtensions
     }
 
     private static List<DateTimeOffset> GetTransitions(TimeZoneInfo zone)
-    {
-        List<DateTimeOffset> transitions = [];
-
-        foreach (TimeZoneInfo.AdjustmentRule rule in zone.GetAdjustmentRules())
-        {
-            for (int year = CurrentYear - 1; year <= CurrentYear + 1; year++)
-            {
-                if (rule.DateStart.Year > year || rule.DateEnd.Year < year)
-                {
-                    continue;
-                }
-
-                // DaylightTransitionStart is expressed in standard time; subtract standard offset to get UTC.
-                // DaylightTransitionEnd is expressed in DST time; subtract DST offset to get UTC.
-                TimeSpan standardOffset = zone.BaseUtcOffset;
-                TimeSpan dstOffset = zone.BaseUtcOffset + rule.DaylightDelta;
-
-                DateTimeOffset? start = TransitionToUtc(rule.DaylightTransitionStart, year, standardOffset);
-                DateTimeOffset? end = TransitionToUtc(rule.DaylightTransitionEnd, year, dstOffset);
-
-                if (start is not null)
-                {
-                    transitions.Add(start.Value);
-                }
-
-                if (end is not null)
-                {
-                    transitions.Add(end.Value);
-                }
-            }
-        }
-
-        return transitions;
-    }
-
-    private static DateTimeOffset? TransitionToUtc(TimeZoneInfo.TransitionTime transition, int year, TimeSpan localOffset)
-    {
-        try
-        {
-            DateTime localDt = transition.IsFixedDateRule
-                ? new DateTime(year, transition.Month, transition.Day,
-                    transition.TimeOfDay.Hour, transition.TimeOfDay.Minute, transition.TimeOfDay.Second)
-                : GetFloatingTransitionDate(year, transition);
-
-            DateTime utcDt = localDt - localOffset;
-            return new DateTimeOffset(utcDt, TimeSpan.Zero);
-        }
-        catch (ArgumentOutOfRangeException)
-        {
-            return null;
-        }
-    }
-
-    private static DateTime GetFloatingTransitionDate(int year, TimeZoneInfo.TransitionTime transition)
-    {
-        int firstDayOfMonth = (int)new DateTime(year, transition.Month, 1).DayOfWeek;
-        int targetDay = (int)transition.DayOfWeek;
-        int offset = (targetDay - firstDayOfMonth + 7) % 7;
-        int day = 1 + offset + ((transition.Week - 1) * 7);
-
-        int daysInMonth = DateTime.DaysInMonth(year, transition.Month);
-        while (day > daysInMonth)
-        {
-            day -= 7;
-        }
-
-        return new DateTime(year, transition.Month, day,
-            transition.TimeOfDay.Hour, transition.TimeOfDay.Minute, transition.TimeOfDay.Second);
-    }
+        => DstTransitionHelper.GetTransitionsUtc(zone, yearMinus: 1, yearPlus: 1);
 
     private static List<TimeZoneInfo> BuildZonesWithDst()
     {

--- a/src/Conjecture.Time/DstTransitionHelper.cs
+++ b/src/Conjecture.Time/DstTransitionHelper.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Time;
+
+internal static class DstTransitionHelper
+{
+    internal static List<DateTimeOffset> GetTransitionsUtc(TimeZoneInfo zone, int yearMinus, int yearPlus)
+    {
+        List<DateTimeOffset> transitions = [];
+        int currentYear = DateTimeOffset.UtcNow.Year;
+
+        foreach (TimeZoneInfo.AdjustmentRule rule in zone.GetAdjustmentRules())
+        {
+            for (int year = currentYear - yearMinus; year <= currentYear + yearPlus; year++)
+            {
+                if (rule.DateStart.Year > year || rule.DateEnd.Year < year)
+                {
+                    continue;
+                }
+
+                TimeSpan standardOffset = zone.BaseUtcOffset;
+                TimeSpan dstOffset = zone.BaseUtcOffset + rule.DaylightDelta;
+
+                DateTimeOffset? start = ToUtc(rule.DaylightTransitionStart, year, standardOffset);
+                DateTimeOffset? end = ToUtc(rule.DaylightTransitionEnd, year, dstOffset);
+
+                if (start is not null)
+                {
+                    transitions.Add(start.Value);
+                }
+
+                if (end is not null)
+                {
+                    transitions.Add(end.Value);
+                }
+            }
+        }
+
+        return transitions;
+    }
+
+    private static DateTimeOffset? ToUtc(TimeZoneInfo.TransitionTime transition, int year, TimeSpan localOffset)
+    {
+        try
+        {
+            DateTime localDt = GetTransitionDate(transition, year);
+            return new DateTimeOffset(localDt - localOffset, TimeSpan.Zero);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return null;
+        }
+    }
+
+    internal static DateTime GetTransitionDate(TimeZoneInfo.TransitionTime transition, int year) =>
+        transition.IsFixedDateRule
+            ? new DateTime(year, transition.Month, transition.Day,
+                transition.TimeOfDay.Hour, transition.TimeOfDay.Minute, transition.TimeOfDay.Second)
+            : GetFloatingTransitionDate(year, transition);
+
+    private static DateTime GetFloatingTransitionDate(int year, TimeZoneInfo.TransitionTime transition)
+    {
+        int firstDayOfMonth = (int)new DateTime(year, transition.Month, 1).DayOfWeek;
+        int targetDay = (int)transition.DayOfWeek;
+        int offset = (targetDay - firstDayOfMonth + 7) % 7;
+        int day = 1 + offset + ((transition.Week - 1) * 7);
+
+        int daysInMonth = DateTime.DaysInMonth(year, transition.Month);
+        while (day > daysInMonth)
+        {
+            day -= 7;
+        }
+
+        return new DateTime(year, transition.Month, day,
+            transition.TimeOfDay.Hour, transition.TimeOfDay.Minute, transition.TimeOfDay.Second);
+    }
+}

--- a/src/Conjecture.Time/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Unshipped.txt
@@ -11,6 +11,22 @@ Conjecture.Time.DateOnlyExtensions.extension(Conjecture.Core.Strategy<System.Dat
 Conjecture.Time.DateOnlyExtensions.extension(Conjecture.Core.Strategy<System.DateOnly>!).NearLeapDay() -> Conjecture.Core.Strategy<System.DateOnly>!
 Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).WithPrecision(System.TimeSpan precision) -> Conjecture.Core.Strategy<System.DateTimeOffset>!
 Conjecture.Time.DateTimeOffsetExtensions.extension(Conjecture.Core.Strategy<System.DateTimeOffset>!).WithStrippedOffset() -> Conjecture.Core.Strategy<(System.DateTimeOffset Original, System.DateTimeOffset Stripped)>!
+Conjecture.Time.RecurringEventSample
+Conjecture.Time.RecurringEventSample.RecurringEventSample(System.DateTimeOffset WindowStart, System.DateTimeOffset WindowEnd, System.Collections.Generic.IReadOnlyList<System.DateTimeOffset>! Occurrences, System.TimeZoneInfo! Zone, System.Func<System.DateTimeOffset, System.DateTimeOffset?>! NextOccurrence) -> void
+Conjecture.Time.RecurringEventSample.NextOccurrence.get -> System.Func<System.DateTimeOffset, System.DateTimeOffset?>!
+Conjecture.Time.RecurringEventSample.NextOccurrence.init -> void
+Conjecture.Time.RecurringEventSample.Occurrences.get -> System.Collections.Generic.IReadOnlyList<System.DateTimeOffset>!
+Conjecture.Time.RecurringEventSample.Occurrences.init -> void
+Conjecture.Time.RecurringEventSample.WindowEnd.get -> System.DateTimeOffset
+Conjecture.Time.RecurringEventSample.WindowEnd.init -> void
+Conjecture.Time.RecurringEventSample.WindowStart.get -> System.DateTimeOffset
+Conjecture.Time.RecurringEventSample.WindowStart.init -> void
+Conjecture.Time.RecurringEventSample.Zone.get -> System.TimeZoneInfo!
+Conjecture.Time.RecurringEventSample.Zone.init -> void
+Conjecture.Time.RecurringEventExtensions
+Conjecture.Time.RecurringEventExtensions.extension(Conjecture.Core.Strategy<Conjecture.Time.RecurringEventSample!>!)
+Conjecture.Time.RecurringEventExtensions.extension(Conjecture.Core.Strategy<Conjecture.Time.RecurringEventSample!>!).NearDstTransition() -> Conjecture.Core.Strategy<Conjecture.Time.RecurringEventSample!>!
+static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).RecurringEvents(System.Func<System.DateTimeOffset, System.DateTimeOffset?>! nextOccurrence, System.TimeZoneInfo! zone, System.TimeSpan window) -> Conjecture.Core.Strategy<Conjecture.Time.RecurringEventSample!>!
 Conjecture.Time.TimeOnlyExtensions
 Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!)
 Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!).NearMidnight() -> Conjecture.Core.Strategy<System.TimeOnly>!

--- a/src/Conjecture.Time/RecurringEventExtensions.cs
+++ b/src/Conjecture.Time/RecurringEventExtensions.cs
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+
+namespace Conjecture.Time;
+
+/// <summary>Extension methods on <see cref="Strategy{T}"/> for <see cref="RecurringEventSample"/>.</summary>
+public static class RecurringEventExtensions
+{
+    extension(Strategy<RecurringEventSample> s)
+    {
+        /// <summary>
+        /// Returns a strategy biased toward windows that overlap a DST transition in <see cref="RecurringEventSample.Zone"/>.
+        /// Places the window start just before a randomly chosen transition and regenerates
+        /// <see cref="RecurringEventSample.Occurrences"/> for the new window.
+        /// Falls back to the base strategy when no transitions are available.
+        /// </summary>
+        public Strategy<RecurringEventSample> NearDstTransition()
+        {
+            return Generate.Compose<RecurringEventSample>(ctx =>
+            {
+                RecurringEventSample sample = ctx.Generate(s);
+                List<DateTimeOffset> transitions = DstTransitionHelper.GetTransitionsUtc(sample.Zone, yearMinus: 2, yearPlus: 2);
+
+                if (transitions.Count == 0)
+                {
+                    return sample;
+                }
+
+                int index = ctx.Generate(Generate.Integers<int>(0, transitions.Count - 1));
+                DateTimeOffset transition = transitions[index];
+                TimeSpan windowDuration = sample.WindowEnd - sample.WindowStart;
+
+                // Jitter so the transition lands somewhere inside the window.
+                long jitterTicks = ctx.Generate(Generate.Integers<long>(-windowDuration.Ticks, 0));
+                DateTimeOffset newWindowStart = transition.AddTicks(jitterTicks);
+                DateTimeOffset newWindowEnd = newWindowStart + windowDuration;
+
+                // Re-walk nextOccurrence so Occurrences reflects the new window.
+                List<DateTimeOffset> occurrences = [];
+                DateTimeOffset? current = sample.NextOccurrence(newWindowStart);
+                int steps = 0;
+                while (current is not null && current.Value <= newWindowEnd)
+                {
+                    if (++steps > 10_000)
+                    {
+                        throw new InvalidOperationException(
+                            "nextOccurrence did not advance past the window after 10 000 steps. " +
+                            "Ensure the delegate always returns a value strictly after its input.");
+                    }
+
+                    if (current.Value >= newWindowStart)
+                    {
+                        occurrences.Add(current.Value);
+                    }
+
+                    current = sample.NextOccurrence(current.Value);
+                }
+
+                return sample with
+                {
+                    WindowStart = newWindowStart,
+                    WindowEnd = newWindowEnd,
+                    Occurrences = occurrences.AsReadOnly(),
+                };
+            });
+        }
+    }
+}

--- a/src/Conjecture.Time/RecurringEventSample.cs
+++ b/src/Conjecture.Time/RecurringEventSample.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Time;
+
+/// <summary>A sample produced by <see cref="TimeGenerateExtensions.RecurringEvents"/>.</summary>
+/// <param name="WindowStart">The inclusive start of the generated window.</param>
+/// <param name="WindowEnd">The inclusive end of the generated window.</param>
+/// <param name="Occurrences">All occurrences that fall within the window.</param>
+/// <param name="Zone">The time zone associated with this sample.</param>
+/// <param name="NextOccurrence">
+/// The recurrence delegate, stored so that extensions like <c>NearDstTransition()</c> can reposition
+/// the window and regenerate <see cref="Occurrences"/> without losing correctness.
+/// </param>
+public sealed record RecurringEventSample(
+    DateTimeOffset WindowStart,
+    DateTimeOffset WindowEnd,
+    IReadOnlyList<DateTimeOffset> Occurrences,
+    TimeZoneInfo Zone,
+    Func<DateTimeOffset, DateTimeOffset?> NextOccurrence);

--- a/src/Conjecture.Time/TimeGenerateExtensions.cs
+++ b/src/Conjecture.Time/TimeGenerateExtensions.cs
@@ -77,6 +77,46 @@ public static class TimeGenerateExtensions
                 return clocks;
             });
         }
+
+        /// <summary>
+        /// Returns a strategy that generates a <see cref="RecurringEventSample"/> by walking
+        /// <paramref name="nextOccurrence"/> from a random window start until <paramref name="window"/> elapses.
+        /// </summary>
+        public static Strategy<RecurringEventSample> RecurringEvents(
+            Func<DateTimeOffset, DateTimeOffset?> nextOccurrence,
+            TimeZoneInfo zone,
+            TimeSpan window)
+        {
+            Strategy<DateTimeOffset> windowStartStrategy = Generate.DateTimeOffsets(
+                new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                new DateTimeOffset(2050, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
+            return Generate.Compose<RecurringEventSample>(ctx =>
+            {
+                DateTimeOffset windowStart = ctx.Generate(windowStartStrategy);
+                DateTimeOffset windowEnd = windowStart + window;
+                List<DateTimeOffset> occurrences = [];
+                DateTimeOffset? current = nextOccurrence(windowStart);
+                int steps = 0;
+                while (current is not null && current.Value <= windowEnd)
+                {
+                    if (++steps > 10_000)
+                    {
+                        throw new InvalidOperationException(
+                            "nextOccurrence did not advance past the window after 10 000 steps. " +
+                            "Ensure the delegate always returns a value strictly after its input.");
+                    }
+
+                    if (current.Value >= windowStart)
+                    {
+                        occurrences.Add(current.Value);
+                    }
+
+                    current = nextOccurrence(current.Value);
+                }
+                return new RecurringEventSample(windowStart, windowEnd, occurrences.AsReadOnly(), zone, nextOccurrence);
+            });
+        }
     }
 
     private static string[] BuildIanaDstIds()


### PR DESCRIPTION
## Description

Adds delegate-based recurrence testing support to `Conjecture.Time`:

- `RecurringEventSample` record: holds a generated window, all occurrences within it, the associated time zone, and the `NextOccurrence` delegate (stored so extensions can reposition the window without losing correctness)
- `Generate.RecurringEvents(nextOccurrence, zone, window)`: walks the caller-supplied delegate from a random window start in [2000, 2050]; throws `InvalidOperationException` after 10 000 steps to catch infinite loops
- `Strategy<RecurringEventSample>.NearDstTransition()`: biased generator that repositions the window around a randomly chosen DST transition and re-walks `NextOccurrence` to regenerate `Occurrences` for the new window; falls back to base strategy for zones with no transitions
- `DstTransitionHelper` extracted as a shared internal class — removes duplicated transition-date logic from `DateTimeOffsetExtensions`

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #415
Part of #292