### PR TITLE
[292.6] Adds AdvancingClocks and ClockWithAdvances strategies

### DIFF
--- a/src/Conjecture.Time.Tests/TimeProviderStrategyTests.cs
+++ b/src/Conjecture.Time.Tests/TimeProviderStrategyTests.cs
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Time;
+
+using Microsoft.Extensions.Time.Testing;
+
+namespace Conjecture.Time.Tests;
+
+public class TimeProviderStrategyTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public void ClockWithAdvances_AdvanceCountMatchesRequested(int advanceCount)
+    {
+        Strategy<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)> strategy =
+            Generate.ClockWithAdvances(advanceCount, TimeSpan.FromSeconds(10));
+
+        (FakeTimeProvider clock, IReadOnlyList<TimeSpan> advances) = DataGen.SampleOne(strategy, seed: 1UL);
+
+        Assert.Equal(advanceCount, advances.Count);
+    }
+
+    [Fact]
+    public void ClockWithAdvances_ForwardOnly_AllAdvancesAreNonNegative()
+    {
+        Strategy<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)> strategy =
+            Generate.ClockWithAdvances(20, TimeSpan.FromMinutes(1), allowBackward: false);
+
+        IReadOnlyList<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)> samples =
+            DataGen.Sample(strategy, count: 10, seed: 1UL);
+
+        Assert.All(samples, static sample =>
+            Assert.All(sample.Advances, static jump =>
+                Assert.True(jump >= TimeSpan.Zero, $"Expected non-negative jump, got {jump}")));
+    }
+
+    [Fact]
+    public void ClockWithAdvances_WithBackward_SomeAdvancesAreNegative()
+    {
+        Strategy<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)> strategy =
+            Generate.ClockWithAdvances(10, TimeSpan.FromMinutes(1), allowBackward: true);
+
+        IReadOnlyList<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)> samples =
+            DataGen.Sample(strategy, count: 30, seed: 42UL);
+
+        bool anyNegative = samples.Any(static s => s.Advances.Any(static j => j < TimeSpan.Zero));
+        Assert.True(anyNegative, "Expected at least one negative advance across 30 samples with allowBackward: true");
+    }
+
+    [Fact]
+    public void ClockWithAdvances_MaxJumpRespected()
+    {
+        TimeSpan maxJump = TimeSpan.FromSeconds(30);
+        Strategy<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)> strategy =
+            Generate.ClockWithAdvances(10, maxJump, allowBackward: true);
+
+        IReadOnlyList<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)> samples =
+            DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, sample =>
+            Assert.All(sample.Advances, jump =>
+                Assert.True(jump.Duration() <= maxJump, $"Jump {jump} exceeds maxJump {maxJump}")));
+    }
+
+    [Fact]
+    public void AdvancingClocks_ProducesVariety()
+    {
+        Strategy<FakeTimeProvider> strategy = Generate.AdvancingClocks(TimeSpan.FromMinutes(5));
+
+        IReadOnlyList<FakeTimeProvider> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        System.Collections.Generic.HashSet<DateTimeOffset> distinct = [.. samples.Select(static c => c.GetUtcNow())];
+        Assert.True(distinct.Count >= 3, $"Expected at least 3 distinct UtcNow starting points, got {distinct.Count}");
+    }
+}

--- a/src/Conjecture.Time/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Time/PublicAPI.Unshipped.txt
@@ -32,3 +32,5 @@ Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.Tim
 Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!).NearMidnight() -> Conjecture.Core.Strategy<System.TimeOnly>!
 Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!).NearNoon() -> Conjecture.Core.Strategy<System.TimeOnly>!
 Conjecture.Time.TimeOnlyExtensions.extension(Conjecture.Core.Strategy<System.TimeOnly>!).NearEndOfDay() -> Conjecture.Core.Strategy<System.TimeOnly>!
+static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).AdvancingClocks(System.TimeSpan maxJump) -> Conjecture.Core.Strategy<Microsoft.Extensions.Time.Testing.FakeTimeProvider!>!
+static Conjecture.Time.TimeGenerateExtensions.extension(Conjecture.Core.Generate!).ClockWithAdvances(int advanceCount, System.TimeSpan maxJump, bool allowBackward = false) -> Conjecture.Core.Strategy<(Microsoft.Extensions.Time.Testing.FakeTimeProvider! Clock, System.Collections.Generic.IReadOnlyList<System.TimeSpan>! Advances)>!

--- a/src/Conjecture.Time/TimeGenerateExtensions.cs
+++ b/src/Conjecture.Time/TimeGenerateExtensions.cs
@@ -18,6 +18,10 @@ public static class TimeGenerateExtensions
     private static readonly string[] WindowsIds = BuildWindowsIds();
     private static readonly TimeZoneInfo[] CrossPlatformDstZones = BuildCrossPlatformDstZones();
 
