### PR TITLE
Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ---
 
+## [0.20.0] — 2026-04-25
+
+### Added
+
+**JsonSchema** (`Conjecture.JsonSchema`) — new package
+- `Generate.FromJsonSchema(string jsonSchemaText)` — generate `JsonElement` values matching a JSON Schema document (text)
+- `Generate.FromJsonSchema(JsonElement root)` — generate `JsonElement` values matching a parsed JSON Schema root
+- `Generate.FromJsonSchema(FileInfo schemaFile)` — generate `JsonElement` values from a JSON Schema file
+- `JsonSchemaType` enum — `None`, `Null`, `Boolean`, `Integer`, `Number`, `String`, `Array`, `Object`, `Any`
+
+**OpenApi** (`Conjecture.OpenApi`) — new package
+- `Generate.FromOpenApi(string filePath)` / `(FileInfo file)` / `(Uri url)` — load an OpenAPI document and obtain an `OpenApiDocument` for strategy construction
+- `OpenApiDocument.PathParameter(method, path, name, maxDepth)` — strategy for a path parameter on a given operation
+- `OpenApiDocument.QueryParameter(method, path, name, maxDepth)` — strategy for a query parameter on a given operation
+- `OpenApiDocument.RequestBody(method, path, maxDepth)` — strategy for the request body on a given operation
+- `OpenApiDocument.ResponseBody(method, path, statusCode, maxDepth)` — strategy for the response body on a given operation+status
+
+**Protobuf** (`Conjecture.Protobuf`) — new package
+- `Generate.FromProtobuf<T>(int maxDepth = 5)` — generate `JsonElement` values matching a Protobuf message type
+- `Generate.FromProtobuf(MessageDescriptor descriptor, int maxDepth = 5)` — generate `JsonElement` values from a runtime Protobuf descriptor
+- `ProtobufFieldStrategy` — public strategy backing Protobuf-driven generation
+
+**Regex** (`Conjecture.Regex`)
+- `Generate.Date()`, `Generate.Time()`, `Generate.Ipv4()`, `Generate.Ipv6()` — new built-in pattern strategies for ISO date, ISO time, IPv4, and IPv6 strings
+- `KnownRegex.Date`, `KnownRegex.Time`, `KnownRegex.Ipv4`, `KnownRegex.Ipv6` — corresponding `Regex` accessors (source-generated via `[GeneratedRegex]`)
+
+### Changed
+
+**Regex** (`Conjecture.Regex`) — **binary breaking change**
+- `KnownRegex.CreditCard`, `Email`, `IsoDate`, `Url`, `Uuid` migrated from `static readonly Regex` fields to `static partial Regex` properties decorated with `[GeneratedRegex]`. Source-level call sites are unchanged; existing compiled consumers must be recompiled.
+
+---
+
 ## [0.19.0] — 2026-04-25
 
 ### Added

--- a/src/Conjecture.JsonSchema/PublicAPI.Shipped.txt
+++ b/src/Conjecture.JsonSchema/PublicAPI.Shipped.txt
@@ -1,1 +1,16 @@
 #nullable enable
+Conjecture.JsonSchema.JsonSchemaGenerate
+Conjecture.JsonSchema.JsonSchemaGenerate.extension(Conjecture.Core.Generate!)
+Conjecture.JsonSchema.JsonSchemaType
+Conjecture.JsonSchema.JsonSchemaType.Any = 8 -> Conjecture.JsonSchema.JsonSchemaType
+Conjecture.JsonSchema.JsonSchemaType.Array = 6 -> Conjecture.JsonSchema.JsonSchemaType
+Conjecture.JsonSchema.JsonSchemaType.Boolean = 2 -> Conjecture.JsonSchema.JsonSchemaType
+Conjecture.JsonSchema.JsonSchemaType.Integer = 3 -> Conjecture.JsonSchema.JsonSchemaType
+Conjecture.JsonSchema.JsonSchemaType.None = 0 -> Conjecture.JsonSchema.JsonSchemaType
+Conjecture.JsonSchema.JsonSchemaType.Null = 1 -> Conjecture.JsonSchema.JsonSchemaType
+Conjecture.JsonSchema.JsonSchemaType.Number = 4 -> Conjecture.JsonSchema.JsonSchemaType
+Conjecture.JsonSchema.JsonSchemaType.Object = 7 -> Conjecture.JsonSchema.JsonSchemaType
+Conjecture.JsonSchema.JsonSchemaType.String = 5 -> Conjecture.JsonSchema.JsonSchemaType
+static Conjecture.JsonSchema.JsonSchemaGenerate.extension(Conjecture.Core.Generate!).FromJsonSchema(string! jsonSchemaText) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
+static Conjecture.JsonSchema.JsonSchemaGenerate.extension(Conjecture.Core.Generate!).FromJsonSchema(System.IO.FileInfo! schemaFile) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
+static Conjecture.JsonSchema.JsonSchemaGenerate.extension(Conjecture.Core.Generate!).FromJsonSchema(System.Text.Json.JsonElement root) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!

