### PR TITLE
[292] Conjecture.Time Enterprise Extensions – MCP + Docs

### DIFF
--- a/.claude/agents/cycle-runner.md
+++ b/.claude/agents/cycle-runner.md
@@ -46,14 +46,18 @@ dotnet format src/ --include <file1> --include <file2> … --exclude-diagnostics
 
 Run `dotnet build src/`. It must fail or show test failures (red). If unexpectedly green, stop and return `UNEXPECTED_GREEN`.
 
+> Do not pass `-q` to `dotnet build` — the quiet flag suppresses errors that are needed to diagnose failures.
+
 ### 2. Green — implement
 
 Spawn `developer` with `test_class_name` + any prior reviewer findings (on retries).
 
 Format changed files as in step 1. Run:
 ```bash
-dotnet test src/ --filter "FullyQualifiedName~<test_class_name>" --no-build
+dotnet test src/ --filter "FullyQualifiedName~<test_class_name>"
 ```
+
+> Do not pass `--no-build` — it skips compilation and may run stale binaries.
 
 If tests still fail, re-spawn `developer` with the failing output as additional context. Cap: **2 total developer attempts per Green phase**. If still failing, stop and return `GREEN_FAILED`.
 

--- a/.claude/skills/implement-enhancement/SKILL.md
+++ b/.claude/skills/implement-enhancement/SKILL.md
@@ -25,7 +25,7 @@ The main thread holds **only**: parent issue #, branch name, contributor list, t
 ```bash
 gh issue view <parent> --repo kommundsen/Conjecture --json number,title,body,state,labels
 gh issue list --repo kommundsen/Conjecture --state open --json number,title --limit 200 \
-  | jq -r '.[] | select(.title | test("^\\[" + "<parent>" + "\\."))'
+  | jq -r --arg p "<parent>" '.[] | select(.title | startswith("[" + $p + "."))'
 ```
 
 Extract:

--- a/.gitignore
+++ b/.gitignore
@@ -491,5 +491,3 @@ $RECYCLE.BIN/
 docs/site/api/
 docs/site/_site/
 
-# Claude Code worktrees
-.claude/worktrees/

--- a/docs/site/articles/explanation/time-bugs.md
+++ b/docs/site/articles/explanation/time-bugs.md
@@ -1,0 +1,65 @@
+# Why time bugs are disproportionately dangerous
+
+Time-related bugs are among the most expensive in enterprise .NET. They are rare enough that teams underinvest in testing them, subtle enough that they survive code review, and devastating when they occur — corrupting billing records, misfiring scheduled tasks, or creating silent data loss that takes days to diagnose. This page explains the four mechanisms that make time bugs so difficult to catch.
+
+## DST transitions create invalid and ambiguous times
+
+Twice a year, most time zones perform a Daylight Saving Time (DST) adjustment:
+
+- **Spring-forward**: clocks skip from 02:00 to 03:00. The times 02:00–02:59 do not exist in that zone on that day. Any code that constructs or maps a local time in this gap either throws, silently wraps, or produces an incorrect result.
+- **Fall-back**: clocks repeat 01:00–01:59. Every local time in that window is ambiguous — it could be the first or second occurrence. Code that does not explicitly handle this maps to the wrong UTC instant roughly half the time.
+
+The impact is concrete: a nightly billing job scheduled for 02:30 local time will skip its execution during spring-forward and run twice during fall-back. A cron-based reminder will fire at the wrong UTC time for all users in the affected zone.
+
+Standard unit tests almost never cover this because developers write tests against `DateTime.UtcNow` and specific dates, not against the ±1-hour window around the transition. Conjecture's `.NearDstTransition()` and `Generate.TimeZone(preferDst: true)` target exactly this region.
+
+## `DateTime.Kind` silently redefines semantics
+
+`DateTime.Kind` is a three-valued property — `Utc`, `Local`, `Unspecified` — that .NET uses to interpret the value. The same ticks with a different `Kind` represent a different instant, but the property is invisible in most logs, JSON output, and database records:
+
+- Serialisers that assume `Kind == Utc` will emit the wrong timestamp when given a `Local` or `Unspecified` value.
+- ORMs that coerce `Unspecified` to `Utc` silently shift timestamps by the server's UTC offset.
+- `DateTime.Compare` and `==` ignore `Kind`, so tests written with `Assert.Equal` pass even when the stored value has the wrong kind.
+
+The `Unspecified` kind is the most dangerous: it is the default when parsing without explicit format information and is also the value returned by many date arithmetic operations. Teams discover these bugs months later when a server is moved to a different time zone.
+
+`Generate.DateTimes().WithKinds()` generates all three kinds in a single property, making it impossible to accidentally test only `Utc`.
+
+## Database providers strip or round time values
+
+The gap between what .NET stores in a `DateTimeOffset` and what the database returns is a persistent source of bugs:
+
+| Scenario | What happens |
+|---|---|
+| SQL Server `datetime2(3)` | Rounds sub-millisecond ticks; your 100 ns precision is silently lost |
+| Most providers (EF Core default) | Strips the UTC offset; reconstructed value is always `Offset = Zero` |
+| SQLite text storage | Rounds to seconds |
+| PostgreSQL `timestamp` (no tz) | Drops offset; value stored as naive local time |
+
+The bug manifests as a roundtrip inequality: `original != db.Reload().Timestamp`. Because this inequality only involves sub-millisecond precision or the offset value, it is invisible to any test that asserts only on the date and time components.
+
+`.WithPrecision(TimeSpan precision)` lets you generate values that already have the precision the provider will store, making the roundtrip property deterministically true or false. `.WithStrippedOffset()` models offset-dropping providers explicitly.
+
+## Clock skew breaks distributed invariants
+
+In distributed systems, each node's `DateTimeOffset.UtcNow` is not identical. NTP keeps clocks roughly synchronised, but "roughly" means differences of tens to hundreds of milliseconds under normal conditions, and arbitrary differences during failover or leap-second events. Bugs that depend on this:
+
+- Leader elections that assume the leader's clock is always ahead of followers.
+- Event-sourcing systems that use `UtcNow` as a sequence number and fail when events arrive out of order.
+- Token expiry checks that rely on clock monotonicity.
+- Rate limiters that bucket requests by minute and silently allow extra requests at minute boundaries.
+
+These bugs are untestable with `DateTime.UtcNow` because the test process has a single clock. `Generate.ClockSet(nodeCount, maxSkew)` generates a cluster of `FakeTimeProvider` instances with bounded pairwise skew, and `Generate.ClockWithAdvances(advanceCount, maxJump, allowBackward: true)` generates adversarial clock sequences including backward jumps.
+
+## Historical note on scope
+
+Conjecture's time strategies target the BCL types: `DateTimeOffset`, `DateOnly`, `TimeOnly`, `TimeZoneInfo`, `DateTimeKind`. Historical timezone data (pre-1970 DST rule changes, the 1883 US railroad standardisation, the 2011 Samoa date line change) is not in scope — the strategies use the current OS tzdata, which does not include historical adjustments. For historically accurate coverage, use the future NodaTime adapter.
+
+## See also
+
+- [How to test DST-sensitive code](../how-to/test-dst-sensitive-code.md)
+- [How to test DateTime.Kind safety](../how-to/test-datetime-kind-safety.md)
+- [How to test DateOnly/TimeOnly boundary conditions](../how-to/test-dateonly-timeonly-boundaries.md)
+- [How to test DB provider DateTimeOffset precision](../how-to/test-datetimeoffset-precision.md)
+- [How to test recurring event schedules across DST](../how-to/test-recurring-events-across-dst.md)
+- [Reference: Time strategies](../reference/time-strategies.md)

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -23,3 +23,5 @@ items:
     href: money-decimal-arithmetic.md
   - name: Why nested quantifiers cause catastrophic backtracking
     href: regex-catastrophic-backtracking.md