+    private static readonly Strategy<DateTimeOffset> ClockStartStrategy = Generate.DateTimeOffsets(
+        new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero),
+        new DateTimeOffset(2050, 1, 1, 0, 0, 0, TimeSpan.Zero));
+
     extension(Generate)
     {
         /// <summary>Returns a strategy that picks uniformly from the system time zones, shrinking toward UTC.</summary>
@@ -79,6 +83,60 @@ public static class TimeGenerateExtensions
         }
 
         /// <summary>
+        /// Returns a strategy that generates a <see cref="FakeTimeProvider"/> pre-positioned at a
+        /// random time within <paramref name="maxJump"/> of the 2000-01-01 UTC anchor.
+        /// </summary>
+        /// <param name="maxJump">Width of the time window. Must be positive.</param>
+        public static Strategy<FakeTimeProvider> AdvancingClocks(TimeSpan maxJump)
+        {
+            if (maxJump <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxJump), maxJump, "maxJump must be positive.");
+            }
+
+            DateTimeOffset anchor = new(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
+            Strategy<DateTimeOffset> startStrategy = Generate.DateTimeOffsets(anchor, anchor + maxJump);
+
+            return Generate.Compose<FakeTimeProvider>(ctx =>
+            {
+                DateTimeOffset start = ctx.Generate(startStrategy);
+                return new FakeTimeProvider(start);
+            });
+        }
+
+        /// <summary>
+        /// Returns a strategy that generates a <see cref="FakeTimeProvider"/> paired with
+        /// <paramref name="advanceCount"/> time advances, each in
+        /// [<paramref name="allowBackward"/> ? <c>-maxJump</c> : <c>Zero</c>, <c>maxJump</c>].
+        /// </summary>
+        /// <param name="advanceCount">Number of advances to generate.</param>
+        /// <param name="maxJump">Maximum magnitude of each advance.</param>
+        /// <param name="allowBackward">When <see langword="true"/>, advances may be negative.</param>
+        public static Strategy<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)> ClockWithAdvances(
+            int advanceCount, TimeSpan maxJump, bool allowBackward = false)
+        {
+            if (advanceCount < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(advanceCount), advanceCount, "advanceCount must be at least 1.");
+            }
+
+            long minTicks = allowBackward ? -maxJump.Ticks : 0L;
+            Strategy<long> jumpStrategy = Generate.Integers<long>(minTicks, maxJump.Ticks);
+
+            return Generate.Compose<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)>(ctx =>
+            {
+                DateTimeOffset start = ctx.Generate(TimeGenerateExtensions.ClockStartStrategy);
+                FakeTimeProvider clock = new(start);
+                TimeSpan[] advances = new TimeSpan[advanceCount];
+                for (int i = 0; i < advanceCount; i++)
+                {
+                    advances[i] = TimeSpan.FromTicks(ctx.Generate(jumpStrategy));
+                }
+                return (clock, advances);
+            });
+        }
+
+        /// <summary>
         /// Returns a strategy that generates a <see cref="RecurringEventSample"/> by walking
         /// <paramref name="nextOccurrence"/> from a random window start until <paramref name="window"/> elapses.
         /// </summary>
@@ -87,13 +145,9 @@ public static class TimeGenerateExtensions
             TimeZoneInfo zone,
             TimeSpan window)
         {
-            Strategy<DateTimeOffset> windowStartStrategy = Generate.DateTimeOffsets(
-                new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero),
-                new DateTimeOffset(2050, 1, 1, 0, 0, 0, TimeSpan.Zero));
-
             return Generate.Compose<RecurringEventSample>(ctx =>
             {
-                DateTimeOffset windowStart = ctx.Generate(windowStartStrategy);
+                DateTimeOffset windowStart = ctx.Generate(TimeGenerateExtensions.ClockStartStrategy);
                 DateTimeOffset windowEnd = windowStart + window;
                 List<DateTimeOffset> occurrences = [];
                 DateTimeOffset? current = nextOccurrence(windowStart);


### PR DESCRIPTION
## Description

Adds two adversarial `FakeTimeProvider` generation strategies to `Conjecture.Time`:

- `Generate.AdvancingClocks(maxJump)` — returns a `FakeTimeProvider` pre-positioned at a random time within `maxJump` of the 2000-01-01 UTC anchor. Guards against non-positive `maxJump`.
- `Generate.ClockWithAdvances(advanceCount, maxJump, allowBackward)` — pairs a `FakeTimeProvider` with a list of `advanceCount` generated `TimeSpan` advances in `[allowBackward ? -maxJump : Zero, maxJump]`. Guards against `advanceCount < 1`.
- Extracts shared `ClockStartStrategy` field (2000–2050 DateTimeOffset range) previously duplicated inline in `RecurringEvents` and across both new methods.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #416
Part of #292