### PR TITLE
Rename Gen → Generate for codebase consistency

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -64,11 +64,23 @@ Solution file: `src/Conjecture.slnx`
 | `src/Conjecture.Tool/` | `src/Conjecture.Tool.Tests/` |
 | `src/Conjecture.Formatters/` | `src/Conjecture.Formatters.Tests/` |
 | `src/Conjecture.Time/` | `src/Conjecture.Time.Tests/` |
+| `src/Conjecture.Regex/` | `src/Conjecture.Regex.Tests/` |
+| `src/Conjecture.Money/` | `src/Conjecture.Money.Tests/` |
 | `src/Conjecture.FSharp/` | `src/Conjecture.FSharp.Tests/` |
 | `src/Conjecture.FSharp.Expecto/` | `src/Conjecture.FSharp.Expecto.Tests/` |
 | `src/Conjecture.Interactive/` | `src/Conjecture.Interactive.Tests/` |
 | `src/Conjecture.LinqPad/` | `src/Conjecture.LinqPad.Tests/` |
 | `src/Conjecture.TestingPlatform/` | `src/Conjecture.TestingPlatform.Tests/` |
+| `src/Conjecture.Interactions/` | `src/Conjecture.Interactions.Tests/` |
+| `src/Conjecture.Http/` | `src/Conjecture.Http.Tests/` |
+| `src/Conjecture.JsonSchema/` | `src/Conjecture.JsonSchema.Tests/` |
+| `src/Conjecture.OpenApi/` | `src/Conjecture.OpenApi.Tests/` |
+| `src/Conjecture.Protobuf/` | `src/Conjecture.Protobuf.Tests/` |
+| `src/Conjecture.Messaging/` | `src/Conjecture.Messaging.Tests/` |
+| `src/Conjecture.Messaging.AzureServiceBus/` | `src/Conjecture.Messaging.AzureServiceBus.Tests/` |
+| `src/Conjecture.Messaging.RabbitMq/` | `src/Conjecture.Messaging.RabbitMq.Tests/` |
+| `src/Conjecture.Grpc/` | `src/Conjecture.Grpc.Tests/` |
+| `src/Conjecture.AspNetCore/` | `src/Conjecture.AspNetCore.Tests/` |
 | `src/Conjecture.Benchmarks/` | _(benchmark project, not a test project)_ |
 | `src/Conjecture.SelfTests/` | _(integration self-tests, no paired prod project)_ |
 