+  - name: Why time bugs are disproportionately dangerous
+    href: time-bugs.md

--- a/docs/site/articles/how-to/test-dateonly-timeonly-boundaries.md
+++ b/docs/site/articles/how-to/test-dateonly-timeonly-boundaries.md
@@ -1,0 +1,93 @@
+# How to test DateOnly and TimeOnly boundary conditions
+
+Month-end rollovers, leap days, and midnight/noon transitions are persistent sources of date arithmetic bugs. Conjecture's `Conjecture.Time` extensions bias generation toward these values so a regular property test reliably hits them.
+
+> [!NOTE]
+> Requires the `Conjecture.Time` NuGet package.
+
+## DateOnly boundary extensions
+
+Chain extensions after `Generate.DateOnlyValues()`.
+
+### `.NearMonthBoundary()`
+
+Generates the first or last day of a random month (year 2000–2099). Targets off-by-one errors in month-spanning ranges:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Time;
+
+[Property]
+public bool BillingCycle_HasCorrectDayCount(int x)
+{
+    DateOnly start = DataGen.SampleOne(Generate.DateOnlyValues().NearMonthBoundary());
+    int days = BillingCycle.DaysInPeriod(start, start.AddMonths(1));
+    return days is >= 28 and <= 31;
+}
+```
+
+### `.NearLeapDay()`
+
+Generates dates within ±1 day of February 29 in a leap year (years 1970–2400). Targets leap-year-specific bugs:
+
+```csharp
+[Property]
+public bool AgeCalculator_HandlesLeapBirthdays(int x)
+{
+    DateOnly birthday = DataGen.SampleOne(Generate.DateOnlyValues().NearLeapDay());
+    DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow);
+    int age = AgeCalculator.ComputeAge(birthday, today);
+    return age >= 0;
+}
+```
+
+## TimeOnly boundary extensions
+
+Chain extensions after `Generate.TimeOnlyValues()`.
+
+### `.NearMidnight()`
+
+Generates times within 30 seconds of midnight, covering both ends of the day: `[00:00:00, 00:00:30]` and `[23:59:30, 23:59:59.9999999]`:
+
+```csharp
+[Property]
+public bool Scheduler_HandlesNearMidnight(int x)
+{
+    TimeOnly trigger = DataGen.SampleOne(Generate.TimeOnlyValues().NearMidnight());
+    return Scheduler.IsValidTriggerTime(trigger);
+}
+```
+
+### `.NearNoon()`
+
+Generates times within 30 seconds of 12:00:00. Useful for systems that treat noon as a shift boundary or special aggregation point:
+
+```csharp
+[Property]
+public bool ShiftHandover_AtNoon_IsComplete(int x)
+{
+    TimeOnly handover = DataGen.SampleOne(Generate.TimeOnlyValues().NearNoon());
+    ShiftHandoverResult result = ShiftManager.ComputeHandover(handover);
+    return result is not null;
+}
+```
+
+### `.NearEndOfDay()`
+
+Generates times within 30 seconds of 23:59:59:
+
+```csharp
+[Property]
+public bool DailyReport_IncludesEndOfDayEntries(int x)
+{
+    TimeOnly entryTime = DataGen.SampleOne(Generate.TimeOnlyValues().NearEndOfDay());
+    DateOnly date = DateOnly.FromDateTime(DateTime.UtcNow);
+    DailyReport report = ReportBuilder.Build(date);
+    return report.Includes(date, entryTime);
+}
+```
+
+## See also
+
+- [Reference: Time strategies](../reference/time-strategies.md)
+- [Explanation: Why time bugs are disproportionately dangerous](../explanation/time-bugs.md)

--- a/docs/site/articles/how-to/test-datetime-kind-safety.md
+++ b/docs/site/articles/how-to/test-datetime-kind-safety.md
@@ -1,0 +1,63 @@
+# How to test DateTime.Kind safety
+
+`DateTime.Kind` silently changes how a value is interpreted. ORMs, JSON serialisers, and HTTP clients that assume `Kind == Utc` produce incorrect results when passed a `Local` or `Unspecified` value — and these bugs are invisible at the call site.
+
+> [!NOTE]
+> Requires the `Conjecture.Time` NuGet package.
+
+## Fuzz all three kinds
+
+`.WithKinds()` generates each `DateTime` value paired with a randomly chosen `DateTimeKind`, covering `Utc`, `Local`, and `Unspecified` uniformly:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Time;
+
+[Property]
+public bool Serializer_PreservesKind(int x)
+{
+    (DateTime value, DateTimeKind kind) = DataGen.SampleOne(
+        Generate.DateTimes().WithKinds());
+
+    string json = JsonSerializer.Serialize(new { Timestamp = value });
+    DateTime roundtripped = JsonSerializer.Deserialize<TimestampDto>(json)!.Timestamp;
+    return roundtripped.Kind == kind;
+}
+```
+
+The strategy shrinks toward `Kind == Utc` and the earliest dates, so a failure simplifies to the minimal `Kind` variant that triggers the bug.
+
+## Catch silent Kind coercion
+
+Many ORMs coerce `Unspecified` to `Utc` without warning. A property that exposes this:
+
+```csharp
+[Property]
+public bool DbContext_DoesNotSilentlyCoerceKind(int x)
+{
+    (DateTime value, DateTimeKind kind) = DataGen.SampleOne(
+        Generate.DateTimes().WithKinds());
+
+    using TestDbContext db = new();
+    db.Events.Add(new Event { OccurredAt = value });
+    db.SaveChanges();
+    db.ChangeTracker.Clear();
+
+    DateTime stored = db.Events.Single().OccurredAt;
+    return stored.Kind == kind;
+}
+```
+
+When this fails, Conjecture will shrink to the minimal `DateTimeKind` and simplest date that exposes the coercion.
+
+> [!TIP]
+> If you only care about one kind, filter with `Where`:
+> ```csharp
+> Generate.DateTimes().WithKinds()
+>     .Where(static t => t.Kind == DateTimeKind.Unspecified)
+> ```
+
+## See also
+
+- [Reference: Time strategies](../reference/time-strategies.md)
+- [Explanation: Why time bugs are disproportionately dangerous](../explanation/time-bugs.md)

