### PR TITLE
Restrict GITHUB_TOKEN to contents:read in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Adds an explicit top-level `permissions` block to `.github/workflows/ci.yml` so the `GITHUB_TOKEN` follows the principle of least privilege.

The CI job only checks out code, builds, tests, and packs — none of those steps require write access to any scope. Without an explicit declaration, the token defaults to broad write permissions on multiple scopes.

Closes GitHub code scanning alert [#1](https://github.com/kommundsen/Conjecture/security/code-scanning/1) (`actions/missing-workflow-permissions`, severity: medium).

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [ ] Refactor (no behavior change)
- [x] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style