--- a/docs/decisions/0033-stateful-test-entry-point-api.md
+++ b/docs/decisions/0033-stateful-test-entry-point-api.md
@@ -21,7 +21,7 @@ public void Stack_invariants_hold(
 
 `StateMachineStrategy<TMachine, TState, TCommand>` is `internal`. It extends `Strategy<StateMachineRun<TState>>` and implements `IStrategyProvider<StateMachineRun<TState>>`, making it usable as the type argument to `[From<T>]` via the existing `SharedParameterStrategyResolver`. The `TMachine` type parameter is constrained to `new()` so the engine instantiates it with `new TMachine()` — no reflection, NativeAOT-safe (ADR-0014).
 
-`Gen.StateMachine<TMachine, TState, TCommand>(int maxSteps = 50)` is the public convenience factory on `Gen.cs` for use in composite strategies.
+`Generate.StateMachine<TMachine, TState, TCommand>(int maxSteps = 50)` is the public convenience factory on `Generate.cs` for use in composite strategies.
 
 `StateMachineRun<TState>` is a public result type carrying:
 - `Steps` — `IReadOnlyList<ExecutedStep<TState>>` in execution order

--- a/docs/decisions/0063-conjecture-aspnetcore-package-design.md
+++ b/docs/decisions/0063-conjecture-aspnetcore-package-design.md
@@ -15,7 +15,7 @@ The decision must answer:
 
 - What is the package's public dependency surface — does it bind to `Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`, or stay at `IHost` + `HttpClient`?
 - How are minimal APIs and MVC controllers discovered uniformly?
-- How does request synthesis compose with `Gen.For<T>()` (#73) for typed DTOs and with the existing `HttpInteraction` shape (ADR 0059)?
+- How does request synthesis compose with `Generate.For<T>()` (#73) for typed DTOs and with the existing `HttpInteraction` shape (ADR 0059)?
 - How is auth handled for endpoints behind `[Authorize]`?
 - How are middleware-short-circuited endpoints (authz, rate limiting) treated?
 - How are user-managed test fixtures (DB seeding, authenticated identity) plugged in?
@@ -65,12 +65,12 @@ public sealed record EndpointParameter(
 
 Per discovered endpoint, `RequestSynthesizer` produces two `Strategy<HttpInteraction>` flavours:
 
-- **Valid** — every required parameter populated from `Gen.For<TParameter>()`; `[FromBody]` payload populated from `Gen.For<TBody>()`; `Content-Type` set to the first `Consumes` entry (default `application/json`); `Accept` set to the first `Produces` entry.
+- **Valid** — every required parameter populated from `Generate.For<TParameter>()`; `[FromBody]` payload populated from `Generate.For<TBody>()`; `Content-Type` set to the first `Consumes` entry (default `application/json`); `Accept` set to the first `Produces` entry.
 - **Malformed** — randomly one of: missing required field, out-of-range numeric, wrong `Content-Type`, malformed JSON in body, missing required header. Used for the `never-5xx` invariant.
 
 Both strategies emit `HttpInteraction` records (the existing Layer 1 shape from ADR 0059) so `HostHttpTarget` dispatches them unchanged. No new interaction shape, no new target — the entire dispatch path is reused.
 
-DTO synthesis delegates to `Gen.For<T>()` (#73) and registered `[Arbitrary]` providers. For primitive parameter types (`int`, `string`, `Guid`, `DateOnly`) the synthesiser falls back to built-in `Strategy<T>` primitives. Unknown parameter types throw at strategy-build time with a clear message pointing at the parameter, the endpoint, and the `Gen.For<T>()` registration the user is missing.
+DTO synthesis delegates to `Generate.For<T>()` (#73) and registered `[Arbitrary]` providers. For primitive parameter types (`int`, `string`, `Guid`, `DateOnly`) the synthesiser falls back to built-in `Strategy<T>` primitives. Unknown parameter types throw at strategy-build time with a clear message pointing at the parameter, the endpoint, and the `Generate.For<T>()` registration the user is missing.
 
 ### Fluent `AspNetCoreRequestBuilder`
 
@@ -133,7 +133,7 @@ Two tiers, mirroring ADR 0061 and 0062:
 - Same `Property.ForAll(target, strategy, assertion, ct)` shape as HTTP, messaging, and gRPC — no new primitives.
 - `HttpInteraction` and `HostHttpTarget` from ADR 0059 are reused unchanged; the package adds *strategy synthesis* over an existing dispatch path.
 - `ExcludeEndpoints` + `WithSetup` cover the realistic test-fixture surface without coupling to any persistence model.
-- DTO synthesis falls out of `Gen.For<T>()` automatically; users get typed-body coverage by registering arbitraries they likely already have.
+- DTO synthesis falls out of `Generate.For<T>()` automatically; users get typed-body coverage by registering arbitraries they likely already have.
 - Aspire compatibility costs nothing because the public surface is `IHost` + `HttpClient`.
 
 **Harder:**
@@ -145,7 +145,7 @@ Two tiers, mirroring ADR 0061 and 0062:
 **Risks:**
 
 - ASP.NET Core 10 (currently in preview) is reorganising parts of the endpoint metadata pipeline; the walker is pinned to the .NET 9 + .NET 10 RTM API surface. Tracked in the integration tier — if the metadata APIs shift, the SelfTests catch it before users do.
-- `Gen.For<T>()` is the v0.22 release — `Conjecture.AspNetCore` ships in v0.23 and hard-depends on it. If a user has not registered an arbitrary for a body DTO type, strategy-build throws at startup. The error message carries the parameter, endpoint, and registration the user is missing; documentation walks through the typical fix.
+- `Generate.For<T>()` is the v0.22 release — `Conjecture.AspNetCore` ships in v0.23 and hard-depends on it. If a user has not registered an arbitrary for a body DTO type, strategy-build throws at startup. The error message carries the parameter, endpoint, and registration the user is missing; documentation walks through the typical fix.
 - Synthesised valid requests will exercise endpoints that mutate state (POST /orders, DELETE /users/{id}) by default. Documentation makes this loud: tests must either run against a fresh `WebApplicationFactory` per scenario, use `.WithSetup` to roll back, or `.ExcludeEndpoints` mutating routes. No automatic mutation detection — the package does not parse endpoint side-effects.
 
 ## Alternatives Considered

--- a/docs/site/articles/explanation/generate-for-source-generator.md
+++ b/docs/site/articles/explanation/generate-for-source-generator.md
@@ -1,4 +1,4 @@
-# Understanding Gen.For&lt;T&gt;() source generation
+# Understanding Generate.For&lt;T&gt;() source generation
 
 `Generate.For<T>()` is the call-site entry point for a strategy the compiler derived from your type at build time. This page explains why source generation was chosen over alternatives, how the emitted code is wired together, and how `Generate.For<T>()` fits into a broader property test.
 
@@ -44,14 +44,14 @@ internal sealed class OrderArbitrary : IStrategyProvider<Order>
 }
 ```
 
-**3. Registry wiring.** The generator also emits a `[ModuleInitializer]` that registers both the provider and the override factory with `GenForRegistry`:
+**3. Registry wiring.** The generator also emits a `[ModuleInitializer]` that registers both the provider and the override factory with `GenerateForRegistry`:
 
 ```csharp
 [ModuleInitializer]
 internal static void RegisterOrderArbitrary()
 {
-    GenForRegistry.Register(typeof(Order), static () => new OrderArbitrary());
-    GenForRegistry.RegisterOverride(typeof(Order),
+    GenerateForRegistry.Register(typeof(Order), static () => new OrderArbitrary());
+    GenerateForRegistry.RegisterOverride(typeof(Order),
         static cfg => OrderArbitrary.CreateWithOverrides((ForConfiguration<Order>)cfg));
 }
 ```
@@ -60,9 +60,9 @@ internal static void RegisterOrderArbitrary()
 
 ## How `Generate.For<T>()` resolves a strategy
 
-`Generate.For<T>()` delegates to `GenForRegistry.Resolve<T>()`, which looks up the registered factory by `typeof(T)` in a `ConcurrentDictionary`. The lookup is O(1) and allocation-free after the first call.
+`Generate.For<T>()` delegates to `GenerateForRegistry.Resolve<T>()`, which looks up the registered factory by `typeof(T)` in a `ConcurrentDictionary`. The lookup is O(1) and allocation-free after the first call.
 
-`Generate.For<T>(cfg => ...)` takes the override path: it constructs a `ForConfiguration<T>`, runs your callback, then calls `GenForRegistry.ResolveWithOverrides<T>(cfg)`, which invokes the override-aware factory. The override factory calls `cfg.TryGet<TProp>(propertyName)` for each parameter — if an override exists it uses it, otherwise it falls back to the default strategy.
+`Generate.For<T>(cfg => ...)` takes the override path: it constructs a `ForConfiguration<T>`, runs your callback, then calls `GenerateForRegistry.ResolveWithOverrides<T>(cfg)`, which invokes the override-aware factory. The override factory calls `cfg.TryGet<TProp>(propertyName)` for each parameter — if an override exists it uses it, otherwise it falls back to the default strategy.
 
 The result is a `Strategy<T>` like any other. It composes, shrinks, and replays exactly as if you had written the `Generate.Compose` call by hand.
 
@@ -91,13 +91,13 @@ For `[Property]` parameters, `[From<OrderArbitrary>]` is the idiomatic shorthand
 
 ## The registry and AOT
 
-`GenForRegistry` is a `public static` class backed by two `ConcurrentDictionary<Type, Func<...>>` fields. Keeping it public allows generated code in user assemblies to call `Register` and `RegisterOverride`. The dictionaries use `Type` as the key rather than a generic type parameter, which is AOT-safe: no `MakeGenericType`, no `MethodInfo.Invoke`, no `Activator.CreateInstance`.
+`GenerateForRegistry` is a `public static` class backed by two `ConcurrentDictionary<Type, Func<...>>` fields. Keeping it public allows generated code in user assemblies to call `Register` and `RegisterOverride`. The dictionaries use `Type` as the key rather than a generic type parameter, which is AOT-safe: no `MakeGenericType`, no `MethodInfo.Invoke`, no `Activator.CreateInstance`.
 
 The generated factories are `static` lambdas (`static () => new OrderArbitrary()`). `static` lambdas are compiler-lowered to static methods, so they produce no closures and hold no references that would confuse the trimmer.
 
 ## Further reading
 
-- [How to use Gen.For&lt;T&gt;()](../how-to/use-gen-for.md) — step-by-step recipes
-- [Reference: Gen.For&lt;T&gt;()](../reference/gen-for.md) — attribute table, primitive mapping, diagnostics
+- [How to use Generate.For&lt;T&gt;()](../how-to/use-generate-for.md) — step-by-step recipes
+- [Reference: Generate.For&lt;T&gt;()](../reference/generate-for.md) — attribute table, primitive mapping, diagnostics
 - [How to use source generators](../how-to/use-source-generators.md) — `[Arbitrary]` basics
 - [Understanding sealed hierarchy strategies](sealed-hierarchy-strategies.md) — hierarchy mode for abstract types

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -5,8 +5,8 @@ items:
     href: shrinking.md
   - name: Sealed hierarchy strategies
     href: sealed-hierarchy-strategies.md
-  - name: Gen.For&lt;T&gt;() source generation
-    href: gen-for-source-generator.md
+  - name: Generate.For&lt;T&gt;() source generation
+    href: generate-for-source-generator.md
   - name: Targeted testing
     href: targeted-testing.md
   - name: The example database

--- a/docs/site/articles/how-to/test-aspnetcore-endpoints.md
+++ b/docs/site/articles/how-to/test-aspnetcore-endpoints.md
@@ -56,7 +56,7 @@ public class OrdersApiProperties : IClassFixture<WebApplicationFactory<Program>>
 }
 ```
 
-The walker discovers every endpoint `Program` exposes. The synthesiser populates `[FromRoute]`, `[FromQuery]`, `[FromHeader]`, and `[FromBody]` parameters from `Gen.For<T>()` (so register an arbitrary for each DTO type via `[Arbitrary]` or `GenForRegistry.Register<T>(...)` — unregistered types throw at strategy-build time with a pointer to the missing registration). `HostHttpTarget` from `Conjecture.Http` dispatches the synthesized `HttpInteraction` through the test server.
+The walker discovers every endpoint `Program` exposes. The synthesiser populates `[FromRoute]`, `[FromQuery]`, `[FromHeader]`, and `[FromBody]` parameters from `Generate.For<T>()` (so register an arbitrary for each DTO type via `[Arbitrary]` or `GenerateForRegistry.Register<T>(...)` — unregistered types throw at strategy-build time with a pointer to the missing registration). `HostHttpTarget` from `Conjecture.Http` dispatches the synthesized `HttpInteraction` through the test server.
 
 ## Test that malformed requests return 4xx, never 5xx
 

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -17,8 +17,8 @@ items:
     href: manage-example-database.md
   - name: Use source generators
     href: use-source-generators.md
-  - name: Use Gen.For&lt;T&gt;()
-    href: use-gen-for.md
+  - name: Use Generate.For&lt;T&gt;()
+    href: use-generate-for.md
   - name: Use sealed hierarchy strategies
     href: use-sealed-hierarchy-strategies.md
   - name: Configure logging

--- a/docs/site/articles/how-to/use-generate-for.md
+++ b/docs/site/articles/how-to/use-generate-for.md
@@ -1,4 +1,4 @@
-# How to use Gen.For&lt;T&gt;()
+# How to use Generate.For&lt;T&gt;()
 
 Use `Generate.For<T>()` to get a `Strategy<T>` for any type decorated with `[Arbitrary]`. The source generator emits the strategy at compile time — no runtime reflection, no manual composition.
 
@@ -147,7 +147,7 @@ Without `[GenMaxDepth]` on a self-referential type, the generator emits a **CON3
 
 ## See also
 
-- [Reference: Gen.For&lt;T&gt;()](../reference/gen-for.md) — attribute table, primitive mapping, diagnostics
-- [Understanding Gen.For&lt;T&gt;() source generation](../explanation/gen-for-source-generator.md) — why source generation and how the registry works
+- [Reference: Generate.For&lt;T&gt;()](../reference/generate-for.md) — attribute table, primitive mapping, diagnostics
+- [Understanding Generate.For&lt;T&gt;() source generation](../explanation/generate-for-source-generator.md) — why source generation and how the registry works
 - [How to use source generators](use-source-generators.md) — `[Arbitrary]` basics and supported types
 - [How to generate sealed class hierarchies](use-sealed-hierarchy-strategies.md) — abstract base + subtypes pattern

--- a/docs/site/articles/how-to/use-source-generators.md
+++ b/docs/site/articles/how-to/use-source-generators.md
@@ -97,7 +97,7 @@ public partial struct Point
 
 ## See also
 
-- [How to use Gen.For&lt;T&gt;()](use-gen-for.md) — overrides, constraint attributes, recursive types
-- [Reference: Gen.For&lt;T&gt;()](../reference/gen-for.md) — attribute table, primitive mapping, diagnostics
+- [How to use Generate.For&lt;T&gt;()](use-generate-for.md) — overrides, constraint attributes, recursive types
+- [Reference: Generate.For&lt;T&gt;()](../reference/generate-for.md) — attribute table, primitive mapping, diagnostics
 - [Reference: Analyzers](../reference/analyzers.md) — runtime analyzer rules (CON100–CON111, CJ0050)
 - [Reference: Attributes](../reference/attributes.md) — `[Arbitrary]`, `[From<T>]` full reference

--- a/docs/site/articles/reference/analyzers.md
+++ b/docs/site/articles/reference/analyzers.md
@@ -227,7 +227,7 @@ The `[Arbitrary]` source generator reports its own set of diagnostics:
 
 ### `Generate.For<T>()` call-site diagnostics (CON310–CON313)
 
-These fire at `Generate.For<T>()` or `[From<T>]` call sites. See [Reference: Gen.For&lt;T&gt;()](gen-for.md#generatefort-call-site-diagnostics) for resolution steps.
+These fire at `Generate.For<T>()` or `[From<T>]` call sites. See [Reference: Generate.For&lt;T&gt;()](generate-for.md#generatefort-call-site-diagnostics) for resolution steps.
 
 | ID | Severity | Description |
 |---|---|---|

--- a/docs/site/articles/reference/aspnetcore-request-builder.md
+++ b/docs/site/articles/reference/aspnetcore-request-builder.md
@@ -30,7 +30,7 @@ Installs an async setup delegate that runs before each generated example. Use fo
 
 ### `ValidRequestsOnly() → AspNetCoreRequestBuilder`
 
-Restricts synthesis to the **valid** flavour: every required parameter populated from `Gen.For<T>()`, valid `Content-Type` / `Accept` headers, well-formed body. Suppresses the malformed flavour.
+Restricts synthesis to the **valid** flavour: every required parameter populated from `Generate.For<T>()`, valid `Content-Type` / `Accept` headers, well-formed body. Suppresses the malformed flavour.
 
 ### `MalformedRequestsOnly() → AspNetCoreRequestBuilder`
 
@@ -60,14 +60,14 @@ The `ExcludeEndpoints` predicate receives a `DiscoveredEndpoint` per route:
 | Property | Type | Meaning |
 |---|---|---|
 | `Name` | `string` | Parameter name as bound by the route / model binder. |
-| `ClrType` | `Type` | Runtime type used to select a generation strategy via `Gen.For<T>()`. |
+| `ClrType` | `Type` | Runtime type used to select a generation strategy via `Generate.For<T>()`. |
 | `Source` | `BindingSource` | `Path`, `Query`, `Header`, `Body`, `Form`, `Services`, etc. |
 | `IsRequired` | `bool` | `true` when the parameter must be present in the request. |
 
 ## Errors
 
 - **No endpoints remain after applying exclusion predicates** (`InvalidOperationException`) — every endpoint is filtered out. Loosen the predicates.
-- **No `Gen.For<T>()` strategy registered** (thrown at `.Build()` time) — a route requires a parameter of type `T` that has no registered arbitrary. Add `[Arbitrary]` to `T` (and its `Conjecture.Generators` source generator runs), or register manually via `GenForRegistry.Register<T>(...)`.
+- **No `Generate.For<T>()` strategy registered** (thrown at `.Build()` time) — a route requires a parameter of type `T` that has no registered arbitrary. Add `[Arbitrary]` to `T` (and its `Conjecture.Generators` source generator runs), or register manually via `GenerateForRegistry.Register<T>(...)`.
 
 ## See also
 

--- a/docs/site/articles/reference/attributes.md
+++ b/docs/site/articles/reference/attributes.md
@@ -168,9 +168,9 @@ Requirements:
 
 See [How to use source generators](../how-to/use-source-generators.md) for full usage and supported types.
 
-## Gen.For&lt;T&gt;() constraint attributes
+## Generate.For&lt;T&gt;() constraint attributes
 
-Applied to constructor parameters or `init` properties of `[Arbitrary]` types to constrain what the source generator produces. See [Reference: Gen.For&lt;T&gt;()](gen-for.md) for the full attribute reference.
+Applied to constructor parameters or `init` properties of `[Arbitrary]` types to constrain what the source generator produces. See [Reference: Generate.For&lt;T&gt;()](generate-for.md) for the full attribute reference.
 
 | Attribute | Target | Effect |
 |---|---|---|

--- a/docs/site/articles/reference/generate-for.md
+++ b/docs/site/articles/reference/generate-for.md
@@ -1,4 +1,4 @@
-# Gen.For&lt;T&gt;() reference
+# Generate.For&lt;T&gt;() reference
 
 API surface, attribute reference, primitive mapping, and diagnostic codes for `Generate.For<T>()` and the constraint attributes.
 
@@ -231,7 +231,7 @@ public partial record Parent(Child? Child);
 
 ## See also
 
-- [How to use Gen.For&lt;T&gt;()](../how-to/use-gen-for.md) — step-by-step recipes
-- [Understanding Gen.For&lt;T&gt;() source generation](../explanation/gen-for-source-generator.md) — design rationale and registry mechanics
+- [How to use Generate.For&lt;T&gt;()](../how-to/use-generate-for.md) — step-by-step recipes
+- [Understanding Generate.For&lt;T&gt;() source generation](../explanation/generate-for-source-generator.md) — design rationale and registry mechanics
 - [Reference: Analyzers](analyzers.md) — CON200–CON202, CON205, CON300–CON302 (type-declaration diagnostics)
 - [Reference: Attributes](attributes.md) — `[Arbitrary]`, `[From<T>]`, `[FromFactory]`

--- a/docs/site/articles/reference/toc.yml
+++ b/docs/site/articles/reference/toc.yml
@@ -9,8 +9,8 @@ items:
     href: extension-properties.md
   - name: Attributes
     href: attributes.md
-  - name: Gen.For&lt;T&gt;()
-    href: gen-for.md
+  - name: Generate.For&lt;T&gt;()
+    href: generate-for.md
   - name: Analyzers
     href: analyzers.md
   - name: Time strategies

--- a/src/Conjecture.AspNetCore.Tests/RequestSynthesizerTests.cs
+++ b/src/Conjecture.AspNetCore.Tests/RequestSynthesizerTests.cs
@@ -274,7 +274,7 @@ public sealed class RequestSynthesizerTests
 }
 
 // ---------------------------------------------------------------------------
-// Marker type: has no [Arbitrary] / Gen.For<T>() registration — used to test
+// Marker type: has no [Arbitrary] / Generate.For<T>() registration — used to test
 // that unknown types throw at strategy-build time.
 // ---------------------------------------------------------------------------
 internal sealed record UnregisteredBodyType(string Value);

--- a/src/Conjecture.AspNetCore.Tests/TestSupport/BuilderTestDtoStrategySupport.cs
+++ b/src/Conjecture.AspNetCore.Tests/TestSupport/BuilderTestDtoStrategySupport.cs
@@ -8,15 +8,15 @@ using Conjecture.Core;
 namespace Conjecture.AspNetCore.Tests.TestSupport;
 
 /// <summary>
-/// Registers <see cref="BuilderTestDto"/> with <see cref="GenForRegistry"/> so
-/// <c>RequestSynthesizer</c> can synthesize bodies for it via <see cref="GenForRegistry.ResolveBoxed"/>.
+/// Registers <see cref="BuilderTestDto"/> with <see cref="GenerateForRegistry"/> so
+/// <c>RequestSynthesizer</c> can synthesize bodies for it via <see cref="GenerateForRegistry.ResolveBoxed"/>.
 /// </summary>
 internal static class BuilderTestDtoStrategySupport
 {
     [ModuleInitializer]
     internal static void Register()
     {
-        GenForRegistry.Register(
+        GenerateForRegistry.Register(
             typeof(BuilderTestDto),
             static () => new BuilderTestDtoProvider(),
             Generate.Compose<object?>(static ctx =>

--- a/src/Conjecture.AspNetCore.Tests/TestSupport/CreateOrderRequestStrategySupport.cs
+++ b/src/Conjecture.AspNetCore.Tests/TestSupport/CreateOrderRequestStrategySupport.cs
@@ -8,15 +8,15 @@ using Conjecture.Core;
 namespace Conjecture.AspNetCore.Tests.TestSupport;
 
 /// <summary>
-/// Registers <see cref="CreateOrderRequest"/> with <see cref="GenForRegistry"/> so
-/// <c>RequestSynthesizer</c> can synthesize bodies for it via <see cref="GenForRegistry.ResolveBoxed"/>.
+/// Registers <see cref="CreateOrderRequest"/> with <see cref="GenerateForRegistry"/> so
+/// <c>RequestSynthesizer</c> can synthesize bodies for it via <see cref="GenerateForRegistry.ResolveBoxed"/>.
 /// </summary>
 internal static class CreateOrderRequestStrategySupport
 {
     [ModuleInitializer]
     internal static void Register()
     {
-        GenForRegistry.Register(
+        GenerateForRegistry.Register(
             typeof(CreateOrderRequest),
             static () => new CreateOrderRequestProvider(),
             Generate.Compose<object?>(static ctx =>

--- a/src/Conjecture.AspNetCore/AspNetCoreRequestBuilder.cs
+++ b/src/Conjecture.AspNetCore/AspNetCoreRequestBuilder.cs
@@ -92,7 +92,7 @@ public sealed class AspNetCoreRequestBuilder
     /// <summary>
     /// Returns a new builder that uses <paramref name="doc"/> as the source of body strategies.
     /// When an endpoint's (method, path) matches an OpenAPI operation with a request body schema,
-    /// the synthesised body is generated from the schema; otherwise the registered <c>Gen.For&lt;T&gt;()</c>
+    /// the synthesised body is generated from the schema; otherwise the registered <c>Generate.For&lt;T&gt;()</c>
     /// strategy is used as a fallback.
     /// </summary>
     public AspNetCoreRequestBuilder FromOpenApi(Conjecture.OpenApi.OpenApiDocument doc)
@@ -137,7 +137,7 @@ public sealed class AspNetCoreRequestBuilder
         return this.flavour switch
         {
             RequestFlavour.ValidOnly => TryBuildValidStrategy(endpoints, this.openApiDoc) ?? throw new InvalidOperationException(
-                "No endpoints can produce valid requests. Register body parameter types with [Arbitrary] or GenForRegistry."),
+                "No endpoints can produce valid requests. Register body parameter types with [Arbitrary] or GenerateForRegistry."),
             RequestFlavour.MalformedOnly => BuildMalformedStrategy(endpoints),
             _ => BuildMixedStrategy(endpoints, this.openApiDoc),
         };

--- a/src/Conjecture.AspNetCore/RequestSynthesizer.cs
+++ b/src/Conjecture.AspNetCore/RequestSynthesizer.cs
@@ -128,15 +128,15 @@ internal sealed class RequestSynthesizer(DiscoveredEndpoint endpoint, Conjecture
             {
                 throw new ArgumentException(
                     $"Cannot synthesize request for endpoint '{endpoint.DisplayName}': " +
-                    $"parameter '{param.Name}' has type '{param.ClrType.FullName}' which is not registered with Gen.For<T>(). " +
-                    $"Decorate the type with [Arbitrary] or register it manually via GenForRegistry.Register().",
+                    $"parameter '{param.Name}' has type '{param.ClrType.FullName}' which is not registered with Generate.For<T>(). " +
+                    $"Decorate the type with [Arbitrary] or register it manually via GenerateForRegistry.Register().",
                     param.Name);
             }
         }
     }
 
     private static bool IsSupportedType(Type type) =>
-        PrimitiveFactories.ContainsKey(type) || GenForRegistry.IsRegistered(type);
+        PrimitiveFactories.ContainsKey(type) || GenerateForRegistry.IsRegistered(type);
 
     private static string BuildPath(string rawPattern, IReadOnlyList<EndpointParameter> parameters, IGeneratorContext ctx)
     {
@@ -200,7 +200,7 @@ internal sealed class RequestSynthesizer(DiscoveredEndpoint endpoint, Conjecture
         }
 
         // Use the registered boxed strategy.
-        Strategy<object?> boxedStrategy = GenForRegistry.ResolveBoxed(bodyParam.ClrType);
+        Strategy<object?> boxedStrategy = GenerateForRegistry.ResolveBoxed(bodyParam.ClrType);
         object? value = ctx.Generate(boxedStrategy);
         return JsonSerializer.Serialize(value);
     }

--- a/src/Conjecture.Core.Tests/StateMachine/GenerateStateMachineTests.cs
+++ b/src/Conjecture.Core.Tests/StateMachine/GenerateStateMachineTests.cs
@@ -8,7 +8,7 @@ using Conjecture.Core.Internal;
 
 namespace Conjecture.Core.Tests.StateMachine;
 
-public class GenStateMachineTests
+public class GenerateStateMachineTests
 {
     private sealed class CounterMachine : IStateMachine<int, string>
     {

--- a/src/Conjecture.Core.Tests/Strategies/GenerateRecursiveTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/GenerateRecursiveTests.cs
@@ -6,7 +6,7 @@ using Conjecture.Core.Internal;
 
 namespace Conjecture.Core.Tests.Strategies;
 
-public class GenRecursiveTests
+public class GenerateRecursiveTests
 {
     private static ConjectureData MakeData(ulong seed = 42UL) =>
         ConjectureData.ForGeneration(new SplittableRandom(seed));

--- a/src/Conjecture.Core/Generate.cs
+++ b/src/Conjecture.Core/Generate.cs
@@ -278,7 +278,7 @@ public static class Generate
     public static Strategy<char> Chars() => new CharStrategy();
 
     /// <summary>Returns a strategy for <typeparamref name="T"/> using its registered <see cref="IStrategyProvider{T}"/>. The type must be decorated with <c>[Arbitrary]</c>.</summary>
-    public static Strategy<T> For<T>() => GenForRegistry.Resolve<T>();
+    public static Strategy<T> For<T>() => GenerateForRegistry.Resolve<T>();
 
     /// <summary>Returns a strategy for <typeparamref name="T"/> with property overrides applied via <paramref name="configure"/>. The type must be decorated with <c>[Arbitrary]</c>.</summary>
     public static Strategy<T> For<T>(Action<ForConfiguration<T>> configure)
@@ -286,6 +286,6 @@ public static class Generate
         ArgumentNullException.ThrowIfNull(configure);
         ForConfiguration<T> cfg = new();
         configure(cfg);
-        return Compose<T>(ctx => ctx.Generate(GenForRegistry.ResolveWithOverrides(cfg)));
+        return Compose<T>(ctx => ctx.Generate(GenerateForRegistry.ResolveWithOverrides(cfg)));
     }
 }

--- a/src/Conjecture.Core/GenerateForRegistry.cs
+++ b/src/Conjecture.Core/GenerateForRegistry.cs
@@ -11,10 +11,10 @@ namespace Conjecture.Core;
 
 /// <summary>
 /// AOT-safe registry for <see cref="IStrategyProvider"/> factories populated by the
-/// <c>GenForGenerator</c> source generator via <c>[ModuleInitializer]</c>.
+/// <c>GenerateForGenerator</c> source generator via <c>[ModuleInitializer]</c>.
 /// Must be <see langword="public"/> so generated code in user assemblies can register types.
 /// </summary>
-public static class GenForRegistry
+public static class GenerateForRegistry
 {
     private static readonly ConcurrentDictionary<Type, Func<IStrategyProvider>> Providers = new();
 
@@ -63,7 +63,7 @@ public static class GenForRegistry
             : throw new InvalidOperationException(
                 $"No boxed strategy is registered for '{type.FullName}'. " +
                 $"Decorate the type with [Arbitrary] and use the Conjecture.Generators source generator, " +
-                $"or register it manually via GenForRegistry.Register(type, factory, boxedStrategy).");
+                $"or register it manually via GenerateForRegistry.Register(type, factory, boxedStrategy).");
     }
 
     internal static Strategy<T> Resolve<T>()

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,12 @@
 #nullable enable
-static Conjecture.Core.GenForRegistry.IsRegistered(System.Type! type) -> bool
-static Conjecture.Core.GenForRegistry.Register(System.Type! type, System.Func<Conjecture.Core.IStrategyProvider!>! factory, Conjecture.Core.Strategy<object?>! boxedStrategy) -> void
-static Conjecture.Core.GenForRegistry.ResolveBoxed(System.Type! type) -> Conjecture.Core.Strategy<object?>!
+*REMOVED*Conjecture.Core.GenForRegistry
+*REMOVED*static Conjecture.Core.GenForRegistry.Register(System.Type! type, System.Func<Conjecture.Core.IStrategyProvider!>! factory) -> void
+*REMOVED*static Conjecture.Core.GenForRegistry.RegisterOverride(System.Type! type, System.Func<object!, object!>! factory) -> void
+*REMOVED*static Conjecture.Core.GenForRegistry.ResolveWithOverrides<T>(Conjecture.Core.ForConfiguration<T>! cfg) -> Conjecture.Core.Strategy<T>!
+Conjecture.Core.GenerateForRegistry
+static Conjecture.Core.GenerateForRegistry.IsRegistered(System.Type! type) -> bool
+static Conjecture.Core.GenerateForRegistry.Register(System.Type! type, System.Func<Conjecture.Core.IStrategyProvider!>! factory) -> void
+static Conjecture.Core.GenerateForRegistry.Register(System.Type! type, System.Func<Conjecture.Core.IStrategyProvider!>! factory, Conjecture.Core.Strategy<object?>! boxedStrategy) -> void
+static Conjecture.Core.GenerateForRegistry.RegisterOverride(System.Type! type, System.Func<object!, object!>! factory) -> void
+static Conjecture.Core.GenerateForRegistry.ResolveBoxed(System.Type! type) -> Conjecture.Core.Strategy<object?>!
+static Conjecture.Core.GenerateForRegistry.ResolveWithOverrides<T>(Conjecture.Core.ForConfiguration<T>! cfg) -> Conjecture.Core.Strategy<T>!

--- a/src/Conjecture.Generators.Tests/ForConfigurationTests.cs
+++ b/src/Conjecture.Generators.Tests/ForConfigurationTests.cs
@@ -140,7 +140,7 @@ public sealed class ForConfigurationTests
         Assert.NotNull(strategy);
     }
 
-    // ── GenForRegistry.ResolveWithOverrides ─────────────────────────────────
+    // ── GenerateForRegistry.ResolveWithOverrides ─────────────────────────────────
 
     [Fact]
     public void ResolveWithOverrides_UnregisteredType_ThrowsInvalidOperationException()
@@ -148,7 +148,7 @@ public sealed class ForConfigurationTests
         ForConfiguration<UnregisteredType> cfg = new();
 
         Assert.Throws<InvalidOperationException>(
-            () => GenForRegistry.ResolveWithOverrides(cfg));
+            () => GenerateForRegistry.ResolveWithOverrides(cfg));
     }
 
     // ── Generator emission: CreateWithOverrides ──────────────────────────────
@@ -229,7 +229,7 @@ public sealed class ForConfigurationTests
                 OutputKind.DynamicallyLinkedLibrary,
                 nullableContextOptions: NullableContextOptions.Enable));
 
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(new GenForGenerator());
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new GenerateForGenerator());
         GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
 
         Compilation outputCompilation = inputCompilation.AddSyntaxTrees(result.GeneratedTrees);

--- a/src/Conjecture.Generators.Tests/GenerateForDiagnosticTests.cs
+++ b/src/Conjecture.Generators.Tests/GenerateForDiagnosticTests.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Conjecture.Generators.Tests;
 
-public sealed class GenForDiagnosticTests
+public sealed class GenerateForDiagnosticTests
 {
     // --- CON310: Generate.For<T>() where T is an interface ---
 
@@ -68,7 +68,7 @@ public sealed class GenForDiagnosticTests
         (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
 
         bool hasRegistry = trees.Any(
-            t => t.FilePath.EndsWith("GenForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
+            t => t.FilePath.EndsWith("GenerateForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
         Assert.False(hasRegistry);
     }
 
@@ -253,7 +253,7 @@ public sealed class GenForDiagnosticTests
         (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(source);
 
         bool hasRegistry = trees.Any(
-            t => t.FilePath.EndsWith("GenForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
+            t => t.FilePath.EndsWith("GenerateForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
         Assert.True(hasRegistry);
     }
 
@@ -316,7 +316,7 @@ public sealed class GenForDiagnosticTests
                 OutputKind.DynamicallyLinkedLibrary,
                 nullableContextOptions: NullableContextOptions.Enable));
 
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(new GenForGenerator());
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new GenerateForGenerator());
         GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
 
         Compilation outputCompilation = inputCompilation.AddSyntaxTrees(result.GeneratedTrees);

--- a/src/Conjecture.Generators.Tests/GenerateForGeneratorTests.cs
+++ b/src/Conjecture.Generators.Tests/GenerateForGeneratorTests.cs
@@ -10,16 +10,16 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Conjecture.Generators.Tests;
 
-public sealed class GenForGeneratorTests
+public sealed class GenerateForGeneratorTests
 {
     [Fact]
-    public void Record_WithPrimitiveFields_EmitsGenForRegistryFile()
+    public void Record_WithPrimitiveFields_EmitsGenerateForRegistryFile()
     {
         (ImmutableArray<SyntaxTree> trees, _, _) = RunGenerator(
             "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Order(int Id, string Name);");
 
         SyntaxTree? tree = trees.FirstOrDefault(
-            t => t.FilePath.EndsWith("GenForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
+            t => t.FilePath.EndsWith("GenerateForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
         Assert.NotNull(tree);
     }
 
@@ -28,7 +28,7 @@ public sealed class GenForGeneratorTests
     {
         string text = GetGeneratedText(
             "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Order(int Id, string Name);",
-            "GenForRegistry.g.cs");
+            "GenerateForRegistry.g.cs");
 
         Assert.Contains("[ModuleInitializer]", text);
     }
@@ -38,7 +38,7 @@ public sealed class GenForGeneratorTests
     {
         string text = GetGeneratedText(
             "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Order(int Id, string Name);",
-            "GenForRegistry.g.cs");
+            "GenerateForRegistry.g.cs");
 
         Assert.Contains("typeof(global::MyApp.Order)", text);
     }
@@ -48,7 +48,7 @@ public sealed class GenForGeneratorTests
     {
         string text = GetGeneratedText(
             "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Order(int Id, string Name);",
-            "GenForRegistry.g.cs");
+            "GenerateForRegistry.g.cs");
 
         Assert.Contains("OrderArbitrary", text);
     }
@@ -58,7 +58,7 @@ public sealed class GenForGeneratorTests
     {
         string text = GetGeneratedText(
             "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial struct Point { public int X { get; init; } public int Y { get; init; } }",
-            "GenForRegistry.g.cs");
+            "GenerateForRegistry.g.cs");
 
         Assert.Contains("typeof(global::MyApp.Point)", text);
         Assert.Contains("PointArbitrary", text);
@@ -69,7 +69,7 @@ public sealed class GenForGeneratorTests
     {
         string text = GetGeneratedText(
             "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial class Box { public Box(int Width, int Height) {} }",
-            "GenForRegistry.g.cs");
+            "GenerateForRegistry.g.cs");
 
         Assert.Contains("typeof(global::MyApp.Box)", text);
         Assert.Contains("BoxArbitrary", text);
@@ -80,7 +80,7 @@ public sealed class GenForGeneratorTests
     {
         string text = GetGeneratedText(
             "using Conjecture.Core; namespace MyApp; [Arbitrary] public partial record Order(int Id); [Arbitrary] public partial record Product(string Name);",
-            "GenForRegistry.g.cs");
+            "GenerateForRegistry.g.cs");
 
         Assert.Contains("typeof(global::MyApp.Order)", text);
         Assert.Contains("typeof(global::MyApp.Product)", text);
@@ -93,14 +93,14 @@ public sealed class GenForGeneratorTests
             "namespace MyApp; public class Plain { public int X { get; set; } }");
 
         SyntaxTree? tree = trees.FirstOrDefault(
-            t => t.FilePath.EndsWith("GenForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
+            t => t.FilePath.EndsWith("GenerateForRegistry.g.cs", StringComparison.OrdinalIgnoreCase));
         Assert.Null(tree);
     }
 
     [Fact]
     public void Record_WithPrimitiveFields_GeneratedCodeCompilesWithoutErrors()
     {
-        // Include a hand-written OrderArbitrary so the GenForRegistry.g.cs reference compiles independently of ArbitraryGenerator.
+        // Include a hand-written OrderArbitrary so the GenerateForRegistry.g.cs reference compiles independently of ArbitraryGenerator.
         string source = """
             using Conjecture.Core;
             namespace MyApp;
@@ -144,7 +144,7 @@ public sealed class GenForGeneratorTests
                 OutputKind.DynamicallyLinkedLibrary,
                 nullableContextOptions: NullableContextOptions.Enable));
 
-        GeneratorDriver driver = CSharpGeneratorDriver.Create(new GenForGenerator());
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(new GenerateForGenerator());
         GeneratorDriverRunResult result = driver.RunGenerators(inputCompilation).GetRunResult();
 
         Compilation outputCompilation = inputCompilation.AddSyntaxTrees(result.GeneratedTrees);

--- a/src/Conjecture.Generators/GenerateForGenerator.cs
+++ b/src/Conjecture.Generators/GenerateForGenerator.cs
@@ -11,9 +11,9 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Conjecture.Generators;
 
-/// <summary>Incremental source generator that emits <c>GenForRegistry.g.cs</c> — a <c>[ModuleInitializer]</c> that registers <c>IStrategyProvider</c> factories for all <c>[Arbitrary]</c> types, enabling <c>Generate.For&lt;T&gt;()</c>.</summary>
+/// <summary>Incremental source generator that emits <c>GenerateForRegistry.g.cs</c> — a <c>[ModuleInitializer]</c> that registers <c>IStrategyProvider</c> factories for all <c>[Arbitrary]</c> types, enabling <c>Generate.For&lt;T&gt;()</c>.</summary>
 [Generator(LanguageNames.CSharp)]
-public sealed class GenForGenerator : IIncrementalGenerator
+public sealed class GenerateForGenerator : IIncrementalGenerator
 {
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
@@ -74,7 +74,7 @@ public sealed class GenForGenerator : IIncrementalGenerator
             }
 
             string registrySource = EmitRegistry(entries);
-            ctx.AddSource("GenForRegistry.g.cs", registrySource);
+            ctx.AddSource("GenerateForRegistry.g.cs", registrySource);
 
             foreach ((TypeModel model, string _) in generatedModels)
             {
@@ -398,17 +398,17 @@ public sealed class GenForGenerator : IIncrementalGenerator
         sb.AppendLine();
         sb.AppendLine("namespace Conjecture.Generated;");
         sb.AppendLine();
-        sb.AppendLine("internal static class GenForRegistryInitializer");
+        sb.AppendLine("internal static class GenerateForRegistryInitializer");
         sb.AppendLine("{");
         sb.AppendLine("    [ModuleInitializer]");
         sb.AppendLine("    internal static void Register()");
         sb.AppendLine("    {");
         foreach ((string typeFqn, string providerFqn) in entries)
         {
-            sb.AppendLine($"        global::Conjecture.Core.GenForRegistry.Register(");
+            sb.AppendLine($"        global::Conjecture.Core.GenerateForRegistry.Register(");
             sb.AppendLine($"            typeof(global::{typeFqn}),");
             sb.AppendLine($"            static () => new global::{providerFqn}());");
-            sb.AppendLine($"        global::Conjecture.Core.GenForRegistry.RegisterOverride(");
+            sb.AppendLine($"        global::Conjecture.Core.GenerateForRegistry.RegisterOverride(");
             sb.AppendLine($"            typeof(global::{typeFqn}),");
             sb.AppendLine($"            static cfg => (object)new global::{providerFqn}().CreateWithOverrides((global::Conjecture.Core.ForConfiguration<global::{typeFqn}>)cfg));");
         }

--- a/src/Conjecture.JsonSchema/JsonSchemaStrategy.cs
+++ b/src/Conjecture.JsonSchema/JsonSchemaStrategy.cs
@@ -7,6 +7,8 @@ using System.Text.Json;
 using Conjecture.Core;
 using Conjecture.Core.Internal;
 
+// Local alias: this class extends Strategy<T> and inherits a Generate(ConjectureData) method,
+// so unqualified `Gen.X` would bind to the inherited method rather than the static class.
 using Gen = Conjecture.Core.Generate;
 
 namespace Conjecture.JsonSchema;

--- a/src/Conjecture.Mcp/Tools/StrategyTools.cs
+++ b/src/Conjecture.Mcp/Tools/StrategyTools.cs
@@ -54,7 +54,7 @@ internal static class StrategyTools
 
             **With property overrides:**
             ```csharp
-            Strategy<{{typeName}}> strategy = Gen.For<{{typeName}}>(cfg => cfg.Override(x => x.SomeProperty, Generate.Integers<int>(min: 0, max: 100)));
+            Strategy<{{typeName}}> strategy = Generate.For<{{typeName}}>(cfg => cfg.Override(x => x.SomeProperty, Generate.Integers<int>(min: 0, max: 100)));
             ```
             """;
     }

--- a/src/Conjecture.Protobuf/ProtobufFieldStrategy.cs
+++ b/src/Conjecture.Protobuf/ProtobufFieldStrategy.cs
@@ -11,6 +11,8 @@ using Google.Protobuf.Reflection;
 
 using FieldType = Google.Protobuf.Reflection.FieldType;
 
+// Local alias: this class extends Strategy<T> and inherits a Generate(ConjectureData) method,
+// so unqualified `Gen.X` would bind to the inherited method rather than the static class.
 using Gen = Conjecture.Core.Generate;
 
 namespace Conjecture.Protobuf;


### PR DESCRIPTION
Aligns class names with file names and removes the historical Gen vs Generate split that made symbol resolution ambiguous.

Production:
- GenForRegistry → GenerateForRegistry (file already renamed by user)
- GenForGenerator → GenerateForGenerator (file + class)
- Source generator output: GenForRegistry.g.cs → GenerateForRegistry.g.cs; GenForRegistryInitializer → GenerateForRegistryInitializer
- PublicAPI.Unshipped.txt records the rename via *REMOVED* entries for the four shipped GenForRegistry symbols

Tests:
- GenForGeneratorTests, GenForDiagnosticTests, GenStateMachineTests, GenRecursiveTests renamed for symmetry

Docs:
- gen-for.md, use-gen-for.md, gen-for-source-generator.md renamed
- TOC entries + cross-links updated; CLAUDE.MD project table extended
- ADR 0063 + how-to/reference content use Generate.For<T>()

Local Gen aliases retained in JsonSchemaStrategy + ProtobufFieldStrategy because each class extends Strategy<T>, whose inherited Generate(ConjectureData) method shadows the static class. A comment now explains why.

Constraint attributes (GenRange, GenStringLength, GenRegex, GenMaxDepth) deliberately keep the short Gen prefix — shipped public surface used in user code as [GenRange(...)].

## Description

<!-- What does this PR do and why? -->

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [x] Refactor (no behavior change)
- [x] Documentation / chore
- [x] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [ ] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style