--- a/docs/site/articles/how-to/test-datetimeoffset-precision.md
+++ b/docs/site/articles/how-to/test-datetimeoffset-precision.md
@@ -1,0 +1,80 @@
+# How to test DB provider DateTimeOffset precision
+
+Database providers commonly transform `DateTimeOffset` values on write: SQL Server rounds to 100 ns, many providers strip the UTC offset entirely and store UTC. These silent transformations produce bugs that only appear in integration tests with real data round-tripped through the database.
+
+> [!NOTE]
+> Requires the `Conjecture.Time` NuGet package.
+
+## Test millisecond-precision roundtrips
+
+`.WithPrecision(TimeSpan precision)` truncates each generated value to the given precision, matching what the provider actually stores, so you can assert that the value survives a full roundtrip:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Time;
+
+[Property]
+public bool Repository_RoundtripsDateTimeOffset(int x)
+{
+    DateTimeOffset value = DataGen.SampleOne(
+        Generate.DateTimeOffsets().WithPrecision(TimeSpan.FromMilliseconds(1)));
+
+    using TestDbContext db = new();
+    db.Orders.Add(new Order { PlacedAt = value });
+    db.SaveChanges();
+    db.ChangeTracker.Clear();
+
+    DateTimeOffset stored = db.Orders.Single().PlacedAt;
+    return stored == value;
+}
+```
+
+> [!TIP]
+> Match precision to your provider:
+> - SQL Server `datetime2(7)` → `TimeSpan.FromTicks(1)` (100 ns)
+> - SQL Server `datetime2(3)` / most others → `TimeSpan.FromMilliseconds(1)`
+> - SQLite → `TimeSpan.FromSeconds(1)` (text storage, second precision by default)
+
+## Test offset-stripping roundtrips
+
+`.WithStrippedOffset()` returns each value paired with a UTC-normalised copy (offset removed), modelling providers that store UTC and reconstruct the value without the original offset:
+
+```csharp
+[Property]
+public bool AuditLog_PreservesUtcTimeAfterNormalisation(int x)
+{
+    (DateTimeOffset original, DateTimeOffset stripped) = DataGen.SampleOne(
+        Generate.DateTimeOffsets().WithStrippedOffset());
+
+    // stripped == original converted to UTC (Offset = Zero, Ticks unchanged)
+    AuditEntry entry = AuditLog.Record(original);
+    AuditEntry loaded = AuditLog.Load(entry.Id);
+
+    return loaded.Timestamp.ToUniversalTime() == original.ToUniversalTime();
+}
+```
+
+## Test near DST transitions
+
+`.NearDstTransition(zone?)` generates values within ±1 hour of a DST transition, which is when offset-stripping bugs are most likely to cause incorrect local-time reconstruction:
+
+```csharp
+[Property]
+public bool Cache_ReconstructsCorrectLocalTime_AroundDst(int x)
+{
+    TimeZoneInfo zone = DataGen.SampleOne(Generate.TimeZone(preferDst: true));
+    DateTimeOffset value = DataGen.SampleOne(
+        Generate.DateTimeOffsets().NearDstTransition(zone));
+
+    CacheEntry cached = Cache.Store(value, zone);
+    DateTimeOffset reconstructed = Cache.Load(cached.Key, zone);
+
+    return reconstructed.ToUniversalTime() == value.ToUniversalTime();
+}
+```
+
+## See also
+
+- [Reference: Time strategies](../reference/time-strategies.md)
+- [How to test DST-sensitive code](test-dst-sensitive-code.md)
+- [Explanation: Why time bugs are disproportionately dangerous](../explanation/time-bugs.md)

--- a/docs/site/articles/how-to/test-dst-sensitive-code.md
+++ b/docs/site/articles/how-to/test-dst-sensitive-code.md
@@ -1,0 +1,77 @@
+# How to test DST-sensitive code
+
+DST transitions cause production incidents in recurring jobs (a 2:00 AM task that fires twice in autumn or not at all in spring), time-window queries, and any code that converts between UTC and local time.
+Conjecture's time strategies let you reproduce these conditions deterministically.
+
+> [!NOTE]
+> Requires the `Conjecture.Time` NuGet package.
+
+## Generate DST-heavy time zones
+
+`Generate.TimeZone(preferDst: true)` biases zone sampling toward zones with active DST rules:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Time;
+
+[Property]
+public bool DailyJob_FiresExactlyOnce(int x)
+{
+    TimeZoneInfo zone = DataGen.SampleOne(Generate.TimeZone(preferDst: true));
+    DateTimeOffset trigger = DataGen.SampleOne(
+        Generate.DateTimeOffsets().NearDstTransition(zone));
+
+    DailyJob job = new(zone);
+    int fires = job.CountFirings(trigger, trigger.AddDays(1));
+    return fires == 1;
+}
+```
+
+## Target DST transition windows
+
+`.NearDstTransition(zone?)` constrains values to within ±1 hour of a real DST transition in `zone` — the window where ambiguous and invalid local times occur:
+
+```csharp
+[Property]
+public bool LocalTimeConversion_Roundtrips(int x)
+{
+    TimeZoneInfo zone = DataGen.SampleOne(Generate.TimeZone(preferDst: true));
+    DateTimeOffset utc = DataGen.SampleOne(
+        Generate.DateTimeOffsets().NearDstTransition(zone));
+
+    DateTimeOffset local = TimeZoneInfo.ConvertTime(utc, zone);
+    DateTimeOffset backToUtc = TimeZoneInfo.ConvertTimeToUtc(local.DateTime, zone);
+    return backToUtc == utc;
+}
+```
+
+If `zone` is `null`, a random DST-having zone from the system list is chosen automatically.
+
+## Use IANA zone IDs for cross-platform tests
+
+`Generate.IanaZoneIds()` samples from a curated ~20-ID cross-platform-safe subset verified to resolve on .NET 8+ on Windows, Linux, and macOS:
+
+```csharp
+[Property]
+public bool ZoneConversion_WorksAcrossPlatforms(int x)
+{
+    string ianaId = DataGen.SampleOne(Generate.IanaZoneIds());
+    TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById(ianaId);
+    return zone is not null;
+}
+```
+
+For Windows timezone IDs, use `Generate.WindowsZoneIds()`. For DST-heavy IDs specifically, pass `preferDst: true`:
+
+```csharp
+string dstIanaId = DataGen.SampleOne(Generate.IanaZoneIds(preferDst: true));
+```
+
+> [!NOTE]
+> The curated IANA subset covers common enterprise zones. For exhaustive coverage, use `Generate.TimeZones()` which calls `TimeZoneInfo.GetSystemTimeZones()`, but note that available IDs differ across operating systems.
+
+## See also
+
+- [Reference: Time strategies](../reference/time-strategies.md) — full API details
+- [How to test recurring event schedules across DST](test-recurring-events-across-dst.md)
+- [Explanation: Why time bugs are disproportionately dangerous](../explanation/time-bugs.md)