--- a/src/Conjecture.JsonSchema/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.JsonSchema/PublicAPI.Unshipped.txt
@@ -1,16 +1,1 @@
 #nullable enable
-Conjecture.JsonSchema.JsonSchemaGenerate
-Conjecture.JsonSchema.JsonSchemaGenerate.extension(Conjecture.Core.Generate!)
-static Conjecture.JsonSchema.JsonSchemaGenerate.extension(Conjecture.Core.Generate!).FromJsonSchema(System.IO.FileInfo! schemaFile) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
-static Conjecture.JsonSchema.JsonSchemaGenerate.extension(Conjecture.Core.Generate!).FromJsonSchema(System.Text.Json.JsonElement root) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
-static Conjecture.JsonSchema.JsonSchemaGenerate.extension(Conjecture.Core.Generate!).FromJsonSchema(string! jsonSchemaText) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
-Conjecture.JsonSchema.JsonSchemaType
-Conjecture.JsonSchema.JsonSchemaType.None = 0 -> Conjecture.JsonSchema.JsonSchemaType
-Conjecture.JsonSchema.JsonSchemaType.Null = 1 -> Conjecture.JsonSchema.JsonSchemaType
-Conjecture.JsonSchema.JsonSchemaType.Boolean = 2 -> Conjecture.JsonSchema.JsonSchemaType
-Conjecture.JsonSchema.JsonSchemaType.Integer = 3 -> Conjecture.JsonSchema.JsonSchemaType
-Conjecture.JsonSchema.JsonSchemaType.Number = 4 -> Conjecture.JsonSchema.JsonSchemaType
-Conjecture.JsonSchema.JsonSchemaType.String = 5 -> Conjecture.JsonSchema.JsonSchemaType
-Conjecture.JsonSchema.JsonSchemaType.Array = 6 -> Conjecture.JsonSchema.JsonSchemaType
-Conjecture.JsonSchema.JsonSchemaType.Object = 7 -> Conjecture.JsonSchema.JsonSchemaType
-Conjecture.JsonSchema.JsonSchemaType.Any = 8 -> Conjecture.JsonSchema.JsonSchemaType

--- a/src/Conjecture.OpenApi/PublicAPI.Shipped.txt
+++ b/src/Conjecture.OpenApi/PublicAPI.Shipped.txt
@@ -1,1 +1,11 @@
 #nullable enable
+Conjecture.OpenApi.OpenApiDocument
+Conjecture.OpenApi.OpenApiDocument.PathParameter(string! method, string! path, string! name, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
+Conjecture.OpenApi.OpenApiDocument.QueryParameter(string! method, string! path, string! name, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
+Conjecture.OpenApi.OpenApiDocument.RequestBody(string! method, string! path, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
+Conjecture.OpenApi.OpenApiDocument.ResponseBody(string! method, string! path, int statusCode, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
+Conjecture.OpenApi.OpenApiGenerate
+Conjecture.OpenApi.OpenApiGenerate.extension(Conjecture.Core.Generate!)
+static Conjecture.OpenApi.OpenApiGenerate.extension(Conjecture.Core.Generate!).FromOpenApi(string! filePath) -> System.Threading.Tasks.Task<Conjecture.OpenApi.OpenApiDocument!>!
+static Conjecture.OpenApi.OpenApiGenerate.extension(Conjecture.Core.Generate!).FromOpenApi(System.IO.FileInfo! file) -> System.Threading.Tasks.Task<Conjecture.OpenApi.OpenApiDocument!>!
+static Conjecture.OpenApi.OpenApiGenerate.extension(Conjecture.Core.Generate!).FromOpenApi(System.Uri! url) -> System.Threading.Tasks.Task<Conjecture.OpenApi.OpenApiDocument!>!

--- a/src/Conjecture.OpenApi/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.OpenApi/PublicAPI.Unshipped.txt
@@ -1,11 +1,1 @@
 #nullable enable
-Conjecture.OpenApi.OpenApiDocument
-Conjecture.OpenApi.OpenApiDocument.PathParameter(string! method, string! path, string! name, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
-Conjecture.OpenApi.OpenApiDocument.QueryParameter(string! method, string! path, string! name, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
-Conjecture.OpenApi.OpenApiDocument.RequestBody(string! method, string! path, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
-Conjecture.OpenApi.OpenApiDocument.ResponseBody(string! method, string! path, int statusCode, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
-Conjecture.OpenApi.OpenApiGenerate
-Conjecture.OpenApi.OpenApiGenerate.extension(Conjecture.Core.Generate!)
-static Conjecture.OpenApi.OpenApiGenerate.extension(Conjecture.Core.Generate!).FromOpenApi(System.IO.FileInfo! file) -> System.Threading.Tasks.Task<Conjecture.OpenApi.OpenApiDocument!>!
-static Conjecture.OpenApi.OpenApiGenerate.extension(Conjecture.Core.Generate!).FromOpenApi(System.Uri! url) -> System.Threading.Tasks.Task<Conjecture.OpenApi.OpenApiDocument!>!
-static Conjecture.OpenApi.OpenApiGenerate.extension(Conjecture.Core.Generate!).FromOpenApi(string! filePath) -> System.Threading.Tasks.Task<Conjecture.OpenApi.OpenApiDocument!>!

--- a/src/Conjecture.Protobuf/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Protobuf/PublicAPI.Shipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+Conjecture.Protobuf.ProtobufFieldStrategy
+Conjecture.Protobuf.ProtobufFieldStrategy.ProtobufFieldStrategy(Google.Protobuf.Reflection.MessageDescriptor! descriptor, int maxDepth = 5) -> void
+Conjecture.Protobuf.ProtobufGenerate
+Conjecture.Protobuf.ProtobufGenerate.extension(Conjecture.Core.Generate!)
+static Conjecture.Protobuf.ProtobufGenerate.extension(Conjecture.Core.Generate!).FromProtobuf(Google.Protobuf.Reflection.MessageDescriptor! descriptor, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
+static Conjecture.Protobuf.ProtobufGenerate.extension(Conjecture.Core.Generate!).FromProtobuf<T>(int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!

--- a/src/Conjecture.Protobuf/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Protobuf/PublicAPI.Unshipped.txt
@@ -1,7 +1,1 @@
 #nullable enable
-Conjecture.Protobuf.ProtobufFieldStrategy
-Conjecture.Protobuf.ProtobufFieldStrategy.ProtobufFieldStrategy(Google.Protobuf.Reflection.MessageDescriptor! descriptor, int maxDepth = 5) -> void
-Conjecture.Protobuf.ProtobufGenerate
-Conjecture.Protobuf.ProtobufGenerate.extension(Conjecture.Core.Generate!)
-static Conjecture.Protobuf.ProtobufGenerate.extension(Conjecture.Core.Generate!).FromProtobuf(Google.Protobuf.Reflection.MessageDescriptor! descriptor, int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!
-static Conjecture.Protobuf.ProtobufGenerate.extension(Conjecture.Core.Generate!).FromProtobuf<T>(int maxDepth = 5) -> Conjecture.Core.Strategy<System.Text.Json.JsonElement>!

--- a/src/Conjecture.Regex/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Regex/PublicAPI.Shipped.txt
@@ -10,7 +10,10 @@ Conjecture.Regex.UnicodeCoverage
 Conjecture.Regex.UnicodeCoverage.Ascii = 0 -> Conjecture.Regex.UnicodeCoverage
 Conjecture.Regex.UnicodeCoverage.Full = 1 -> Conjecture.Regex.UnicodeCoverage
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).CreditCard() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Date() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Email() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Ipv4() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Ipv6() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).IsoDate() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Matching(string! pattern, Conjecture.Regex.RegexGenOptions? options = null) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Matching(System.Text.RegularExpressions.Regex! regex, Conjecture.Regex.RegexGenOptions? options = null) -> Conjecture.Core.Strategy<string!>!
@@ -21,7 +24,17 @@ static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generat
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).NotMatching(System.Text.RegularExpressions.Regex! regex, Conjecture.Regex.RegexGenOptions? options = null) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).NotUrl() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).NotUuid() -> Conjecture.Core.Strategy<string!>!
-static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Url() -> Conjecture.Core.Strategy<string!>!
-static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Uuid() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).ReDoSHunter(string! pattern, int maxMatchMs = 5) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).ReDoSHunter(System.Text.RegularExpressions.Regex! regex, int maxMatchMs = 5) -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Time() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Url() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Uuid() -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Regex.KnownRegex.CreditCard.get -> System.Text.RegularExpressions.Regex!
+static Conjecture.Regex.KnownRegex.Date.get -> System.Text.RegularExpressions.Regex!
+static Conjecture.Regex.KnownRegex.Email.get -> System.Text.RegularExpressions.Regex!
+static Conjecture.Regex.KnownRegex.Ipv4.get -> System.Text.RegularExpressions.Regex!
+static Conjecture.Regex.KnownRegex.Ipv6.get -> System.Text.RegularExpressions.Regex!
+static Conjecture.Regex.KnownRegex.IsoDate.get -> System.Text.RegularExpressions.Regex!
+static Conjecture.Regex.KnownRegex.Time.get -> System.Text.RegularExpressions.Regex!
+static Conjecture.Regex.KnownRegex.Url.get -> System.Text.RegularExpressions.Regex!
+static Conjecture.Regex.KnownRegex.Uuid.get -> System.Text.RegularExpressions.Regex!

--- a/src/Conjecture.Regex/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Regex/PublicAPI.Unshipped.txt
@@ -1,19 +1,1 @@
 #nullable enable
-*REMOVED*static readonly Conjecture.Regex.KnownRegex.CreditCard -> System.Text.RegularExpressions.Regex!
-*REMOVED*static readonly Conjecture.Regex.KnownRegex.Email -> System.Text.RegularExpressions.Regex!
-*REMOVED*static readonly Conjecture.Regex.KnownRegex.IsoDate -> System.Text.RegularExpressions.Regex!
-*REMOVED*static readonly Conjecture.Regex.KnownRegex.Url -> System.Text.RegularExpressions.Regex!
-*REMOVED*static readonly Conjecture.Regex.KnownRegex.Uuid -> System.Text.RegularExpressions.Regex!
-static Conjecture.Regex.KnownRegex.CreditCard.get -> System.Text.RegularExpressions.Regex!
-static Conjecture.Regex.KnownRegex.Date.get -> System.Text.RegularExpressions.Regex!
-static Conjecture.Regex.KnownRegex.Email.get -> System.Text.RegularExpressions.Regex!
-static Conjecture.Regex.KnownRegex.Ipv4.get -> System.Text.RegularExpressions.Regex!
-static Conjecture.Regex.KnownRegex.Ipv6.get -> System.Text.RegularExpressions.Regex!
-static Conjecture.Regex.KnownRegex.IsoDate.get -> System.Text.RegularExpressions.Regex!
-static Conjecture.Regex.KnownRegex.Time.get -> System.Text.RegularExpressions.Regex!
-static Conjecture.Regex.KnownRegex.Url.get -> System.Text.RegularExpressions.Regex!
-static Conjecture.Regex.KnownRegex.Uuid.get -> System.Text.RegularExpressions.Regex!
-static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Date() -> Conjecture.Core.Strategy<string!>!
-static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Ipv4() -> Conjecture.Core.Strategy<string!>!
-static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Ipv6() -> Conjecture.Core.Strategy<string!>!
-static Conjecture.Core.RegexGenerateExtensions.extension(Conjecture.Core.Generate!).Time() -> Conjecture.Core.Strategy<string!>!


### PR DESCRIPTION
## Description

Prepares the v0.20.0 release.

- Promotes `PublicAPI.Unshipped.txt` → `PublicAPI.Shipped.txt` for `JsonSchema`, `OpenApi`, `Protobuf`, and `Regex`.
- Updates `CHANGELOG.md` with the v0.20.0 section summarising additions and the `Regex` binary breaking change (`KnownRegex` field → property migration).
- api-baseline DLLs are intentionally **not** updated this release.

### v0.20.0 highlights

- **JsonSchema** — new package: `Generate.FromJsonSchema(...)` (string / `JsonElement` / `FileInfo`); public `JsonSchemaType` enum.
- **OpenApi** — new package: `Generate.FromOpenApi(...)` returning an `OpenApiDocument`; per-operation strategies for path / query parameters, request body, and response body.
- **Protobuf** — new package: `Generate.FromProtobuf<T>()` and descriptor overload; public `ProtobufFieldStrategy`.
- **Regex** — new built-ins `Generate.Date()`, `.Time()`, `.Ipv4()`, `.Ipv6()` plus matching `KnownRegex` accessors. `KnownRegex.CreditCard / Email / IsoDate / Url / Uuid` migrated from `static readonly Regex` fields to source-generated `[GeneratedRegex]` partial properties — source-compatible, **binary-breaking**.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes (2199 passed, 0 failed, 0 skipped)
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style