--- a/docs/site/articles/how-to/test-recurring-events-across-dst.md
+++ b/docs/site/articles/how-to/test-recurring-events-across-dst.md
@@ -1,0 +1,100 @@
+# How to test recurring event schedules across DST
+
+Recurring jobs (daily reports, billing cycles, cron tasks) fail silently across DST transitions: a job scheduled for 2:30 AM either skips that slot during spring-forward or fires twice during fall-back. `Generate.RecurringEvents` lets you verify these invariants without a scheduling library dependency.
+
+> [!NOTE]
+> Requires the `Conjecture.Time` NuGet package.
+
+## Define a recurrence delegate
+
+`Generate.RecurringEvents` accepts a `Func<DateTimeOffset, DateTimeOffset?> nextOccurrence` delegate. It must return the next firing time strictly after the given instant, or `null` to signal no further occurrences:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.Time;
+
+static DateTimeOffset? NextDailyAt2Am(DateTimeOffset after)
+{
+    // Next 02:00 in UTC — replace with your scheduler's logic
+    DateTimeOffset candidate = after.UtcDateTime.Date.AddDays(1).AddHours(2);
+    return candidate > after ? candidate : candidate.AddDays(1);
+}
+```
+
+> [!WARNING]
+> `nextOccurrence` must always return a value strictly after its input. After 10,000 non-advancing calls `Generate.RecurringEvents` throws `InvalidOperationException` as a safeguard against infinite loops.
+
+## Write a DST-invariant property
+
+`Generate.RecurringEvents` generates a `RecurringEventSample` containing the window boundaries, all occurrences within it, the zone, and the delegate — ready for invariant assertions:
+
+```csharp
+[Property]
+public bool DailyJob_FiringCountIsReasonable(int x)
+{
+    TimeZoneInfo zone = DataGen.SampleOne(Generate.TimeZone(preferDst: true));
+    RecurringEventSample sample = DataGen.SampleOne(
+        Generate.RecurringEvents(NextDailyAt2Am, zone, window: TimeSpan.FromDays(7)));
+
+    // A daily job should fire 6–8 times in a 7-day window (DST may add or remove one)
+    return sample.Occurrences.Count is >= 6 and <= 8;
+}
+```
+
+## Bias toward DST transition windows
+
+`.NearDstTransition()` on `Strategy<RecurringEventSample>` shifts the window start to just before a real DST transition in the zone — the most adversarial region for recurring events:
+
+```csharp
+[Property]
+public bool DailyJob_FiresAtLeastOnceAcrossTransition(int x)
+{
+    TimeZoneInfo zone = DataGen.SampleOne(Generate.TimeZone(preferDst: true));
+    RecurringEventSample sample = DataGen.SampleOne(
+        Generate.RecurringEvents(NextDailyAt2Am, zone, window: TimeSpan.FromDays(2))
+            .NearDstTransition());
+
+    // Even if the spring-forward gap swallows exactly one 2 AM slot, the job must fire
+    // at least once across a 2-day window around the transition
+    return sample.Occurrences.Count >= 1;
+}
+```
+
+## Integrate with NCrontab or other schedulers
+
+Because the delegate is a plain `Func`, you can wrap any scheduling library:
+
+```csharp
+using NCrontab;
+
+CrontabSchedule cron = CrontabSchedule.Parse("30 2 * * *"); // 02:30 daily
+
+static DateTimeOffset? NextOccurrence(DateTimeOffset after) =>
+    new DateTimeOffset?(cron.GetNextOccurrence(after.UtcDateTime));
+
+[Property]
+public bool CronJob_NoDoubleFireInFallBack(int x)
+{
+    TimeZoneInfo eastern = TimeZoneInfo.FindSystemTimeZoneById("America/New_York");
+    RecurringEventSample sample = DataGen.SampleOne(
+        Generate.RecurringEvents(NextOccurrence, eastern, window: TimeSpan.FromDays(1))
+            .NearDstTransition());
+
+    // No two occurrences within the same logical slot (less than 23 hours apart)
+    for (int i = 1; i < sample.Occurrences.Count; i++)
+    {
+        if (sample.Occurrences[i] - sample.Occurrences[i - 1] < TimeSpan.FromHours(23))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+```
+
+## See also
+
+- [Reference: Time strategies](../reference/time-strategies.md)
+- [How to test DST-sensitive code](test-dst-sensitive-code.md)
+- [Explanation: Why time bugs are disproportionately dangerous](../explanation/time-bugs.md)

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -31,6 +31,16 @@ items:
     href: use-cli-tool.md
   - name: Use time strategies
     href: use-time-strategies.md
+  - name: Test DST-sensitive code
+    href: test-dst-sensitive-code.md
+  - name: Test DateTime.Kind safety
+    href: test-datetime-kind-safety.md
+  - name: Test DateOnly/TimeOnly boundary conditions
+    href: test-dateonly-timeonly-boundaries.md
+  - name: Test DB provider DateTimeOffset precision
+    href: test-datetimeoffset-precision.md
+  - name: Test recurring event schedules across DST
+    href: test-recurring-events-across-dst.md
   - name: Use money strategies
     href: use-money-strategies.md
   - name: Use Gen.auto for F# records and unions

--- a/docs/site/articles/reference/time-strategies.md
+++ b/docs/site/articles/reference/time-strategies.md
@@ -3,17 +3,52 @@
 Strategies in the `Conjecture.Time` package for generating time-related values with boundary awareness.
 
 > [!NOTE]
-> Requires the `Conjecture.Time` NuGet package. The core `Generate.DateTimeOffsets()`, `Generate.TimeSpans()`, `Generate.DateOnlyValues()`, and `Generate.TimeOnlyValues()` methods are in `Conjecture.Core` and do not require this package.
+> Requires the `Conjecture.Time` NuGet package. The core `Generate.DateTimeOffsets()`, `Generate.TimeSpans()`, `Generate.DateOnlyValues()`, `Generate.TimeOnlyValues()`, and `Generate.DateTimes()` methods are in `Conjecture.Core` and do not require this package.
 
-## `Generate.TimeZones()`
+---
+
+## TimeZoneInfo strategies
+
+### `Generate.TimeZones()`
 
 ```csharp
 Strategy<TimeZoneInfo> Generate.TimeZones()
 ```
 
-Picks uniformly from system time zones. Shrinks toward `TimeZoneInfo.Utc`.
+Picks uniformly from all system time zones via `TimeZoneInfo.GetSystemTimeZones()`. Shrinks toward `TimeZoneInfo.Utc`.
 
-## `Generate.ClockSet(int nodeCount, TimeSpan maxSkew)`
+> [!NOTE]
+> Available IDs differ across operating systems. For reproducible cross-platform tests, prefer `Generate.TimeZone()` or `Generate.IanaZoneIds()`.
+
+### `Generate.TimeZone(bool preferDst = false)`
+
+```csharp
+Strategy<TimeZoneInfo> Generate.TimeZone(bool preferDst = false)
+```
+
+Samples from a curated ~20-ID cross-platform-safe subset verified to resolve on .NET 8+ on Windows, Linux, and macOS. When `preferDst` is `true`, restricts to the subset of zones with active DST rules.
+
+### `Generate.IanaZoneIds(bool preferDst = false)`
+
+```csharp
+Strategy<string> Generate.IanaZoneIds(bool preferDst = false)
+```
+
+Returns IANA timezone IDs from the same cross-platform-safe curated subset as `Generate.TimeZone()`. Pass `preferDst: true` to restrict to DST-having zones. Use the returned string with `TimeZoneInfo.FindSystemTimeZoneById(id)`.
+
+### `Generate.WindowsZoneIds()`
+
+```csharp
+Strategy<string> Generate.WindowsZoneIds()
+```
+
+Returns Windows timezone IDs derived from the curated IANA subset via `TimeZoneInfo.TryConvertIanaIdToWindowsId`. Useful for testing code that stores or reads Windows-format zone IDs.
+
+---
+
+## FakeTimeProvider strategies
+
+### `Generate.ClockSet(int nodeCount, TimeSpan maxSkew)`
 
 ```csharp
 Strategy<FakeTimeProvider[]> Generate.ClockSet(int nodeCount, TimeSpan maxSkew)
@@ -21,44 +56,102 @@ Strategy<FakeTimeProvider[]> Generate.ClockSet(int nodeCount, TimeSpan maxSkew)
 
 Generates an array of `nodeCount` `FakeTimeProvider` instances, each with a clock offset in `[-maxSkew/2, +maxSkew/2]` relative to `DateTimeOffset.UtcNow`. `nodeCount` must be >= 2.
 
-## `TimeProviderArbitrary`
+Use for distributed-system tests where nodes observe slightly different wall-clock times.
+
+### `Generate.AdvancingClocks(TimeSpan maxJump)`
+
+```csharp
+Strategy<FakeTimeProvider> Generate.AdvancingClocks(TimeSpan maxJump)
+```
+
+Generates a single `FakeTimeProvider` pre-positioned at a random time within `[2000-01-01, 2000-01-01 + maxJump]`. `maxJump` must be positive.
+
+### `Generate.ClockWithAdvances(int advanceCount, TimeSpan maxJump, bool allowBackward = false)`
+
+```csharp
+Strategy<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)>
+    Generate.ClockWithAdvances(int advanceCount, TimeSpan maxJump, bool allowBackward = false)
+```
+
+Generates a `FakeTimeProvider` paired with `advanceCount` pre-drawn `TimeSpan` advances, each in `[0, maxJump]` (or `[-maxJump, maxJump]` when `allowBackward` is `true`). `advanceCount` must be >= 1.
+
+Use to drive the clock through adversarial sequences without coupling the test to `Thread.Sleep`:
+
+```csharp
+[Property]
+public bool TokenRefresh_HandlesClockJumps(int x)
+{
+    (FakeTimeProvider clock, IReadOnlyList<TimeSpan> advances) = DataGen.SampleOne(
+        Generate.ClockWithAdvances(advanceCount: 5, maxJump: TimeSpan.FromMinutes(10)));
+
+    TokenService svc = new(clock);
+    foreach (TimeSpan advance in advances)
+    {
+        clock.Advance(advance);
+        svc.RefreshIfNeeded();
+    }
+
+    return svc.Token.IsValid;
+}
+```
+
+### `TimeProviderArbitrary`
 
 ```csharp
 [Arbitrary]
 public sealed class TimeProviderArbitrary : IStrategyProvider<TimeProvider>
 ```
 
-Auto-provider for `TimeProvider` parameters. Each generated value is a `FakeTimeProvider` with a deterministic epoch start.
+Auto-provider for `TimeProvider` parameters. Each generated value is a `FakeTimeProvider` with a deterministic epoch start. Use with `[From<TimeProviderArbitrary>]` or let `[Arbitrary]` resolution pick it up automatically.
 
-Use with `[From<TimeProviderArbitrary>]` or let `[Arbitrary]` resolution pick it up automatically.
+---
+
+## Recurring event strategies
+
+### `Generate.RecurringEvents(...)`
+
+```csharp
+Strategy<RecurringEventSample> Generate.RecurringEvents(
+    Func<DateTimeOffset, DateTimeOffset?> nextOccurrence,
+    TimeZoneInfo zone,
+    TimeSpan window)
+```
+
+Generates a `RecurringEventSample` by walking `nextOccurrence` from a random window start until `window` elapses. `nextOccurrence` must return a value strictly after its input; returning `null` signals no further occurrences. Throws `InvalidOperationException` after 10,000 non-advancing steps.
+
+### `RecurringEventSample` record
+
+```csharp
+public sealed record RecurringEventSample(
+    DateTimeOffset WindowStart,
+    DateTimeOffset WindowEnd,
+    IReadOnlyList<DateTimeOffset> Occurrences,
+    TimeZoneInfo Zone,
+    Func<DateTimeOffset, DateTimeOffset?> NextOccurrence);
+```
+
+### `.NearDstTransition()` on `Strategy<RecurringEventSample>`
+
+```csharp
+Strategy<RecurringEventSample> NearDstTransition()
+```
+
+Biases the window start to just before a DST transition in `RecurringEventSample.Zone`. Re-walks `NextOccurrence` so `Occurrences` reflects the shifted window. Falls back to the base strategy when no transitions are available.
+
+---
 
 ## DateTimeOffset extension methods
 
-Extension properties on `Strategy<DateTimeOffset>` that narrow the output to values near interesting temporal boundaries. Chain after `Generate.DateTimeOffsets()`.
+Chain after `Generate.DateTimeOffsets()`. These methods are in `Conjecture.Core` except where noted.
 
-### `.NearMidnight()`
-
-```csharp
-Strategy<DateTimeOffset> NearMidnight()
-```
-
-Values within +/-30 minutes of midnight UTC.
-
-### `.NearLeapYear()`
-
-```csharp
-Strategy<DateTimeOffset> NearLeapYear()
-```
-
-Values within +/-1 day of February 29 in a leap year (years 1970-2400).
-
-### `.NearEpoch()`
-
-```csharp
-Strategy<DateTimeOffset> NearEpoch()
-```
-
-Values within +/-1 hour of well-known epoch anchors: Unix epoch (1970-01-01), near-min (0001-01-02), near-max (9999-12-30), Y2K38 (2038-01-19).
+| Method | Package | Description |
+|---|---|---|
+| `.NearMidnight()` | Core | ±30 min of midnight UTC |
+| `.NearLeapYear()` | Core | ±1 day of Feb 29 in a leap year |
+| `.NearEpoch()` | Core | ±1 hour of Unix epoch, min/max, Y2K38 |
+| `.NearDstTransition(TimeZoneInfo? zone)` | `Conjecture.Time` | ±1 hour of a DST transition |
+| `.WithPrecision(TimeSpan precision)` | `Conjecture.Time` | Truncates to provider precision |
+| `.WithStrippedOffset()` | `Conjecture.Time` | Pairs with offset-stripped (UTC) copy |
 
 ### `.NearDstTransition(TimeZoneInfo? zone = null)`
 
@@ -66,4 +159,86 @@ Values within +/-1 hour of well-known epoch anchors: Unix epoch (1970-01-01), ne
 Strategy<DateTimeOffset> NearDstTransition(TimeZoneInfo? zone = null)
 ```
 
-Values within +/-1 hour of a DST transition. Picks a random DST-having zone if `zone` is null. Falls back to `.NearEpoch()` if no transitions are found.
+Values within ±1 hour of a DST transition in `zone`. Picks a random DST-having system zone if `zone` is `null`. Falls back to `.NearEpoch()` if no transitions are found.
+
+### `.WithPrecision(TimeSpan precision)`
+
+```csharp
+Strategy<DateTimeOffset> WithPrecision(TimeSpan precision)
+```
+
+Truncates each value to `precision` ticks, matching provider-imposed precision. `precision` must be positive.
+
+### `.WithStrippedOffset()`
+
+```csharp
+Strategy<(DateTimeOffset Original, DateTimeOffset Stripped)> WithStrippedOffset()
+```
+
+Pairs each value with a copy that has the UTC offset removed (`Offset = Zero`), modelling providers that lose the offset on roundtrip.
+
+---
+
+## DateOnly extension methods
+
+Chain after `Generate.DateOnlyValues()`.
+
+### `.NearMonthBoundary()`
+
+```csharp
+Strategy<DateOnly> NearMonthBoundary()
+```
+
+Generates the first or last day of a random month (years 2000–2099).
+
+### `.NearLeapDay()`
+
+```csharp
+Strategy<DateOnly> NearLeapDay()
+```
+
+Generates dates within ±1 day of February 29 in a leap year (years 1970–2400). Uses `ctx.Assume` to filter to leap years.
+
+---
+
+## TimeOnly extension methods
+
+Chain after `Generate.TimeOnlyValues()`.
+
+### `.NearMidnight()`
+
+```csharp
+Strategy<TimeOnly> NearMidnight()
+```
+
+Generates times within 30 seconds of midnight, covering both ends: `[00:00:00, 00:00:30]` and `[23:59:30, TimeOnly.MaxValue]`.
+
+### `.NearNoon()`
+
+```csharp
+Strategy<TimeOnly> NearNoon()
+```
+
+Generates times within 30 seconds of 12:00:00, in the range `[11:59:30, 12:00:30]`.
+
+### `.NearEndOfDay()`
+
+```csharp
+Strategy<TimeOnly> NearEndOfDay()
+```
+
+Generates times within 30 seconds of end of day: `[23:59:30, TimeOnly.MaxValue]`.
+
+---
+
+## DateTime extension methods
+
+Chain after `Generate.DateTimes()`.
+
+### `.WithKinds()`
+
+```csharp
+Strategy<(DateTime Value, DateTimeKind Kind)> WithKinds()
+```
+
+Pairs each generated `DateTime` with a randomly chosen `DateTimeKind` (`Utc`, `Local`, `Unspecified`), covering all three uniformly. Shrinks toward `Utc`.

--- a/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTimeTypesTests.cs
+++ b/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTimeTypesTests.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Mcp.Tools;
+
+namespace Conjecture.Mcp.Tests.Tools;
+
+public class StrategyToolsTimeTypesTests
+{
+    // DateOnly
+    [Fact]
+    public void SuggestForType_DateOnly_ContainsDateOnlyValues()
+    {
+        string result = StrategyTools.SuggestForType("DateOnly");
+        Assert.Contains("Generate.DateOnlyValues()", result);
+    }
+
+    [Fact]
+    public void SuggestForType_DateOnly_MentionsNearMonthBoundary()
+    {
+        string result = StrategyTools.SuggestForType("DateOnly");
+        Assert.Contains("NearMonthBoundary()", result);
+    }
+
+    [Fact]
+    public void SuggestForType_DateOnly_MentionsNearLeapDay()
+    {
+        string result = StrategyTools.SuggestForType("DateOnly");
+        Assert.Contains("NearLeapDay()", result);
+    }
+
+    // TimeOnly
+    [Fact]
+    public void SuggestForType_TimeOnly_ContainsTimeOnlyValues()
+    {
+        string result = StrategyTools.SuggestForType("TimeOnly");
+        Assert.Contains("Generate.TimeOnlyValues()", result);
+    }
+
+    [Fact]
+    public void SuggestForType_TimeOnly_MentionsNearMidnight()
+    {
+        string result = StrategyTools.SuggestForType("TimeOnly");
+        Assert.Contains("NearMidnight()", result);
+    }
+
+    [Fact]
+    public void SuggestForType_TimeOnly_MentionsNearNoon()
+    {
+        string result = StrategyTools.SuggestForType("TimeOnly");
+        Assert.Contains("NearNoon()", result);
+    }
+
+    [Fact]
+    public void SuggestForType_TimeOnly_MentionsNearEndOfDay()
+    {
+        string result = StrategyTools.SuggestForType("TimeOnly");
+        Assert.Contains("NearEndOfDay()", result);
+    }
+
+    // DateTime (kind-sensitive)
+    [Fact]
+    public void SuggestForType_DateTime_ContainsWithKinds()
+    {
+        string result = StrategyTools.SuggestForType("DateTime");
+        Assert.Contains("WithKinds()", result);
+    }
+
+    [Fact]
+    public void SuggestForType_DateTime_ContainsGenerateDateTimes()
+    {
+        string result = StrategyTools.SuggestForType("DateTime");
+        Assert.Contains("Generate.DateTimes()", result);
+    }
+
+    // TimeZoneInfo (DST focus)
+    [Fact]
+    public void SuggestForType_TimeZoneInfo_ContainsTimeZonePreferDst()
+    {
+        string result = StrategyTools.SuggestForType("TimeZoneInfo");
+        Assert.Contains("Generate.TimeZone(preferDst: true)", result);
+    }
+
+    // FakeTimeProvider / TimeProvider (adversarial)
+    [Fact]
+    public void SuggestForType_FakeTimeProvider_ContainsClockWithAdvances()
+    {
+        string result = StrategyTools.SuggestForType("FakeTimeProvider");
+        Assert.Contains("Generate.ClockWithAdvances(", result);
+    }
+
+    [Fact]
+    public void SuggestForType_TimeProvider_ContainsClockWithAdvances()
+    {
+        string result = StrategyTools.SuggestForType("TimeProvider");
+        Assert.Contains("Generate.ClockWithAdvances(", result);
+    }
+
+    // DateTimeOffset — updated to mention WithPrecision and WithStrippedOffset
+    [Fact]
+    public void SuggestForType_DateTimeOffset_MentionsWithPrecision()
+    {
+        string result = StrategyTools.SuggestForType("DateTimeOffset");
+        Assert.Contains("WithPrecision(", result);
+    }
+
+    [Fact]
+    public void SuggestForType_DateTimeOffset_MentionsWithStrippedOffset()
+    {
+        string result = StrategyTools.SuggestForType("DateTimeOffset");
+        Assert.Contains("WithStrippedOffset()", result);
+    }
+}

--- a/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTimeTypesTests.cs
+++ b/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTimeTypesTests.cs
@@ -98,6 +98,13 @@ public class StrategyToolsTimeTypesTests
 
     // DateTimeOffset — updated to mention WithPrecision and WithStrippedOffset
     [Fact]
+    public void SuggestForType_DateTimeOffset_ContainsGenerateDateTimeOffsets()
+    {
+        string result = StrategyTools.SuggestForType("DateTimeOffset");
+        Assert.Contains("Generate.DateTimeOffsets()", result);
+    }
+
+    [Fact]
     public void SuggestForType_DateTimeOffset_MentionsWithPrecision()
     {
         string result = StrategyTools.SuggestForType("DateTimeOffset");

--- a/src/Conjecture.Mcp/Tools/StrategyTools.cs
+++ b/src/Conjecture.Mcp/Tools/StrategyTools.cs
@@ -82,16 +82,98 @@ internal static class StrategyTools
                 "Use `Generate.Doubles()` for the full range, or `Generate.Doubles(min, max)` for bounded. Includes NaN and ±Infinity.",
 
             "DateTimeOffset" =>
-                "Use `Generate.DateTimeOffsets()` for the full range, or `Generate.DateTimeOffsets(min, max)` for bounded.",
+                """
+            Use `Generate.DateTimeOffsets()` for the full range, or `Generate.DateTimeOffsets(min, max)` for bounded.
+
+            For precision-sensitive roundtrip tests, chain the edge-case extensions from `Conjecture.Time`:
+            ```csharp
+            Generate.DateTimeOffsets().WithPrecision(TimeSpan.FromMilliseconds(1))
+            // → Strategy<DateTimeOffset> truncated to millisecond precision
+
+            Generate.DateTimeOffsets().WithStrippedOffset()
+            // → Strategy<(DateTimeOffset Original, DateTimeOffset Stripped)>
+            ```
+
+            Add the NuGet package: `Conjecture.Time`
+            """,
 
             "TimeSpan" =>
                 "Use `Generate.TimeSpans()` for the full range, or `Generate.TimeSpans(min, max)` for bounded.",
 
             "DateOnly" =>
-                "Use `Generate.DateOnlyValues()` for the full range, or `Generate.DateOnlyValues(min, max)` for bounded.",
+                """
+            Use `Generate.DateOnlyValues()` for the full range, or `Generate.DateOnlyValues(min, max)` for bounded.
+
+            For boundary-sensitive tests, chain the edge-case extensions from `Conjecture.Time`:
+            ```csharp
+            Generate.DateOnlyValues().NearMonthBoundary()
+            // → Strategy<DateOnly> biased to first/last day of each month
+
+            Generate.DateOnlyValues().NearLeapDay()
+            // → Strategy<DateOnly> within ±1 day of Feb 29 in leap years
+            ```
+
+            Add the NuGet package: `Conjecture.Time`
+            """,
 
             "TimeOnly" =>
-                "Use `Generate.TimeOnlyValues()` for the full range, or `Generate.TimeOnlyValues(min, max)` for bounded.",
+                """
+            Use `Generate.TimeOnlyValues()` for the full range, or `Generate.TimeOnlyValues(min, max)` for bounded.
+
+            For boundary-sensitive tests, chain the edge-case extensions from `Conjecture.Time`:
+            ```csharp
+            Generate.TimeOnlyValues().NearMidnight()
+            // → Strategy<TimeOnly> within 30 s of midnight (wraps both ends)
+
+            Generate.TimeOnlyValues().NearNoon()
+            // → Strategy<TimeOnly> within 30 s of 12:00:00
+
+            Generate.TimeOnlyValues().NearEndOfDay()
+            // → Strategy<TimeOnly> within 30 s of 23:59:59
+            ```
+
+            Add the NuGet package: `Conjecture.Time`
+            """,
+
+            "DateTime" =>
+                """
+            Use `Generate.DateTimes()` for the full range, or `Generate.DateTimes(min, max)` for bounded.
+
+            For kind-sensitive tests, chain the extension from `Conjecture.Time`:
+            ```csharp
+            Generate.DateTimes().WithKinds()
+            // → Strategy<(DateTime Value, DateTimeKind Kind)> covering Utc / Local / Unspecified
+            ```
+
+            Add the NuGet package: `Conjecture.Time`
+            """,
+
+            "TimeZoneInfo" =>
+                """
+            Use `Generate.TimeZone(preferDst: true)` from `Conjecture.Time` to sample cross-platform time zones, biased toward zones with DST transitions:
+            ```csharp
+            Generate.TimeZone(preferDst: true)
+            // → Strategy<TimeZoneInfo> from the cross-platform DST-aware subset
+            ```
+
+            For raw IANA/Windows IDs, use `Generate.IanaZoneIds()` or `Generate.WindowsZoneIds()`.
+
+            Add the NuGet package: `Conjecture.Time`
+            """,
+
+            "FakeTimeProvider" or "TimeProvider" =>
+                """
+            Use `Generate.ClockWithAdvances(advanceCount, maxJump)` from `Conjecture.Time` to generate an adversarial clock paired with pre-drawn time advances:
+            ```csharp
+            Generate.ClockWithAdvances(advanceCount: 5, maxJump: TimeSpan.FromMinutes(10))
+            // → Strategy<(FakeTimeProvider Clock, IReadOnlyList<TimeSpan> Advances)>
+
+            // Allow backward jumps to test clock-skew handling:
+            Generate.ClockWithAdvances(advanceCount: 3, maxJump: TimeSpan.FromSeconds(30), allowBackward: true)
+            ```
+
+            Add the NuGet package: `Conjecture.Time`
+            """,
 
             "string" =>
                 """


### PR DESCRIPTION
## Description

Completes #292 (Conjecture.Time Enterprise Extensions) with the final two cycles:

- **Cycle 7 (#417):** Updates `StrategyTools.cs` so the `suggest-strategy` MCP tool returns correct guidance for the new Time enterprise types: `DateOnly`, `TimeOnly`, `DateTime` (kind-sensitive), `TimeZoneInfo` (DST-focused), `FakeTimeProvider`/`TimeProvider` (adversarial clocks), and updated `DateTimeOffset` (precision/offset-stripping). 14 new tests in `StrategyToolsTimeTypesTests`.

- **Cycle 8 (#418):** Adds Diataxis documentation — 5 focused how-to guides (DST, Kind safety, DateOnly/TimeOnly boundaries, DB precision, recurring events), an expanded `time-strategies.md` reference covering all new public APIs, and a new explanation doc on why time bugs are disproportionately dangerous.

Also fixes the `cycle-runner` agent spec to remove `-q` from `dotnet build` and `--no-build` from `dotnet test`, both of which suppressed errors or ran stale binaries.

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore
- [x] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #292

## Cycles included
- 34453a4 Add Diataxis documentation for Conjecture.Time enterprise extensions
- cd60017 Updates suggest-strategy for Conjecture.Time enterprise types
- bb1c6ff Fix jq sub-issue filter and remove worktrees gitignore entry