### PR TITLE
[291] EF Core Integration

### DIFF
--- a/docs/decisions/0065-conjecture-efcore-package-design.md
+++ b/docs/decisions/0065-conjecture-efcore-package-design.md
@@ -1,0 +1,160 @@
+# 0065. Conjecture.EFCore package design
+
+**Date:** 2026-04-27
+**Status:** Accepted
+
+## Context
+
+ADR 0059 ships `Conjecture.Interactions` plus `Conjecture.Http` as the v0.20 interaction foundation. ADR 0061 (`Conjecture.Messaging`), ADR 0062 (`Conjecture.Grpc`), ADR 0063 (`Conjecture.AspNetCore`), and ADR 0064 (`Conjecture.Aspire`) extend that foundation across the major transport and host layers, validating that the interaction model generalises beyond a single service.
+
+Persistence is the next gap. EF Core is the canonical .NET data-access layer for relational models, and EF Core's `IModel` already exposes the structural metadata Conjecture needs to synthesise entities (CLR types, nullable, MaxLength, Precision, navigation properties, key relationships). Property-based testing of EF Core is doubly valuable: it exercises both the application's domain invariants under synthetic load and EF's own translation/tracking behavior under unusual but legal entity graphs.
+
+The decision must answer:
+
+- Ship as a separate `Conjecture.EFCore` satellite package or fold strategies into `Conjecture.Generators`?
+- What is the default test provider, and how do callers override it?
+- How are navigation-property cycles handled when synthesising entity graphs?
+- What constraint surface is honoured in v1 (nullable, MaxLength, CheckConstraint, value generators)?
+- Are strategies generated at runtime via reflection over `IModel`, or precomputed via a Roslyn source generator?
+- Is LINQ query-shape fuzzing in scope for v1?
+- Is migration up/down snapshot testing in scope for v1?
+- How does EF Core conform to the Layer-1 (Interactions) abstraction shipped in ADR 0059, so it composes with `Conjecture.Http`, `Conjecture.Messaging`, and `Conjecture.Grpc`?
+
+## Decision
+
+Ship a single `Conjecture.EFCore` NuGet package containing `PropertyStrategyBuilder`, `EntityStrategyBuilder`, `EFCoreGenerate` extensions, `RoundtripAsserter`, `MigrationHarness`, plus the Layer-1 interaction surface (`DbInteraction`, `IDbTarget`, `Generate.Db`, `DbInvariantExtensions`). The package depends on `Microsoft.EntityFrameworkCore` and `Conjecture.Core`; it does not reference any test framework — framework wiring is handled by thin satellite packages per ADR 0055.
+
+### Package topology — separate satellite, not embedded in `Conjecture.Generators`
+
+`Conjecture.EFCore` is a standalone satellite package, not a feature of `Conjecture.Generators`. The dependency on `Microsoft.EntityFrameworkCore` (and transitively the relational provider stack) is heavy and should not be forced onto consumers who do not use EF Core. Framework adapters reference `Conjecture.EFCore` optionally per ADR 0055.
+
+### Default test provider — SQLite in-memory, with `DbContextFactory` override
+
+`Generate.EntitySet<T>()` and `Generate.Db.*` strategies default to building entity graphs against an EF Core `IModel` resolved from a SQLite in-memory `DbContext`. SQLite in-memory is the canonical EF testing provider: it is real SQL, supports migrations and transactions, and runs entirely in-process with no external dependency.
+
+Callers override the provider by supplying a `DbContextFactory<TContext>` to `IDbTarget`. The override path is provider-agnostic: callers can target `InMemory`, `Sqlite`, `Npgsql`, `SqlServer`, or any provider that produces a valid `IModel`. v1 ships `InMemoryDbTarget` (EF's `Microsoft.EntityFrameworkCore.InMemory` for fast unit tests where SQL fidelity is not required) and `SqliteDbTarget` (the recommended default).
+
+```csharp
+public interface IDbTarget : IInteractionTarget
+{
+    DbContext Resolve(string resourceName);
+    Task ResetAsync(string resourceName, CancellationToken ct = default);
+}
+
+public sealed class SqliteDbTarget : IDbTarget { ... }
+public sealed class InMemoryDbTarget : IDbTarget { ... }
+```
+
+Multi-provider matrix testing (one property run executed against multiple providers in sequence) is out of scope for v1 — it can be expressed today by parameterising the test method over `IDbTarget` instances.
+
+### Navigation cycles — bounded depth, default 2, aligned with `Generate.Recursive()`
+
+`EntityStrategyBuilder` walks navigation properties to compose entity graphs. Cyclic navigations (e.g. `Order.Customer.Orders.Customer.…`) are bounded by a configurable depth, default `2`, mirroring the depth semantics of `Generate.Recursive()` (ADR 0042). At the depth bound, optional navigations are set to `null` and required navigations are terminated with the first generated parent (no further descent). This guarantees finite graphs without forcing the caller to declare cycle-breaking strategies.
+
+Consumers raise the bound for deeper graphs via `Generate.EntitySet<T>().WithMaxDepth(n)` or override per-navigation via `.WithoutNavigation(e => e.Customer)`.
+
+### Constraint scope (v1) — type-system metadata only
+
+`PropertyStrategyBuilder` honours the type-system constraints exposed directly on `IProperty`:
+
+- CLR type (`int`, `string`, `Guid`, `DateTime`, `decimal`, etc.)
+- Nullability (`IsNullable`)
+- `MaxLength` for `string` and `byte[]`
+- `Precision` and `Scale` for `decimal`
+- `IsConcurrencyToken` (for the concurrency invariant; no special generation)
+
+Out of scope for v1:
+
+- `CheckConstraint` evaluation — would require parsing relational SQL fragments per provider; deferred to a future opt-in extension.
+- `HasConversion`/value converters — generated values target the CLR property type; converters are exercised on save/read but not modelled in the strategy.
+- `ValueGeneratedOnAdd`/`ValueGeneratedOnUpdate` — strategies leave the property at its CLR default; EF assigns the generated value on insert. This avoids fighting EF's own value generation.
+- Index uniqueness constraints across an entity set — `EntityStrategyBuilder` does not de-duplicate generated keys for unique indexes; collisions surface as `DbUpdateException` and are reported via `RoundtripAsserter`.
+
+### Strategy generation — runtime reflection over `IModel`, no Roslyn codegen
+
+Strategies are built at runtime by walking `IModel` and composing primitive `Strategy<T>` instances. No Roslyn source generator runs at build time. The runtime path is sufficient because:
+
+- `IModel` is already a fully-resolved metadata object — no syntactic information is required.
+- Strategy construction happens once per `Generate.EntitySet<T>()` call and is then cached per-entity-type by `EntityStrategyBuilder`, so per-example overhead is minimal.
+- A source-generator path would require duplicating EF's model-building logic and would not survive `OnModelCreating` overrides.
+
+A future codegen-only path (e.g. for AOT scenarios) is not precluded but is not delivered in v1.
+
+### LINQ query-shape fuzzing — deferred to `Conjecture.EFCore.Linq`
+
+Generating arbitrary `IQueryable<T>` expressions to fuzz EF's query-translation pipeline is a separate, large effort that intersects with expression-tree synthesis and provider-specific SQL emission. v1 ships entity-graph generation only. A future `Conjecture.EFCore.Linq` package will host LINQ query-shape strategies and the translation-success invariant.
+
+### Migration up/down snapshot harness — in scope for v1
+
+`MigrationHarness` is in scope for v1. The harness applies all pending migrations forward, snapshots the resulting schema, applies the latest migration's `Down`, then re-applies its `Up` and asserts the resulting schema matches the snapshot. This catches migrations that are not symmetric (a common cause of staging/production drift). The harness is invoked explicitly via `MigrationHarness.AssertUpDownIdempotent(ctx)` — it is not implicit in `RoundtripAsserter`.
+
+### Owned types — generated inline with owner
+
+EF Core owned types (`OwnsOne`, `OwnsMany`) are generated inline as part of the owner's strategy and are not exposed as standalone `Generate.EntitySet<TOwned>()` calls. This matches EF's modelling semantics: owned types have no independent identity. Callers who want to share owned-type generation across owners should compose at the property level via `PropertyStrategyBuilder`.
+
+### Query translation invariant — deferred to v2, success-or-`InvalidOperationException`
+
+A "queries always translate" invariant is deferred to v2. When delivered, the invariant will execute the generated query and assert that the outcome is one of:
+
+- successful translation and execution, or
+- `InvalidOperationException` (EF's documented "untranslatable expression" signal).
+
+`NullReferenceException` or any other exception type will be reported as a failure. This shape is chosen so the invariant catches genuine translator bugs without classifying every "this LINQ shape isn't supported by this provider" message as a defect.
+
+### Layer-1 (Interactions) conformance — third transport concretion
+
+`Conjecture.EFCore` ships a Layer-1 surface alongside the strategy builders so EF Core is a first-class transport in the interaction model, not a parallel stateful-testing stack:
+
+- **`DbInteraction : IInteraction`** (#488) — a record carrying `ResourceName`, `Op` (`{ Add, Update, Remove, SaveChanges, Query }`), and an opaque `Payload` (entity, key, or query specification).
+- **`IDbTarget : IInteractionTarget`** (#489) — resolves a `DbContext` by `ResourceName` for the runner. `InMemoryDbTarget` and `SqliteDbTarget` are the reference implementations; both expose `ResetAsync` for inter-example state reset.
+- **`Generate.Db.*`** (#490) — extension-block strategy builders (`Generate.Db.Add<T>(...)`, `Generate.Db.Update<T>(...)`, `Generate.Db.SaveChanges()`, etc.) returning `Strategy<DbInteraction>`. Composes with `InteractionStateMachine<TState>` (ADR 0033) and reuses `CommandSequenceShrinkPass` (ADR 0034).
+- **`DbInvariantExtensions`** (#491) — fluent assertions mirroring `HttpInvariantExtensions`:
+  - `Roundtrip()` — every `Add`/`Update`/`Remove` is observable on a fresh `DbContext`.
+  - `ConcurrencyToken()` — concurrent `Update`s on the same key produce `DbUpdateConcurrencyException`.
+  - `NoOrphans()` — no required relationship has a missing parent after `SaveChanges`.
+  - `NoTrackingMatchesTracked()` — `AsNoTracking().FirstOrDefault(key)` agrees with the tracked entity's projection.
+
+`CompositeInteractionTarget` (ADR 0064) routes named resources across `IHttpTarget + IDbTarget + IMessageBusTarget`. This unblocks v0.26 (AspNetCore + EFCore) and v0.27 (Aspire + EFCore) integration packages: a single `InteractionStateMachine<TState>` can interleave HTTP requests, message-queue publications, and database mutations against a unified state.
+
+### Per-adapter test strategy
+
+Two tiers, mirroring ADR 0061, ADR 0063, and ADR 0064:
+
+- **Unit tier** (`Conjecture.EFCore.Tests`) — `InMemoryDbTarget` and a fake `SqliteDbTarget` substitute. Covers `PropertyStrategyBuilder` constraint mapping, `EntityStrategyBuilder` cycle bounds and required-navigation termination, `RoundtripAsserter` happy and failure paths, `MigrationHarness` symmetric and asymmetric cases, `DbInteraction`/`IDbTarget` plumbing, and shrunk-trace emission. No external SQL server.
+- **Integration tier** (`Conjecture.SelfTests/EFCore/`) — real SQLite (file-backed) plus an opt-in PostgreSQL path (`EFCORE_POSTGRES_TESTS=1`). Asserts cross-provider behavior, validates the Layer-1 composition with `Conjecture.Http` against a tiny ASP.NET Core+EFCore sample, and exercises the migration harness against a multi-step migration history. Off by default in CI; runs on-demand and pre-release.
+
+## Consequences
+
+**Easier:**
+
+- `IModel`-driven strategies mean callers get reasonable defaults without writing per-entity strategies — a domain with 30 entities works out of the box.
+- Layer-1 conformance lets EF Core compose with HTTP and messaging in a single `InteractionStateMachine<TState>`, which is the headline win for the v0.26 and v0.27 integration packages.
+- SQLite in-memory default keeps unit-tier tests hermetic and fast.
+- Bounded navigation depth aligned with `Generate.Recursive()` is a single mental model for users — they already know the recursive-strategy semantics.
+- Migration up/down harness catches a class of bugs that is otherwise only seen in production rollbacks.
+
+**Harder:**
+
+- Type-system-only constraint scope means that a property with a `CheckConstraint("Quantity > 0")` will generate values that violate the constraint and surface as `DbUpdateException`. This is acceptable for v1 (the failure mode is loud), but documentation must call it out.
+- `ValueGeneratedOnAdd` properties left at their CLR default mean the strategy cannot synthesise a fully-populated entity for *unsaved* assertions — callers wanting that must call `SaveChanges` first. Documented in the reference.
+- Owned-type strategies are not independently composable. Teams who want to share an owned-type strategy across two owners must drop to `PropertyStrategyBuilder`.
+- `MigrationHarness` requires an `IDesignTimeDbContextFactory` or runtime-resolved `DbContext` that supports `Database.GetMigrations()`. Apps using only `EnsureCreated` will not benefit; documented as a precondition.
+- The integration self-test tier requires PostgreSQL and is off by default in CI, which means provider-specific regressions may not be caught until a contributor enables the flag.
+
+## Alternatives Considered
+
+**Fold strategies into `Conjecture.Generators`** — ship `Generate.EntitySet<T>()` from the existing generator package. Rejected: drags `Microsoft.EntityFrameworkCore` into every consumer of `Generate.For<T>()`, including consumers who just want primitive strategies. The satellite-package pattern (ADR 0055) applies cleanly here.
+
+**Roslyn source generator over `IModel`** — emit per-entity strategies at build time. Rejected for v1: would require re-implementing EF's model builder (which honours `OnModelCreating`, fluent configuration, and convention-based shaping), an enormous surface area to mirror correctly. Runtime reflection is sufficient and is cached after first use. Codegen path remains an option for AOT in a future release.
+
+**Per-example `DbContext` instance** — instantiate a fresh `DbContext` for every generated example. Rejected: works but is unnecessarily expensive. `IDbTarget.ResetAsync` (transactional rollback or `SaveChanges` of compensating mutations) is fast and matches the lifecycle pattern in ADR 0064.
+
+**Multi-provider matrix in v1** — run each property against `Sqlite + InMemory + Npgsql + SqlServer` automatically. Rejected: matrix execution is an orthogonal concern (test parameterisation, CI cost, provider availability) better handled by the test framework. Users who want matrix coverage parameterise their `[Property]` over multiple `IDbTarget` instances.
+
+**LINQ query-shape fuzzing in v1** — synthesise arbitrary `IQueryable<T>` expressions and assert translation success. Rejected: large, deep, and provider-sensitive. Deferred to `Conjecture.EFCore.Linq` to keep v1 shippable.
+
+**Skip migration harness — leave migrations to FluentMigrator/etc.** — defer migration testing entirely. Rejected: migrations are the highest-stakes EF surface (irreversible production changes) and the harness is small (one APIs, one round-trip). Including it in v1 raises the package's value proposition substantially with little additional cost.
+
+**Honour `CheckConstraint` via SQL evaluation in v1** — parse the constraint expression and bias generation away from violations. Rejected: per-provider SQL parsing is a large undertaking, and the failure mode of generating values that hit the constraint (loud `DbUpdateException`) is acceptable for v1. Future opt-in via a `[CheckConstraint]` extension hook.
+
+**Treat `CompositeInteractionTarget` as out-of-scope for `Conjecture.EFCore`** — let the integration packages (v0.26, v0.27) wire composition. Rejected: the composition pattern is a property of the Layer-1 design (ADR 0064), and EF Core's `IDbTarget` must satisfy the contract from day one. Without this, the integration packages would either bypass the Layer-1 contract or duplicate it.

--- a/docs/site/articles/explanation/efcore-property-testing.md
+++ b/docs/site/articles/explanation/efcore-property-testing.md
@@ -1,0 +1,69 @@
+# Why property testing finds EF Core bugs
+
+EF Core sits between domain code and SQL. Most of its surface is metadata — `IModel`, `IEntityType`, `IProperty`, `INavigation`, `IForeignKey` — all eagerly resolved by the time your `DbContext` finishes building. Conjecture turns that metadata into strategies, which means you can synthesise structurally-valid entity graphs without writing per-entity factories. The interesting consequence is what those strategies *find*.
+
+## Three classes of bugs cluster at the EF boundary
+
+### 1. Model–domain divergence
+
+Your domain says "every `Order` has a customer." Your `OnModelCreating` says `entity.HasOne(o => o.Customer).WithMany().IsRequired(false)` because the migration history once allowed orphans. The two diverge silently — `Order? Customer` is reference-typed and tolerated by the runtime, but a property test that generates `Order` graphs from `IModel` will produce `Order` instances with `Customer = null`. If your domain logic dereferences `order.Customer.Name` anywhere, the property fails on the first such draw.
+
+This is not a bug in EF. It's a bug in the *contract* between the model configuration and the domain code. The strategy mechanically generates the legal value space the model claims; if your code can't handle that space, the test fails.
+
+### 2. Value converter precision loss
+
+`HasConversion<T, U>` lets you store `MoneyAmount` as `decimal`, `DateOnly` as a string, `Status` as an `int`. Each converter is a small function pair; each function pair is a place where round-tripping can lose information. The most common shape: a converter that truncates sub-second precision, drops trailing zeros, or normalises a string in only one direction.
+
+`RoundtripAsserter.AssertRoundtripAsync` saves an entity, reads it back from a fresh `DbContext`, and walks scalar properties via `IProperty.PropertyInfo!.GetValue` to compare. The comparison reads the *post-converter* value, so an asymmetric converter shows up as a property-level diff: `expected '12:34:56.7890000', got '12:34:56.0000000'`. Without property testing, this surfaces in production when a downstream system compares timestamps and rejects the divergence.
+
+### 3. Migration data loss on `Down`
+
+Migrations apply forward in production and (usually) only forward. The `Down` direction is exercised in two scenarios: a developer rolling back during local iteration, and a deployment system reverting a failed release. Both are rare, both are high-stakes, both happen in environments where you can't easily re-derive the lost data.
+
+`MigrationHarness.AssertUpDownIdempotentAsync` applies migrations to head, snapshots `sqlite_master`, runs `Down` on the latest, then re-applies `Up` and asserts the snapshot didn't drift. The harness catches three patterns:
+
+- `Down` drops a table that `Up` only altered. Re-applying `Up` recreates the table from the model snapshot — and any data the developer expected `Down` to preserve is gone.
+- `Down` forgets to drop an index `Up` created. The next `Up` collides on the index name.
+- `Down` recreates a column under a slightly different definition. The schema text drifts; downstream queries that depended on the original definition silently break.
+
+## Why `IModel` is enough metadata
+
+EF Core's `IModel` carries every type-system constraint the framework itself enforces: CLR type, nullability, `MaxLength` for strings/blobs, `Precision`/`Scale` for decimals, primary keys, foreign keys, navigation cardinality. v1 of Conjecture.EFCore honours exactly that surface — and only that surface. `CheckConstraint` text, value-converter internals, and computed-column expressions are out of scope. The reason: provider-specific SQL fragments are unparseable without re-implementing each provider's parser, and the failure mode for an unhonoured `CheckConstraint` is loud (`DbUpdateException`) rather than silent. Loud failures are diagnosable; silent ones aren't.
+
+ADR 0065 lists what's in and out for v1. The short version: type-system constraints in, behavioural constraints out, LINQ query-shape fuzzing deferred to a future `Conjecture.EFCore.Linq`.
+
+## Bounded navigation depth, aligned with `Generate.Recursive`
+
+Cyclic navigations (`Customer ↔ Orders`) terminate at `maxDepth = 2` by default. The depth bound mirrors `Generate.Recursive()` so users carry a single mental model across primitive recursion and entity-graph recursion. At the bound: required reference navigations reuse the first generated parent of the same target type; optional reference navigations are set to `null`; collection navigations are emitted empty. Owned types — entities with no independent identity — are generated inline regardless of depth, matching EF's own modelling semantics.
+
+The depth bound exists for a practical reason: without it, generation diverges on any model with a cycle. With it, generation is deterministic and shrinks predictably. Users who want larger graphs can override per-build via `EntityStrategyBuilder.WithMaxDepth`.
+
+## Composition with the Layer-1 interaction model
+
+EF Core is the third transport concretion in the Conjecture interaction model — after HTTP (v0.19) and messaging (v0.21). The core of that model is `IInteractionTarget`, a single interface that resolves a named resource (HTTP host, message bus, or `DbContext`) and routes a generated `IInteraction` to it. `CompositeInteractionTarget` (introduced in ADR 0064) lets a single `InteractionStateMachine<TState>` interleave HTTP requests, message-queue publications, and database mutations against unified application state.
+
+The implication: a property test for an ASP.NET Core endpoint that writes to a database can drive both — generating a sequence of HTTP `POST`s and asserting the resulting `DbContext` state matches a model. The state machine doesn't care that one step was HTTP and the next was a `SaveChanges`; the runner shrinks the entire interaction sequence as one trace. This composition is what unblocks the v0.26 (AspNetCore + EFCore) and v0.27 (Aspire + EFCore) integration packages.
+
+## Why SQLite by default
+
+The reference test provider in v1 is SQLite (in-memory). Three reasons:
+
+- **It's real SQL.** Migrations apply, transactions commit, value converters round-trip through the wire format. A test that passes against SQLite is doing real database work, not pretending.
+- **It's hermetic.** No external service, no Docker, no port allocation. Tests run in milliseconds and parallelise without coordination.
+- **Its `IModel` shape is identical.** The model EF builds from `OnModelCreating` is provider-agnostic; the strategies the entity builder emits would be the same against PostgreSQL or SQL Server. Dropping to a different provider via `IDbTarget` is a one-line change.
+
+The trade-off: SQLite has gaps in DDL (notably column rebuild) that real production providers don't. The integration self-test tier in `Conjecture.SelfTests/EFCore/` exercises the harness against a richer provider matrix; that tier is gated on a CI flag and is not the default test mode.
+
+## What a passing property test buys you
+
+A property test that runs `RoundtripAsserter.AssertRoundtripAsync` over `Generate.Entity<T>(db)` for every aggregate root in your domain answers a hard question precisely: *for the entire space of structurally-valid entities the model claims, can I save and reload without observable change?* If the answer is yes, you've ruled out an entire class of value-converter, model-mismatch, and tracking-edge bugs in tens of seconds. If the answer is no, you have a shrunk counterexample — typically a single-field divergence — that goes straight into a regression test.
+
+That ratio of cost to coverage is what property-based testing optimises for. EF Core's metadata-rich surface makes it one of the highest-leverage targets in the .NET ecosystem.
+
+## See also
+
+- [ADR 0065: Conjecture.EFCore package design](../../decisions/0065-conjecture-efcore-package-design.md)
+- [Reference: Conjecture.EFCore](../reference/efcore.md)
+- [Tutorial: Property tests for EF Core](../tutorials/10-efcore-integration.md)
+- [Explanation: Property-based testing](property-based-testing.md)
+- [Explanation: Shrinking](shrinking.md)

--- a/docs/site/articles/explanation/toc.yml
+++ b/docs/site/articles/explanation/toc.yml
@@ -37,3 +37,5 @@ items:
     href: aspnetcore-host-abstraction.md
   - name: Why Aspire uses a shared lifecycle
     href: aspire-lifecycle.md
+  - name: Why property testing finds EF Core bugs
+    href: efcore-property-testing.md

--- a/docs/site/articles/how-to/customise-efcore-entity-generation.md
+++ b/docs/site/articles/how-to/customise-efcore-entity-generation.md
@@ -1,0 +1,99 @@
+# Customise EF Core entity generation
+
+`Generate.Entity<T>` produces structurally-valid entities from your `IModel` out of the box. This guide covers the three customisations you'll reach for first: bounding navigation depth, excluding specific navigations, and overriding individual property strategies.
+
+## Adjust navigation depth
+
+Navigation cycles (`Customer → Orders → Customer → …`) are bounded by `maxDepth`, default `2`. Beyond the bound: required reference navigations are populated by reusing the first generated parent of the same target type; optional reference navigations are set to `null`; collection navigations are emitted empty.
+
+Pass `maxDepth` directly to `Generate.Entity<T>`:
+
+```csharp
+Strategy<Customer> shallow = Generate.Entity<Customer>(db, maxDepth: 0);
+Strategy<Customer> deep    = Generate.Entity<Customer>(db, maxDepth: 4);
+```
+
+| `maxDepth` | What you get |
+|---|---|
+| `0` | Scalars only. All navigations terminated at the root. Fast. |
+| `1` | Direct navigations populated; second-level navigations terminated. Default for "small graphs." |
+| `2` (default) | Two-level chains. Aligns with [`Generate.Recursive()`](../tutorials/06-advanced-patterns.md#recursive-strategies) defaults. |
+| `>3` | Larger graphs. Cost grows roughly linearly per added level for tree-shaped models, faster for highly-connected ones. |
+
+> [!WARNING]
+> Increasing `maxDepth` doesn't increase coverage proportionally — past depth `2` you're mostly generating the same shapes with longer tails. Prefer narrow strategies that exercise specific properties.
+
+## Exclude a specific navigation
+
+Drop into `EntityStrategyBuilder` when you need finer control than `maxDepth` provides:
+
+```csharp
+using Conjecture.Core;
+using Conjecture.EFCore;
+
+EntityStrategyBuilder b = new EntityStrategyBuilder(db.Model)
+    .WithMaxDepth(2)
+    .WithoutNavigation<Customer>(c => c.Orders)
+    .WithoutNavigation<Order>(o => o.Customer);
+
+Strategy<Customer> customers = b.Build<Customer>();
+Strategy<Order>    orders    = b.Build<Order>();
+```
+
+Each `WithoutNavigation<TEntity>(expr)` call drops one navigation. Reference navigations become `null`; collection navigations become empty lists. The lambda is parsed at `Build` time — pass a member access expression like `c => c.Orders`, not a lambda body.
+
+Use this when:
+
+- A navigation is only meaningful in a subset of test scenarios — drop it from the strategy and add it explicitly per-test.
+- A bidirectional cycle confuses your assertion (`o.Customer.Orders[0] == o`?) — drop one side.
+- A navigation pulls in expensive types (e.g. `byte[]` blobs) and you don't need them for the property under test.
+
+## Override a property's strategy
+
+`PropertyStrategyBuilder.Build(IProperty)` honours the v1 type-system constraint scope (CLR type, nullability, `MaxLength`, `Precision`/`Scale`, `ValueGenerated`). For domain rules outside that scope — e.g. "`Customer.Email` must contain `@`" — wrap the strategy with `.Filter` or compose a domain-specific strategy:
+
+```csharp
+Strategy<Customer> domain = Generate.Entity<Customer>(db)
+    .Filter(c => c.Email.Contains('@'))
+    .Map(c => c with { Email = c.Email.ToLowerInvariant() });
+```
+
+`.Filter` is the fallback. Prefer composition with strategy combinators when you can — Conjecture shrinks better through `.Map` than through `.Filter`.
+
+For per-property strategies, build the entity manually and inject your strategy at the field site:
+
+```csharp
+Strategy<string> emails = Generate.For<string>().Where(s => s.Contains('@'));
+
+Strategy<Customer> customers = Generate
+    .Object(() => new Customer())
+    .With(c => c.Id, Generate.Guid())
+    .With(c => c.Name, Generate.For<string>())
+    .With(c => c.Email, emails);
+```
+
+(`Generate.Object().With(...)` is the existing builder in `Conjecture.Core`. It bypasses `IModel`-driven generation entirely — you lose `MaxLength` and friends but gain full control.)
+
+## Combining customisations
+
+The three patterns compose. A common shape:
+
+1. Use `EntityStrategyBuilder` for the entity-level shape (depth, dropped navigations).
+2. Use `.Filter`/`.Map` at the strategy site for cross-field rules.
+3. Drop to `Generate.Object().With(...)` for individual properties that need bespoke generation.
+
+```csharp
+Strategy<Customer> baseStrategy = new EntityStrategyBuilder(db.Model)
+    .WithoutNavigation<Customer>(c => c.Orders)
+    .Build<Customer>();
+
+Strategy<Customer> tailored = baseStrategy
+    .Filter(c => c.JoinedAt < DateTime.UtcNow)
+    .Map(c => c with { Email = c.Email.ToLowerInvariant() });
+```
+
+## See also
+
+- [Reference: Conjecture.EFCore](../reference/efcore.md)
+- [Reference: Generate.For&lt;T&gt;()](../reference/generate-for.md)
+- [Tutorial: Custom strategies](../tutorials/03-custom-strategies.md)

--- a/docs/site/articles/how-to/setup-efcore-property-testing.md
+++ b/docs/site/articles/how-to/setup-efcore-property-testing.md
@@ -1,0 +1,202 @@
+# Set up EF Core property testing
+
+This guide gets you from an empty test project to a passing roundtrip property test against a SQLite-backed `DbContext`.
+
+## Install
+
+```xml
+<PackageReference Include="Conjecture.EFCore" />
+<PackageReference Include="Conjecture.Xunit" />
+<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+```
+
+> [!NOTE]
+> SQLite (in-memory) is the recommended default test provider per [ADR 0065](../../decisions/0065-conjecture-efcore-package-design.md). Any provider that produces a valid `IModel` works for entity strategies; SQLite gives you real SQL and migrations without external infrastructure.
+
+## Step 1: Define your `DbContext`
+
+A minimal context. Keep entity types public so EF reflection can discover them.
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    public DbSet<Order> Orders => Set<Order>();
+}
+
+public class Order
+{
+    public Guid Id { get; set; }
+    public string Customer { get; set; } = "";
+    public decimal Total { get; set; }
+    public DateTime PlacedAt { get; set; }
+}
+```
+
+## Step 2: Wire a SQLite-in-memory factory
+
+A shared in-memory connection so every `DbContext` instance the test creates sees the same schema.
+
+```csharp
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+public sealed class SqliteAppDbContextFactory : IAsyncDisposable
+{
+    private readonly SqliteConnection connection;
+    private readonly DbContextOptions<AppDbContext> options;
+
+    public SqliteAppDbContextFactory()
+    {
+        connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using AppDbContext bootstrap = new AppDbContext(options);
+        bootstrap.Database.EnsureCreated();
+    }
+
+    public AppDbContext Create() => new AppDbContext(options);
+
+    public ValueTask DisposeAsync()
+    {
+        connection.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+> [!TIP]
+> Open the connection once and keep it open for the test class's lifetime. Closing the connection drops the in-memory database.
+
+## Step 3: Write your first roundtrip property test
+
+Use `RoundtripAsserter.AssertRoundtripAsync` to assert that any generated `Order` survives `SaveChanges` + reload without observable change.
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.EFCore;
+using Conjecture.Xunit.V3;
+
+public class OrderRoundtripTests : IAsyncDisposable
+{
+    private readonly SqliteAppDbContextFactory factory = new();
+
+    [Property]
+    public async Task Order_Roundtrips_Without_Loss(Strategy<Order> orders)
+    {
+        Order order = orders.Sample();
+        await RoundtripAsserter.AssertRoundtripAsync(factory.Create, order);
+    }
+
+    public ValueTask DisposeAsync() => factory.DisposeAsync();
+}
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.EFCore;
+using Conjecture.NUnit;
+
+public class OrderRoundtripTests
+{
+    private SqliteAppDbContextFactory factory = null!;
+
+    [SetUp] public void Setup() => factory = new SqliteAppDbContextFactory();
+    [TearDown] public async Task Teardown() => await factory.DisposeAsync();
+
+    [Property]
+    public async Task Order_Roundtrips_Without_Loss(Strategy<Order> orders)
+    {
+        Order order = orders.Sample();
+        await RoundtripAsserter.AssertRoundtripAsync(factory.Create, order);
+    }
+}
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.EFCore;
+using Conjecture.MSTest;
+
+[TestClass]
+public class OrderRoundtripTests
+{
+    private SqliteAppDbContextFactory factory = null!;
+
+    [TestInitialize] public void Init() => factory = new SqliteAppDbContextFactory();
+    [TestCleanup] public async Task Cleanup() => await factory.DisposeAsync();
+
+    [Property]
+    public async Task Order_Roundtrips_Without_Loss(Strategy<Order> orders)
+    {
+        Order order = orders.Sample();
+        await RoundtripAsserter.AssertRoundtripAsync(factory.Create, order);
+    }
+}
+```
+
+***
+
+When the property runs, Conjecture draws a fresh `Order` per example, saves it, and reloads it from a new `DbContext`. The default comparer walks scalar properties and reports the offending field on mismatch.
+
+## Step 4: Bind the strategy from the model
+
+The `Strategy<Order>` parameter above is resolved from the registered `Generate.For<Order>()` provider. Wire it from your `DbContext` model:
+
+```csharp
+[ConjectureSettings]
+public class AssemblyFixture
+{
+    public AssemblyFixture()
+    {
+        // Register before the first test fires.
+        using SqliteAppDbContextFactory bootstrap = new();
+        using AppDbContext db = bootstrap.Create();
+        GenerateForRegistry.Register(typeof(Order), () => new ModelStrategyProvider(db.Model));
+    }
+}
+
+internal sealed class ModelStrategyProvider(IModel model) : IStrategyProvider
+{
+    public Strategy<T> Get<T>() where T : class => Generate.Entity<T>(() =>
+    {
+        // Build from the cached IModel without instantiating a real context per draw
+        DbContextOptions opts = new DbContextOptionsBuilder().UseSqlite("DataSource=:memory:").Options;
+        return new DbContext(opts);
+    });
+}
+```
+
+For the simpler case — explicit factory inside the test method — call `Generate.Entity<Order>(factory.Create)` directly:
+
+```csharp
+[Property]
+public async Task Order_Roundtrips_Without_Loss()
+{
+    Strategy<Order> orders = Generate.Entity<Order>(factory.Create);
+    Order order = orders.Sample();
+    await RoundtripAsserter.AssertRoundtripAsync(factory.Create, order);
+}
+```
+
+## What you have now
+
+- Each property example draws a structurally-valid `Order` honouring `IProperty` constraints (nullable, `MaxLength`, `Precision`/`Scale`).
+- `RoundtripAsserter` saves, reloads from a fresh context, and reports the first mismatched scalar property.
+- Failure shrinks down to the smallest counterexample that still triggers the divergence.
+
+## See also
+
+- [How-to: Customise entity generation](customise-efcore-entity-generation.md)
+- [How-to: Test migration up/down invariants](test-efcore-migrations.md)
+- [Reference: Conjecture.EFCore](../reference/efcore.md)

--- a/docs/site/articles/how-to/test-efcore-migrations.md
+++ b/docs/site/articles/how-to/test-efcore-migrations.md
@@ -1,0 +1,103 @@
+# Test migration up/down invariants
+
+`MigrationHarness.AssertUpDownIdempotentAsync` applies all pending migrations to head, snapshots the schema, runs the latest migration's `Down`, then re-applies its `Up` and asserts the resulting schema matches the snapshot. Use it to catch migrations that apply forward but break backward — a common source of staging/production drift.
+
+## When to use it
+
+- You have a `DbContext` with a real EF migrations history (not `EnsureCreated`).
+- You want every PR that touches a migration to fail CI if the `Down` is asymmetric.
+- You target SQLite (the supported provider in v1).
+
+> [!NOTE]
+> v1 is SQLite-only. The harness throws `NotSupportedException` for other providers. ADR 0065 covers why and what would be needed for multi-provider support.
+
+## Prerequisites
+
+- A `DbContext` configured for SQLite.
+- At least one migration committed under `Migrations/`.
+- The default test provider from [the setup guide](setup-efcore-property-testing.md) — shared in-memory connection so `Migrate()` can apply against an isolated database per test.
+
+## Basic usage
+
+```csharp
+using Conjecture.EFCore;
+
+[Fact]
+public async Task Latest_Migration_RoundTrips()
+{
+    await using SqliteAppDbContextFactory factory = new();
+    await using AppDbContext db = factory.Create();
+    await MigrationHarness.AssertUpDownIdempotentAsync(db);
+}
+```
+
+The harness:
+
+1. Calls `db.Database.MigrateAsync()` to bring the schema to head.
+2. Snapshots `sqlite_master` (excluding the `__EFMigrationsHistory` table and `sqlite_%` system rows).
+3. Calls `migrator.MigrateAsync(rollbackTarget)` where `rollbackTarget` is the prior migration ID (or `Migration.InitialDatabase = "0"` if there's only one).
+4. Calls `migrator.MigrateAsync()` again to return to head.
+5. Re-snapshots, compares, and throws `MigrationAssertionException` if they differ.
+
+## Common failure modes
+
+The harness catches:
+
+- **`Down` drops a table that `Up` only altered.** The next `Up` rebuilds it from the model snapshot — and any data you intended to preserve is gone.
+- **`Down` forgets to drop an index `Up` created.** Re-running `Up` against the surviving index throws on conflicting names.
+- **`Down` recreates a column under a slightly different definition.** The post-roundtrip `sqlite_master.sql` text differs and the harness reports the divergence.
+
+## Sample failure message
+
+```text
+Conjecture.EFCore.MigrationAssertionException:
+Schema diverged after Down/Up roundtrip.
+
+Before:
+  table  Orders  CREATE TABLE "Orders" ("Id" TEXT NOT NULL CONSTRAINT "PK_Orders" PRIMARY KEY, "Total" TEXT NOT NULL)
+After:
+  table  Orders  CREATE TABLE "Orders" ("Id" TEXT NOT NULL CONSTRAINT "PK_Orders" PRIMARY KEY, "Total" TEXT NOT NULL)
+  index  IX_Orders_Total  CREATE INDEX "IX_Orders_Total" ON "Orders" ("Total")
+```
+
+The extra `IX_Orders_Total` row reveals that the latest migration's `Down` didn't drop the index it created.
+
+## SQLite-friendly migrations
+
+SQLite cannot natively `DROP COLUMN` or `ALTER COLUMN` on older table-rebuild paths. EF Core 10 still supports these via table rebuild, but the rebuild itself can perturb implicit ordering and trip the snapshot comparison.
+
+For predictable rollbacks, prefer:
+
+- `CreateTable` / `DropTable`
+- `CreateIndex` / `DropIndex`
+- `AddColumn` (additive — the symmetric `Down` is `DropColumn`, but the round-trip is brittle on SQLite; consider a forward-only schema policy or test on a richer provider via the integration self-test tier)
+
+If your migrations rely on `DropColumn` round-trips and your CI runs SQLite, gate the harness assertion behind a per-test attribute or run it only against migrations that exercise additive shapes.
+
+## Integration with property tests
+
+Combine the harness with a property test that generates entity graphs against the *current* schema and rounds them through `Down` + `Up`:
+
+```csharp
+[Property]
+public async Task Migration_Roundtrip_Preserves_Existing_Rows(Strategy<Order> orders)
+{
+    await using SqliteAppDbContextFactory factory = new();
+    await using AppDbContext db = factory.Create();
+
+    db.Orders.Add(orders.Sample());
+    await db.SaveChangesAsync();
+
+    await MigrationHarness.AssertUpDownIdempotentAsync(db);
+
+    // After roundtrip, the row should still be reachable.
+    Assert.Equal(1, await db.Orders.CountAsync());
+}
+```
+
+The first failure shrinks to the smallest `Order` that triggers the divergence — usually a column-specific edge case (a `null` where a `Down` recreates `NOT NULL`, etc.).
+
+## See also
+
+- [Reference: MigrationHarness](../reference/efcore.md#migrationharness)
+- [ADR 0065: Conjecture.EFCore package design](../../decisions/0065-conjecture-efcore-package-design.md)

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -75,5 +75,11 @@ items:
     href: reset-aspire-state.md
   - name: Configure Aspire retry policy
     href: configure-aspire-retry.md
+  - name: Set up EF Core property testing
+    href: setup-efcore-property-testing.md
+  - name: Test EF Core migration up/down invariants
+    href: test-efcore-migrations.md
+  - name: Customise EF Core entity generation
+    href: customise-efcore-entity-generation.md
   - name: Troubleshoot
     href: troubleshoot.md

--- a/docs/site/articles/reference/efcore.md
+++ b/docs/site/articles/reference/efcore.md
@@ -1,0 +1,199 @@
+# Conjecture.EFCore reference
+
+API reference for the `Conjecture.EFCore` package. Install via:
+
+```xml
+<PackageReference Include="Conjecture.EFCore" />
+```
+
+`Conjecture.EFCore` derives entity-graph strategies from an EF Core `IModel`, asserts `SaveChanges` roundtrips without data loss, and verifies migration up/down symmetry. v1 ships with SQLite (in-memory) as the canonical test provider; any provider that produces a valid `IModel` works for entity strategies. The migration harness is SQLite-only in v1.
+
+> [!NOTE]
+> Design rationale lives in [ADR 0065: Conjecture.EFCore package design](../../decisions/0065-conjecture-efcore-package-design.md).
+
+---
+
+## `Generate.Entity<T>` — extension methods on `Generate`
+
+```csharp
+namespace Conjecture.EFCore;
+
+public static class EFCoreGenerateExtensions
+{
+    extension(Conjecture.Core.Generate)
+    {
+        public static Strategy<T> Entity<T>(DbContext context, int maxDepth = 2) where T : class;
+        public static Strategy<T> Entity<T>(Func<DbContext> contextFactory, int maxDepth = 2) where T : class;
+    }
+}
+```
+
+| Overload | Use when |
+|---|---|
+| `Entity<T>(DbContext context, int maxDepth = 2)` | You already hold a `DbContext` instance — typically inside a single test method or a class fixture. The strategy reads `context.Model` once on construction. |
+| `Entity<T>(Func<DbContext> contextFactory, int maxDepth = 2)` | You want each draw to build the entity in a fresh `DbContext`, e.g. when seeding a test that itself creates and disposes a context per example. |
+
+`maxDepth` controls navigation-property recursion (default `2`). Required reference navigations beyond the bound are populated by reusing the first generated parent of the same target type; optional reference navigations are set to `null`; collection navigations are emitted empty. Owned types are always generated inline regardless of `maxDepth`.
+
+Both overloads delegate to [`EntityStrategyBuilder`](#entitystrategybuilder) — drop down to the builder when you need `WithoutNavigation` or other model-level customisation.
+
+```csharp
+using Conjecture.Core;
+using Conjecture.EFCore;
+
+await using AppDbContext db = CreateContext();
+Strategy<Order> orders = Generate.Entity<Order>(db);
+Order example = orders.Sample();
+```
+
+---
+
+## `EntityStrategyBuilder`
+
+```csharp
+namespace Conjecture.EFCore;
+
+public sealed class EntityStrategyBuilder
+{
+    public EntityStrategyBuilder(IModel model);
+    public EntityStrategyBuilder WithMaxDepth(int depth);
+    public EntityStrategyBuilder WithoutNavigation<TEntity>(Expression<Func<TEntity, object?>> navigation);
+    public Strategy<TEntity> Build<TEntity>() where TEntity : class;
+}
+```
+
+Builder-style entry point for entity strategies. Use this when you need to suppress specific navigations or set a custom recursion bound, then call `Build<TEntity>()` once per entity type.
+
+| Member | Purpose |
+|---|---|
+| `EntityStrategyBuilder(IModel model)` | Construct from `context.Model`. The builder caches per-entity strategies on first build. |
+| `WithMaxDepth(int depth)` | Override navigation-cycle bound. Default `2`. Pass `0` to suppress navigations entirely. |
+| `WithoutNavigation<TEntity>(expr)` | Drop a specific navigation by lambda accessor: `b.WithoutNavigation<Customer>(c => c.Orders)`. Reference navigations become `null`; collection navigations become empty. |
+| `Build<TEntity>()` | Returns `Strategy<TEntity>` for an entity type registered in the model. Throws `InvalidOperationException` for unknown types. |
+
+Mutable-self builder — `WithMaxDepth` and `WithoutNavigation` return `this`.
+
+```csharp
+EntityStrategyBuilder b = new EntityStrategyBuilder(db.Model)
+    .WithMaxDepth(1)
+    .WithoutNavigation<Customer>(c => c.Orders);
+
+Strategy<Customer> customers = b.Build<Customer>();
+```
+
+---
+
+## `PropertyStrategyBuilder`
+
+```csharp
+namespace Conjecture.EFCore;
+
+public static class PropertyStrategyBuilder
+{
+    public static Strategy<object?> Build(IProperty property);
+}
+```
+
+Maps a single EF Core `IProperty` to a `Strategy<object?>` (boxed) honouring the v1 type-system constraint scope. Used internally by `EntityStrategyBuilder`; exposed for callers who want to plug primitive strategies into a hand-written entity composer.
+
+| Honoured | Mechanism |
+|---|---|
+| CLR type | `int`, `long`, `short`, `byte`, `bool`, `decimal`, `double`, `float`, `string`, `Guid`, `DateTime`, `byte[]` |
+| Nullability (`IsNullable`) | Lifts the inner strategy via `OneOf(inner, Constant(null))` |
+| `MaxLength` (string, byte[]) | Bounded length on the underlying primitive strategy |
+| `Precision`/`Scale` (decimal) | Bounds magnitude and fractional digits |
+| `ValueGenerated` (`OnAdd`, `OnAddOrUpdate`) | Returns CLR default — EF assigns the real value on insert |
+
+Out of scope in v1: `CheckConstraint`, `HasConversion` value converters, unique-index dedup. See [explanation](../explanation/efcore-property-testing.md) for why.
+
+---
+
+## `RoundtripAsserter`
+
+```csharp
+namespace Conjecture.EFCore;
+
+public static class RoundtripAsserter
+{
+    public static Task AssertRoundtripAsync<TEntity>(
+        Func<DbContext> factory,
+        TEntity entity,
+        IEqualityComparer<TEntity>? comparer = null,
+        CancellationToken cancellationToken = default) where TEntity : class;
+
+    public static Task AssertNoTrackingMatchesTrackedAsync<TEntity>(
+        Func<DbContext> factory,
+        TEntity entity,
+        IEqualityComparer<TEntity>? comparer = null,
+        CancellationToken cancellationToken = default) where TEntity : class;
+}
+```
+
+| Method | Behaviour |
+|---|---|
+| `AssertRoundtripAsync` | Saves `entity` via `factory()`, opens a *fresh* `DbContext`, reloads by primary key, and compares using `comparer` (or a default scalar-property comparer that skips navigations). Throws `RoundtripAssertionException` on mismatch. |
+| `AssertNoTrackingMatchesTrackedAsync` | Saves, then reads the entity twice from fresh contexts: once tracked (`Find`), once `AsNoTracking`. Compares the two. Catches navigation/include divergence. |
+
+The default comparer walks `entityType.GetProperties()` and reads each value via `IProperty.PropertyInfo!.GetValue(entity)` — so cross-context attach is never triggered. The exception message includes the offending property name and both values.
+
+```csharp
+await RoundtripAsserter.AssertRoundtripAsync(
+    () => new AppDbContext(_options),
+    new Order { Id = Guid.NewGuid(), PlacedAt = DateTimeOffset.UtcNow });
+```
+
+### `RoundtripAssertionException`
+
+```csharp
+public sealed class RoundtripAssertionException : Exception
+{
+    public RoundtripAssertionException(string message);
+}
+```
+
+---
+
+## `MigrationHarness`
+
+```csharp
+namespace Conjecture.EFCore;
+
+public static class MigrationHarness
+{
+    public static Task AssertUpDownIdempotentAsync(
+        DbContext context,
+        CancellationToken cancellationToken = default);
+}
+```
+
+Applies all pending migrations forward, snapshots the resulting schema (via `sqlite_master` for SQLite), runs the latest migration's `Down`, then re-applies its `Up` and asserts the post-roundtrip schema matches the snapshot. Catches asymmetric migrations that apply forward cleanly but leave residue on rollback.
+
+Throws `MigrationAssertionException` if the snapshots diverge. Throws `InvalidOperationException` if no migrations are defined. Throws `NotSupportedException` for non-SQLite providers in v1.
+
+The rollback step uses `IMigrator.MigrateAsync(rollbackTarget)` — the same path EF runs in production. No raw SQL bypass.
+
+```csharp
+await using AppDbContext db = new AppDbContext(sqliteOptions);
+await MigrationHarness.AssertUpDownIdempotentAsync(db);
+```
+
+### `MigrationAssertionException`
+
+```csharp
+public sealed class MigrationAssertionException : Exception
+{
+    public MigrationAssertionException(string message);
+    public MigrationAssertionException(string message, Exception innerException);
+}
+```
+
+---
+
+## See also
+
+- [Tutorial: Property tests for EF Core](../tutorials/10-efcore-integration.md)
+- [How-to: Set up EF Core property testing](../how-to/setup-efcore-property-testing.md)
+- [How-to: Test migration up/down invariants](../how-to/test-efcore-migrations.md)
+- [How-to: Customise EF Core entity generation](../how-to/customise-efcore-entity-generation.md)
+- [Explanation: Why property testing finds EF Core bugs](../explanation/efcore-property-testing.md)
+- [ADR 0065: Conjecture.EFCore package design](../../decisions/0065-conjecture-efcore-package-design.md)

--- a/docs/site/articles/reference/toc.yml
+++ b/docs/site/articles/reference/toc.yml
@@ -31,3 +31,5 @@ items:
     href: aspnetcore-request-builder.md
   - name: Conjecture.Aspire
     href: aspire.md
+  - name: Conjecture.EFCore
+    href: efcore.md

--- a/docs/site/articles/tutorials/10-efcore-integration.md
+++ b/docs/site/articles/tutorials/10-efcore-integration.md
@@ -1,0 +1,242 @@
+# Tutorial 10: Property tests for EF Core
+
+This tutorial walks you through writing your first EF Core property test end to end. You will:
+
+1. Add `Conjecture.EFCore` to a test project.
+2. Configure a SQLite-in-memory `DbContext` factory.
+3. Write a `RoundtripAsserter.AssertRoundtripAsync` property test.
+4. Add migration up/down assertions with `MigrationHarness`.
+5. Customise the strategy via `EntityStrategyBuilder`.
+
+## Prerequisites
+
+- .NET 10 SDK
+- A test project referencing `Conjecture.Xunit`, `Conjecture.NUnit`, `Conjecture.MSTest`, or `Conjecture.TestingPlatform`
+- Familiarity with `[Property]` attributes — see [Tutorial 1](01-your-first-property-test.md) if not
+
+## Install
+
+```xml
+<PackageReference Include="Conjecture.EFCore" />
+<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+```
+
+## Step 1: Define a domain
+
+A small domain with one aggregate root, one owned type, and one navigation. EF will derive an `IModel` from this — Conjecture will derive entity strategies from that model.
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+public class Order
+{
+    public Guid Id { get; set; }
+    public string Customer { get; set; } = "";
+    public decimal Total { get; set; }
+    public DateTime PlacedAt { get; set; }
+    public Address ShippingAddress { get; set; } = new();
+}
+
+public class Address
+{
+    public string Street { get; set; } = "";
+    public string City { get; set; } = "";
+}
+
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    public DbSet<Order> Orders => Set<Order>();
+
+    protected override void OnModelCreating(ModelBuilder b)
+    {
+        b.Entity<Order>(o =>
+        {
+            o.HasKey(x => x.Id);
+            o.Property(x => x.Customer).HasMaxLength(100).IsRequired();
+            o.Property(x => x.Total).HasPrecision(18, 2);
+            o.OwnsOne(x => x.ShippingAddress);
+        });
+    }
+}
+```
+
+## Step 2: Wire a SQLite-in-memory factory
+
+A shared in-memory connection so every `DbContext` instance the test creates sees the same schema. Open the connection once for the test class's lifetime — closing it drops the database.
+
+```csharp
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+public sealed class SqliteAppDbContextFactory : IAsyncDisposable
+{
+    private readonly SqliteConnection connection;
+    private readonly DbContextOptions<AppDbContext> options;
+
+    public SqliteAppDbContextFactory()
+    {
+        connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        options = new DbContextOptionsBuilder<AppDbContext>().UseSqlite(connection).Options;
+
+        using AppDbContext bootstrap = new AppDbContext(options);
+        bootstrap.Database.EnsureCreated();
+    }
+
+    public AppDbContext Create() => new AppDbContext(options);
+
+    public ValueTask DisposeAsync()
+    {
+        connection.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}
+```
+
+## Step 3: Write the roundtrip property
+
+The first property: every generated `Order` survives `SaveChanges` + reload from a fresh context with no observable change.
+
+# [xUnit v3](#tab/xunit-v3)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.EFCore;
+using Conjecture.Xunit.V3;
+
+public class OrderRoundtripTests : IAsyncDisposable
+{
+    private readonly SqliteAppDbContextFactory factory = new();
+
+    [Property]
+    public async Task Order_Saves_And_Reloads_Without_Loss()
+    {
+        Strategy<Order> orders = Generate.Entity<Order>(factory.Create);
+        Order order = orders.Sample();
+
+        await RoundtripAsserter.AssertRoundtripAsync(factory.Create, order);
+    }
+
+    public ValueTask DisposeAsync() => factory.DisposeAsync();
+}
+```
+
+# [NUnit](#tab/nunit)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.EFCore;
+using Conjecture.NUnit;
+
+public class OrderRoundtripTests
+{
+    private SqliteAppDbContextFactory factory = null!;
+
+    [SetUp] public void Setup() => factory = new SqliteAppDbContextFactory();
+    [TearDown] public async Task Teardown() => await factory.DisposeAsync();
+
+    [Property]
+    public async Task Order_Saves_And_Reloads_Without_Loss()
+    {
+        Strategy<Order> orders = Generate.Entity<Order>(factory.Create);
+        Order order = orders.Sample();
+
+        await RoundtripAsserter.AssertRoundtripAsync(factory.Create, order);
+    }
+}
+```
+
+# [MSTest](#tab/mstest)
+
+```csharp
+using Conjecture.Core;
+using Conjecture.EFCore;
+using Conjecture.MSTest;
+
+[TestClass]
+public class OrderRoundtripTests
+{
+    private SqliteAppDbContextFactory factory = null!;
+
+    [TestInitialize] public void Init() => factory = new SqliteAppDbContextFactory();
+    [TestCleanup] public async Task Cleanup() => await factory.DisposeAsync();
+
+    [Property]
+    public async Task Order_Saves_And_Reloads_Without_Loss()
+    {
+        Strategy<Order> orders = Generate.Entity<Order>(factory.Create);
+        Order order = orders.Sample();
+
+        await RoundtripAsserter.AssertRoundtripAsync(factory.Create, order);
+    }
+}
+```
+
+***
+
+Run it. Each example draws a structurally-valid `Order` (honouring `MaxLength(100)` on `Customer`, `Precision(18, 2)` on `Total`, and an inline `ShippingAddress`), saves it, reloads it from a fresh context, and reports the first mismatched scalar property if any.
+
+If the property passes, you've ruled out value-converter precision loss, missing-property mappings, and required-property nullability mismatches across the entire generated entity space.
+
+## Step 4: Catch a deliberate bug
+
+To see what failure looks like, add a value converter that silently truncates `Order.PlacedAt` to seconds:
+
+```csharp
+o.Property(x => x.PlacedAt).HasConversion(
+    d => new DateTime(d.Ticks - d.Ticks % TimeSpan.TicksPerSecond, d.Kind),
+    d => d);
+```
+
+Re-run. The property fails:
+
+```text
+Conjecture.EFCore.RoundtripAssertionException:
+Roundtrip assertion failed (roundtrip reload):
+  Property 'PlacedAt': expected '2026-04-27T14:23:11.4567890', got '2026-04-27T14:23:11.0000000'.
+```
+
+Conjecture shrinks down to a minimal `Order` with `PlacedAt` carrying sub-second precision. Remove the converter, the property passes again.
+
+## Step 5: Test migrations
+
+Add a migration to the project (`dotnet ef migrations add InitialCreate`) and call the harness:
+
+```csharp
+[Property]
+public async Task Migrations_RoundTrip()
+{
+    await using SqliteAppDbContextFactory factory = new();
+    await using AppDbContext db = factory.Create();
+    await MigrationHarness.AssertUpDownIdempotentAsync(db);
+}
+```
+
+The harness applies migrations to head, snapshots `sqlite_master`, runs the latest migration's `Down`, re-applies its `Up`, and throws `MigrationAssertionException` if the schema drifts. See [the migrations how-to](../how-to/test-efcore-migrations.md) for failure-mode patterns.
+
+## Step 6: Customise the strategy
+
+Suppress the `ShippingAddress.Street` requirement, or drop the navigation entirely:
+
+```csharp
+EntityStrategyBuilder b = new EntityStrategyBuilder(db.Model)
+    .WithMaxDepth(1)                                    // shallow graphs
+    .WithoutNavigation<Order>(o => o.ShippingAddress);  // null out the address
+
+Strategy<Order> minimalOrders = b.Build<Order>();
+```
+
+`Generate.Entity<T>` is a thin wrapper over `EntityStrategyBuilder`; reach for the builder when you need `WithoutNavigation` or a non-default `WithMaxDepth`. See [customise entity generation](../how-to/customise-efcore-entity-generation.md) for the broader pattern.
+
+## What you have now
+
+- One property test that asserts roundtrip integrity over the entire structurally-valid entity space.
+- A migration harness that catches asymmetric `Down` migrations.
+- A clear path to drop into `EntityStrategyBuilder` when defaults aren't sufficient.
+
+## Where to go next
+
+- [How-to: Customise EF Core entity generation](../how-to/customise-efcore-entity-generation.md)
+- [How-to: Test migration up/down invariants](../how-to/test-efcore-migrations.md)
+- [Reference: Conjecture.EFCore](../reference/efcore.md)
+- [Explanation: Why property testing finds EF Core bugs](../explanation/efcore-property-testing.md)

--- a/docs/site/articles/tutorials/toc.yml
+++ b/docs/site/articles/tutorials/toc.yml
@@ -17,3 +17,5 @@ items:
     href: 08-fsharp-property-tests.md
   - name: Property tests for Aspire apps
     href: 09-aspire-integration.md
+  - name: Property tests for EF Core
+    href: 10-efcore-integration.md

--- a/src/Conjecture.EFCore.Tests/Conjecture.EFCore.Tests.csproj
+++ b/src/Conjecture.EFCore.Tests/Conjecture.EFCore.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.EFCore\Conjecture.EFCore.csproj" />
+    <ProjectReference Include="..\Conjecture.Interactions\Conjecture.Interactions.csproj" />
     <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.EFCore.Tests/Conjecture.EFCore.Tests.csproj
+++ b/src/Conjecture.EFCore.Tests/Conjecture.EFCore.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.EFCore.Tests/Conjecture.EFCore.Tests.csproj
+++ b/src/Conjecture.EFCore.Tests/Conjecture.EFCore.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.EFCore\Conjecture.EFCore.csproj" />
+    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.EFCore.Tests/DbInteractionTests.cs
+++ b/src/Conjecture.EFCore.Tests/DbInteractionTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Linq;
+
+using Conjecture.EFCore;
+using Conjecture.Interactions;
+
+namespace Conjecture.EFCore.Tests;
+
+public class DbInteractionTests
+{
+    private sealed class Order
+    {
+        public int Id { get; set; }
+    }
+
+    [Fact]
+    public void DbInteraction_IsIInteraction()
+    {
+        Assert.True(typeof(IInteraction).IsAssignableFrom(typeof(DbInteraction)));
+    }
+
+    [Fact]
+    public void DbInteraction_HasResourceNameOpAndPayload()
+    {
+        Order payload = new() { Id = 1 };
+        DbInteraction interaction = new("orders-db", DbOpKind.Add, payload);
+
+        Assert.Equal("orders-db", interaction.ResourceName);
+        Assert.Equal(DbOpKind.Add, interaction.Op);
+        Assert.True(interaction.Payload is Order { Id: 1 });
+    }
+
+    [Fact]
+    public void DbInteraction_OpKinds_HaveExpectedValues()
+    {
+        DbOpKind[] values = Enum.GetValues<DbOpKind>();
+
+        Assert.Equal(5, values.Length);
+        Assert.Contains(DbOpKind.Add, values);
+        Assert.Contains(DbOpKind.Update, values);
+        Assert.Contains(DbOpKind.Remove, values);
+        Assert.Contains(DbOpKind.SaveChanges, values);
+        Assert.Contains(DbOpKind.Query, values);
+    }
+
+    [Fact]
+    public void DbInteraction_StructuralEquality()
+    {
+        Order payload = new() { Id = 42 };
+        DbInteraction a = new("db", DbOpKind.Update, payload);
+        DbInteraction b = new("db", DbOpKind.Update, payload);
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void DbInteraction_NullPayload_AllowedForSaveChanges()
+    {
+        DbInteraction interaction = new("db", DbOpKind.SaveChanges, null);
+
+        Assert.Null(interaction.Payload);
+    }
+}

--- a/src/Conjecture.EFCore.Tests/DbInvariantExtensionsTests.cs
+++ b/src/Conjecture.EFCore.Tests/DbInvariantExtensionsTests.cs
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+
+using Conjecture.EFCore;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore.Tests;
+
+public class DbInvariantExtensionsTests
+{
+    // ---- test entities -------------------------------------------------
+
+    private sealed class Product
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public DateTime CreatedAt { get; set; }
+    }
+
+    private sealed class ProductWithToken
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        [ConcurrencyCheck]
+        public int Version { get; set; }
+    }
+
+    private sealed class ProductWithoutToken
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private sealed class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    private sealed class Order
+    {
+        public int Id { get; set; }
+        public int CustomerId { get; set; }
+    }
+
+    // ---- DbContext definitions ------------------------------------------
+
+    private sealed class ProductContext(DbContextOptions<ProductContext> options) : DbContext(options)
+    {
+        public DbSet<Product> Products { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Product>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+            });
+        }
+    }
+
+    private sealed class ProductContextWithPrecisionLoss(DbContextOptions<ProductContextWithPrecisionLoss> options)
+        : DbContext(options)
+    {
+        public DbSet<Product> Products { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Product>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+                b.Property(e => e.CreatedAt)
+                    .HasConversion(
+                        d => new DateTime(d.Ticks - (d.Ticks % TimeSpan.TicksPerSecond), d.Kind),
+                        d => d);
+            });
+        }
+    }
+
+    private sealed class ProductWithTokenContext(DbContextOptions<ProductWithTokenContext> options) : DbContext(options)
+    {
+        public DbSet<ProductWithToken> Products { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ProductWithToken>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+                b.Property(e => e.Version).IsConcurrencyToken();
+            });
+        }
+    }
+
+    private sealed class ProductWithoutTokenContext(DbContextOptions<ProductWithoutTokenContext> options) : DbContext(options)
+    {
+        public DbSet<ProductWithoutToken> Products { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ProductWithoutToken>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+            });
+        }
+    }
+
+    private sealed class ShopContext(DbContextOptions<ShopContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+        public DbSet<Order> Orders { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+            });
+
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.HasOne<Customer>()
+                    .WithMany()
+                    .HasForeignKey(o => o.CustomerId)
+                    .IsRequired();
+            });
+        }
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private static (SqliteConnection connection, SqliteDbTarget target) CreateTarget<TContext>(
+        string resourceName,
+        Func<DbContextOptions<TContext>, TContext> contextFactory)
+        where TContext : DbContext
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        connection.Open();
+
+        DbContextOptions<TContext> options = new DbContextOptionsBuilder<TContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        TContext seed = contextFactory(options);
+        seed.Database.EnsureCreated();
+        seed.Dispose();
+
+        SqliteDbTarget target = new(resourceName, () => contextFactory(options));
+        return (connection, target);
+    }
+
+    // ---- tests ----------------------------------------------------------
+
+    [Fact]
+    public async Task AssertRoundtripAsync_Sqlite_PassesForCleanRoundtrip()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget<ProductContext>(
+            "products", static opts => new(opts));
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        Product entity = new() { Name = "Widget", CreatedAt = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+
+        await target.AssertRoundtripAsync(entity);
+    }
+
+    [Fact]
+    public async Task AssertRoundtripAsync_Sqlite_ThrowsWithLossyConverter()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget<ProductContextWithPrecisionLoss>(
+            "products", static opts => new(opts));
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        Product entity = new() { Name = "Gizmo", CreatedAt = new DateTime(2025, 6, 1, 12, 34, 56, 789, DateTimeKind.Utc) };
+
+        IEqualityComparer<Product> ticksComparer = new CreatedAtTicksComparer();
+
+        await Assert.ThrowsAsync<RoundtripAssertionException>(
+            async () => await target.AssertRoundtripAsync(entity, ticksComparer));
+    }
+
+    [Fact]
+    public async Task AssertConcurrencyTokenRespectedAsync_StaleSecondUpdate_ThrowsOnSecond()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget<ProductWithTokenContext>(
+            "products", static opts => new(opts));
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        ProductWithToken entity = new() { Name = "Original" };
+
+        await target.AssertConcurrencyTokenRespectedAsync(
+            entity,
+            first => { first.Name = "First update"; first.Version++; },
+            second => { second.Name = "Second update"; second.Version++; });
+    }
+
+    [Fact]
+    public async Task AssertConcurrencyTokenRespectedAsync_NoConcurrencyToken_ThrowsBecauseNoCheckHappened()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget<ProductWithoutTokenContext>(
+            "products", static opts => new(opts));
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        ProductWithoutToken entity = new() { Name = "Original" };
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            async () => await target.AssertConcurrencyTokenRespectedAsync(
+                entity,
+                first => { first.Name = "First update"; },
+                second => { second.Name = "Second update"; }));
+    }
+
+    [Fact]
+    public async Task AssertNoOrphansAsync_NoOrphans_Passes()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget<ShopContext>(
+            "shop", static opts => new(opts));
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        await target.AssertNoOrphansAsync();
+    }
+
+    [Fact]
+    public async Task AssertNoOrphansAsync_OrphanInserted_Throws()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget<ShopContext>(
+            "shop", static opts => new(opts));
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        await using DbContext ctx = target.ResolveContext("shop");
+        await ctx.Database.ExecuteSqlRawAsync(
+            "PRAGMA foreign_keys = OFF; INSERT INTO \"Orders\" (\"Id\", \"CustomerId\") VALUES (1, 9999); PRAGMA foreign_keys = ON;");
+
+        await Assert.ThrowsAnyAsync<Exception>(
+            async () => await target.AssertNoOrphansAsync());
+    }
+
+    [Fact]
+    public async Task AssertNoTrackingMatchesTrackedAsync_Passes_OnSimpleEntity()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget<ProductContext>(
+            "products", static opts => new(opts));
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        Product entity = new() { Name = "Sprocket", CreatedAt = new DateTime(2025, 3, 15, 0, 0, 0, DateTimeKind.Utc) };
+
+        await target.AssertNoTrackingMatchesTrackedAsync(entity);
+    }
+
+    [Fact]
+    public async Task AssertRoundtripAsync_NullTarget_Throws()
+    {
+        IDbTarget? nullTarget = null;
+        Product entity = new() { Name = "Test" };
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await nullTarget!.AssertRoundtripAsync(entity));
+    }
+
+    // ---- comparers -------------------------------------------------------
+
+    private sealed class CreatedAtTicksComparer : IEqualityComparer<Product>
+    {
+        public bool Equals(Product? x, Product? y)
+        {
+            if (x is null && y is null)
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            return x.CreatedAt.Ticks == y.CreatedAt.Ticks;
+        }
+
+        public int GetHashCode(Product obj) => obj.CreatedAt.GetHashCode();
+    }
+}

--- a/src/Conjecture.EFCore.Tests/DbTargetTests.cs
+++ b/src/Conjecture.EFCore.Tests/DbTargetTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Conjecture.EFCore;
+using Conjecture.Interactions;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore.Tests;
+
+public class DbTargetTests
+{
+    private sealed class OrderItem
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class TestDbContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<OrderItem> OrderItems => Set<OrderItem>();
+    }
+
+    private static TestDbContext CreateInMemoryContext()
+    {
+        DbContextOptions<TestDbContext> opts = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase("orders-db")
+            .Options;
+        return new(opts);
+    }
+
+    private static TestDbContext CreateSqliteContext(Microsoft.Data.Sqlite.SqliteConnection connection)
+    {
+        DbContextOptions<TestDbContext> opts = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        return new(opts);
+    }
+
+    [Fact]
+    public void IDbTarget_IsInteractionTarget()
+    {
+        Assert.True(typeof(IInteractionTarget).IsAssignableFrom(typeof(IDbTarget)));
+    }
+
+    [Fact]
+    public void InMemoryDbTarget_Resolve_ReturnsContextForResource()
+    {
+        InMemoryDbTarget target = new("orders-db", static () =>
+        {
+            DbContextOptions<TestDbContext> opts = new DbContextOptionsBuilder<TestDbContext>()
+                .UseInMemoryDatabase("orders-db")
+                .Options;
+            return new TestDbContext(opts);
+        });
+
+        DbContext ctx = target.ResolveContext("orders-db");
+
+        Assert.NotNull(ctx);
+        Assert.True(ctx.Database.ProviderName?.Contains("InMemory", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void InMemoryDbTarget_Resolve_UnknownResource_Throws()
+    {
+        InMemoryDbTarget target = new("orders-db", static () =>
+        {
+            DbContextOptions<TestDbContext> opts = new DbContextOptionsBuilder<TestDbContext>()
+                .UseInMemoryDatabase("orders-db")
+                .Options;
+            return new TestDbContext(opts);
+        });
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => { target.ResolveContext("unknown"); });
+        Assert.Contains("unknown", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task InMemoryDbTarget_ResetAsync_ClearsState()
+    {
+        InMemoryDbTarget target = new("orders-db", static () =>
+        {
+            DbContextOptions<TestDbContext> opts = new DbContextOptionsBuilder<TestDbContext>()
+                .UseInMemoryDatabase("orders-db")
+                .Options;
+            return new TestDbContext(opts);
+        });
+
+        TestDbContext addCtx = (TestDbContext)target.ResolveContext("orders-db");
+        addCtx.OrderItems.Add(new() { Id = 1, Name = "Widget" });
+        await addCtx.SaveChangesAsync();
+
+        await target.ResetAsync("orders-db", CancellationToken.None);
+
+        TestDbContext freshCtx = (TestDbContext)target.ResolveContext("orders-db");
+        int count = await freshCtx.OrderItems.CountAsync();
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void SqliteDbTarget_Resolve_ReturnsContextForResource()
+    {
+        using Microsoft.Data.Sqlite.SqliteConnection conn = new("Data Source=:memory:");
+        conn.Open();
+
+        SqliteDbTarget target = new("orders-db", () => CreateSqliteContext(conn));
+        DbContext ctx = target.ResolveContext("orders-db");
+        ctx.Database.EnsureCreated();
+
+        Assert.NotNull(ctx);
+        Assert.True(ctx.Database.ProviderName?.Contains("Sqlite", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task SqliteDbTarget_ResetAsync_ClearsState()
+    {
+        using Microsoft.Data.Sqlite.SqliteConnection conn = new("Data Source=:memory:");
+        conn.Open();
+
+        SqliteDbTarget target = new("orders-db", () => CreateSqliteContext(conn));
+
+        TestDbContext addCtx = (TestDbContext)target.ResolveContext("orders-db");
+        addCtx.Database.EnsureCreated();
+        addCtx.OrderItems.Add(new() { Id = 1, Name = "Widget" });
+        await addCtx.SaveChangesAsync();
+
+        await target.ResetAsync("orders-db", CancellationToken.None);
+
+        TestDbContext freshCtx = (TestDbContext)target.ResolveContext("orders-db");
+        int count = await freshCtx.OrderItems.CountAsync();
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task SqliteDbTarget_AsyncDispose_ClosesConnection()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection conn = new("Data Source=:memory:");
+        conn.Open();
+
+        SqliteDbTarget target = new("orders-db", () => CreateSqliteContext(conn));
+        await target.DisposeAsync();
+
+        Assert.ThrowsAny<Exception>(() =>
+        {
+            DbContext ctx = target.ResolveContext("orders-db");
+            ctx.Database.EnsureCreated();
+        });
+    }
+}

--- a/src/Conjecture.EFCore.Tests/EFCoreGenerateTests.cs
+++ b/src/Conjecture.EFCore.Tests/EFCoreGenerateTests.cs
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+
+using Conjecture.Core;
+using Conjecture.EFCore;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore.Tests;
+
+public class EFCoreGenerateTests
+{
+    // ---- test entities -------------------------------------------------
+
+    private sealed class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public List<Order> Orders { get; set; } = [];
+    }
+
+    private sealed class Order
+    {
+        public int Id { get; set; }
+        public Customer? Customer { get; set; }
+        public int? CustomerId { get; set; }
+        public DateTime PlacedAt { get; set; }
+    }
+
+    private sealed class NotInModel { }
+
+    // ---- test DbContext ------------------------------------------------
+
+    private sealed class ShopContext : DbContext
+    {
+        public ShopContext(DbContextOptions<ShopContext> options) : base(options) { }
+
+        public DbSet<Customer> Customers { get; set; } = null!;
+        public DbSet<Order> Orders { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+                b.HasMany(e => e.Orders)
+                    .WithOne(o => o.Customer)
+                    .HasForeignKey(o => o.CustomerId)
+                    .IsRequired(false);
+            });
+
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+            });
+        }
+    }
+
+    // ---- helpers -------------------------------------------------------
+
+    private static ShopContext CreateShopContext()
+    {
+        DbContextOptions<ShopContext> options = new DbContextOptionsBuilder<ShopContext>()
+            .UseInMemoryDatabase($"EFCoreGenerateTests_{Guid.NewGuid()}")
+            .Options;
+        return new(options);
+    }
+
+    // ---- tests ---------------------------------------------------------
+
+    [Fact]
+    public void Entity_FromDbContext_ReturnsNonNullStrategy()
+    {
+        using ShopContext context = CreateShopContext();
+
+        Strategy<Customer> strategy = Generate.Entity<Customer>(context);
+
+        Assert.NotNull(strategy);
+    }
+
+    [Fact]
+    public void Entity_FromDbContext_SampledInstance_IsNonNull()
+    {
+        using ShopContext context = CreateShopContext();
+        Strategy<Customer> strategy = Generate.Entity<Customer>(context);
+
+        IReadOnlyList<Customer> samples = DataGen.Sample(strategy, count: 10, seed: 1UL);
+
+        Assert.All(samples, static c => Assert.NotNull(c));
+    }
+
+    [Fact]
+    public void Entity_FromDbContext_RequiredStringProperty_IsNonNull()
+    {
+        using ShopContext context = CreateShopContext();
+        Strategy<Customer> strategy = Generate.Entity<Customer>(context);
+
+        IReadOnlyList<Customer> samples = DataGen.Sample(strategy, count: 20, seed: 2UL);
+
+        Assert.All(samples, static c => Assert.NotNull(c.Name));
+    }
+
+    [Fact]
+    public void Entity_FactoryOverload_CreatesDifferentInstancesPerSample()
+    {
+        DbContextOptions<ShopContext> options = new DbContextOptionsBuilder<ShopContext>()
+            .UseInMemoryDatabase($"EFCoreGenerateTests_Factory_{Guid.NewGuid()}")
+            .Options;
+
+        Strategy<Customer> strategy = Generate.Entity<Customer>(static () =>
+            new ShopContext(
+                new DbContextOptionsBuilder<ShopContext>()
+                    .UseInMemoryDatabase($"EFCoreGenerateTests_Factory_Inner_{Guid.NewGuid()}")
+                    .Options));
+
+        IReadOnlyList<Customer> samples = DataGen.Sample(strategy, count: 10, seed: 3UL);
+
+        Assert.Equal(10, samples.Count);
+        // All must be distinct object references — factory creates a new entity per sample
+        Assert.All(samples, static c => Assert.NotNull(c));
+        Assert.True(
+            new System.Collections.Generic.HashSet<Customer>(samples, ReferenceEqualityComparer.Instance).Count > 1,
+            "Factory overload should produce distinct Customer instances across samples");
+    }
+
+    [Fact]
+    public void Entity_MaxDepthZero_NavigationsAreEmpty()
+    {
+        using ShopContext context = CreateShopContext();
+        Strategy<Customer> strategy = Generate.Entity<Customer>(context, maxDepth: 0);
+
+        IReadOnlyList<Customer> samples = DataGen.Sample(strategy, count: 20, seed: 4UL);
+
+        Assert.All(samples, static c => Assert.Empty(c.Orders));
+    }
+
+    [Fact]
+    public void Entity_UnknownType_Throws()
+    {
+        using ShopContext context = CreateShopContext();
+
+        Assert.Throws<InvalidOperationException>(() => Generate.Entity<NotInModel>(context));
+    }
+}

--- a/src/Conjecture.EFCore.Tests/EntityStrategyBuilderTests.cs
+++ b/src/Conjecture.EFCore.Tests/EntityStrategyBuilderTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Conjecture.Core;
+using Conjecture.EFCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Conjecture.EFCore.Tests;
+
+public class EntityStrategyBuilderTests
+{
+    // ---- test entities -------------------------------------------------
+
+    private sealed class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public List<Order> Orders { get; set; } = [];
+    }
+
+    private sealed class Order
+    {
+        public int Id { get; set; }
+        public Customer? Customer { get; set; }
+        public int? CustomerId { get; set; }
+        public DateTime PlacedAt { get; set; }
+    }
+
+    private sealed class Product
+    {
+        public int Id { get; set; }
+        public Address ShippingAddress { get; set; } = new();
+    }
+
+    private sealed class Address
+    {
+        public string Street { get; set; } = "";
+        public string City { get; set; } = "";
+    }
+
+    private sealed class NotInModelType { }
+
+    // ---- test DbContext ------------------------------------------------
+
+    private sealed class ShopContext : DbContext
+    {
+        public ShopContext(DbContextOptions<ShopContext> options) : base(options) { }
+
+        public DbSet<Customer> Customers { get; set; } = null!;
+        public DbSet<Order> Orders { get; set; } = null!;
+        public DbSet<Product> Products { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+                b.HasMany(e => e.Orders)
+                    .WithOne(o => o.Customer)
+                    .HasForeignKey(o => o.CustomerId)
+                    .IsRequired(false);
+            });
+
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+            });
+
+            modelBuilder.Entity<Product>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.OwnsOne(e => e.ShippingAddress);
+            });
+        }
+    }
+
+    // ---- helpers -------------------------------------------------------
+
+    private static ShopContext CreateShopContext()
+    {
+        DbContextOptions<ShopContext> options = new DbContextOptionsBuilder<ShopContext>()
+            .UseInMemoryDatabase($"EntityStrategyBuilderTests_{Guid.NewGuid()}")
+            .Options;
+        return new(options);
+    }
+
+    // ---- tests ---------------------------------------------------------
+
+    [Fact]
+    public void Build_ScalarProperties_ProduceValuesViaPropertyStrategyBuilder()
+    {
+        using ShopContext context = CreateShopContext();
+        IModel model = context.Model;
+        EntityStrategyBuilder builder = new(model);
+
+        Strategy<Customer> strategy = builder.Build<Customer>();
+        IReadOnlyList<Customer> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, static c =>
+        {
+            Assert.NotNull(c.Name);
+            // Id is ValueGeneratedOnAdd — left at CLR default (0)
+            Assert.Equal(0, c.Id);
+        });
+    }
+
+    [Fact]
+    public void Build_RequiredOwnedNavigation_GeneratedInline()
+    {
+        using ShopContext context = CreateShopContext();
+        IModel model = context.Model;
+        EntityStrategyBuilder builder = new(model);
+
+        Strategy<Product> strategy = builder.Build<Product>();
+        IReadOnlyList<Product> samples = DataGen.Sample(strategy, count: 20, seed: 2UL);
+
+        Assert.All(samples, static p =>
+        {
+            Assert.NotNull(p.ShippingAddress);
+            Assert.NotNull(p.ShippingAddress.Street);
+            Assert.NotNull(p.ShippingAddress.City);
+        });
+    }
+
+    [Fact]
+    public void Build_OptionalNavigation_AtDepthBound_IsNull()
+    {
+        using ShopContext context = CreateShopContext();
+        IModel model = context.Model;
+        EntityStrategyBuilder builder = new EntityStrategyBuilder(model).WithMaxDepth(0);
+
+        Strategy<Order> strategy = builder.Build<Order>();
+        IReadOnlyList<Order> samples = DataGen.Sample(strategy, count: 20, seed: 3UL);
+
+        Assert.All(samples, static o => Assert.Null(o.Customer));
+    }
+
+    [Fact]
+    public void Build_DefaultMaxDepth_IsTwo()
+    {
+        using ShopContext context = CreateShopContext();
+        IModel model = context.Model;
+        EntityStrategyBuilder builder = new(model);
+
+        Strategy<Customer> strategy = builder.Build<Customer>();
+        // Take several samples for robustness; at depth 2, Customer.Orders[*].Customer must be null
+        IReadOnlyList<Customer> samples = DataGen.Sample(strategy, count: 30, seed: 4UL);
+
+        // At least some orders should be present across samples
+        bool anyOrders = samples.Any(static c => c.Orders.Count > 0);
+        Assert.True(anyOrders, "Default depth 2 should populate Orders at depth 1");
+
+        // At depth 2, the Order's Customer back-reference must be null (cycle terminated)
+        Assert.All(samples, static c =>
+        {
+            Assert.All(c.Orders, static o => Assert.Null(o.Customer));
+        });
+    }
+
+    [Fact]
+    public void Build_WithoutNavigation_OmitsNavigation()
+    {
+        using ShopContext context = CreateShopContext();
+        IModel model = context.Model;
+        EntityStrategyBuilder builder = new EntityStrategyBuilder(model)
+            .WithoutNavigation<Customer>(static c => c.Orders);
+
+        Strategy<Customer> strategy = builder.Build<Customer>();
+        IReadOnlyList<Customer> samples = DataGen.Sample(strategy, count: 20, seed: 5UL);
+
+        Assert.All(samples, static c => Assert.Empty(c.Orders));
+    }
+
+    [Fact]
+    public void Build_UnknownEntityType_Throws()
+    {
+        using ShopContext context = CreateShopContext();
+        IModel model = context.Model;
+        EntityStrategyBuilder builder = new(model);
+
+        Assert.Throws<InvalidOperationException>(static () =>
+        {
+            EntityStrategyBuilder localBuilder = new(new ShopContext(
+                new DbContextOptionsBuilder<ShopContext>()
+                    .UseInMemoryDatabase("throw_test")
+                    .Options)
+                .Model);
+            localBuilder.Build<NotInModelType>();
+        });
+    }
+}

--- a/src/Conjecture.EFCore.Tests/GenerateDbTests.cs
+++ b/src/Conjecture.EFCore.Tests/GenerateDbTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Conjecture.Core;
+using Conjecture.EFCore;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Conjecture.EFCore.Tests;
+
+public class GenerateDbTests
+{
+    // ---- test entity ---------------------------------------------------
+
+    private sealed class Order
+    {
+        public int Id { get; set; }
+        public string Description { get; set; } = "";
+    }
+
+    // ---- test DbContext ------------------------------------------------
+
+    private sealed class OrderDbContext : DbContext
+    {
+        public OrderDbContext(DbContextOptions<OrderDbContext> options) : base(options) { }
+
+        public DbSet<Order> Orders { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Description).IsRequired();
+            });
+        }
+    }
+
+    // ---- helpers -------------------------------------------------------
+
+    private static IModel CreateOrderModel()
+    {
+        DbContextOptions<OrderDbContext> options = new DbContextOptionsBuilder<OrderDbContext>()
+            .UseInMemoryDatabase($"GenerateDbTests_{Guid.NewGuid()}")
+            .Options;
+        using OrderDbContext context = new(options);
+        return context.Model;
+    }
+
+    // ---- tests ---------------------------------------------------------
+
+    [Fact]
+    public void Generate_Db_Add_ProducesAddInteraction()
+    {
+        IModel model = CreateOrderModel();
+        Strategy<DbInteraction> strategy = Generate.Db.Add<Order>("orders-db", model);
+
+        IReadOnlyList<DbInteraction> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, static s =>
+        {
+            Assert.Equal(DbOpKind.Add, s.Op);
+            Assert.Equal("orders-db", s.ResourceName);
+            Assert.True(s.Payload is Order, $"Payload should be Order but was {s.Payload?.GetType().Name}");
+        });
+    }
+
+    [Fact]
+    public void Generate_Db_Update_ProducesUpdateInteraction()
+    {
+        IModel model = CreateOrderModel();
+        Strategy<DbInteraction> strategy = Generate.Db.Update<Order>("orders-db", model);
+
+        IReadOnlyList<DbInteraction> samples = DataGen.Sample(strategy, count: 20, seed: 2UL);
+
+        Assert.All(samples, static s =>
+        {
+            Assert.Equal(DbOpKind.Update, s.Op);
+            Assert.Equal("orders-db", s.ResourceName);
+            Assert.True(s.Payload is Order, $"Payload should be Order but was {s.Payload?.GetType().Name}");
+        });
+    }
+
+    [Fact]
+    public void Generate_Db_Remove_ProducesRemoveInteraction()
+    {
+        IModel model = CreateOrderModel();
+        Strategy<DbInteraction> strategy = Generate.Db.Remove<Order>("orders-db", model);
+
+        IReadOnlyList<DbInteraction> samples = DataGen.Sample(strategy, count: 20, seed: 3UL);
+
+        Assert.All(samples, static s =>
+        {
+            Assert.Equal(DbOpKind.Remove, s.Op);
+            Assert.Equal("orders-db", s.ResourceName);
+            Assert.True(s.Payload is Order, $"Payload should be Order but was {s.Payload?.GetType().Name}");
+        });
+    }
+
+    [Fact]
+    public void Generate_Db_SaveChanges_ProducesSaveChangesInteraction()
+    {
+        Strategy<DbInteraction> strategy = Generate.Db.SaveChanges("orders-db");
+
+        IReadOnlyList<DbInteraction> samples = DataGen.Sample(strategy, count: 10, seed: 4UL);
+
+        Assert.All(samples, static s =>
+        {
+            Assert.Equal(DbOpKind.SaveChanges, s.Op);
+            Assert.Equal("orders-db", s.ResourceName);
+            Assert.Null(s.Payload);
+        });
+    }
+
+    [Fact]
+    public void Generate_Db_Sequence_ProducesListInRange()
+    {
+        IModel model = CreateOrderModel();
+        Strategy<IReadOnlyList<DbInteraction>> strategy = Generate.Db.Sequence("orders-db", model, min: 2, max: 4);
+
+        IReadOnlyList<IReadOnlyList<DbInteraction>> samples = DataGen.Sample(strategy, count: 30, seed: 5UL);
+
+        Assert.All(samples, static list =>
+        {
+            Assert.True(list.Count >= 2 && list.Count <= 4,
+                $"Expected Count in [2,4] but got {list.Count}");
+        });
+    }
+
+    [Fact]
+    public void Generate_Db_Sequence_ListContainsValidInteractions()
+    {
+        IModel model = CreateOrderModel();
+        Strategy<IReadOnlyList<DbInteraction>> strategy = Generate.Db.Sequence("orders-db", model, min: 1, max: 5);
+
+        IReadOnlyList<IReadOnlyList<DbInteraction>> samples = DataGen.Sample(strategy, count: 30, seed: 6UL);
+
+        Assert.All(samples, static list =>
+        {
+            Assert.All(list, static interaction =>
+            {
+                Assert.NotNull(interaction);
+                Assert.Equal("orders-db", interaction.ResourceName);
+            });
+        });
+    }
+
+    [Fact]
+    public void Generate_Db_Add_NullModel_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => Generate.Db.Add<Order>("orders-db", null!));
+    }
+
+    [Fact]
+    public void Generate_Db_Add_NullResourceName_Throws()
+    {
+        IModel model = CreateOrderModel();
+
+        Assert.Throws<ArgumentNullException>(() => Generate.Db.Add<Order>(null!, model));
+    }
+}

--- a/src/Conjecture.EFCore.Tests/MigrationHarnessTests.cs
+++ b/src/Conjecture.EFCore.Tests/MigrationHarnessTests.cs
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Threading.Tasks;
+
+using Conjecture.EFCore;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Conjecture.EFCore.Tests;
+
+public sealed class MigrationHarnessTests
+{
+    // ---- symmetric migration fixtures ------------------------------------
+
+    [DbContext(typeof(SymmetricMigrationContext))]
+    [Migration("20240101000000_Initial")]
+    private sealed class SymmetricInitialMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                "Items",
+                columns: static t => new
+                {
+                    Id = t.Column<int>(nullable: false),
+                    Name = t.Column<string>(nullable: false),
+                },
+                constraints: static t =>
+                {
+                    t.PrimaryKey("PK_Items", static x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable("Items");
+        }
+    }
+
+    [DbContext(typeof(SymmetricMigrationContext))]
+    [Migration("20240102000000_AddPrices")]
+    private sealed class SymmetricAddPriceMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                "Prices",
+                columns: static t => new
+                {
+                    Id = t.Column<int>(nullable: false),
+                    Amount = t.Column<decimal>(nullable: false),
+                },
+                constraints: static t =>
+                {
+                    t.PrimaryKey("PK_Prices", static x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable("Prices");
+        }
+    }
+
+    private sealed class SymmetricMigrationContextSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasAnnotation("ProductVersion", "9.0.0");
+            modelBuilder.Entity(
+                "Item",
+                static b =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd();
+                    b.Property<string>("Name").IsRequired();
+                    b.HasKey("Id");
+                    b.ToTable("Items");
+                });
+            modelBuilder.Entity(
+                "Price",
+                static b =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd();
+                    b.Property<decimal>("Amount");
+                    b.HasKey("Id");
+                    b.ToTable("Prices");
+                });
+        }
+    }
+
+    private sealed class SymmetricMigrationContext : DbContext
+    {
+        public SymmetricMigrationContext(DbContextOptions<SymmetricMigrationContext> options)
+            : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity(
+                "Item",
+                static (EntityTypeBuilder b) =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd();
+                    b.Property<string>("Name").IsRequired();
+                    b.HasKey("Id");
+                    b.ToTable("Items");
+                });
+            modelBuilder.Entity(
+                "Price",
+                static (EntityTypeBuilder b) =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd();
+                    b.Property<decimal>("Amount");
+                    b.HasKey("Id");
+                    b.ToTable("Prices");
+                });
+        }
+    }
+
+    // ---- asymmetric migration fixtures -----------------------------------
+
+    [DbContext(typeof(AsymmetricMigrationContext))]
+    [Migration("20240101000000_Initial")]
+    private sealed class AsymmetricInitialMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                "Products",
+                columns: static t => new
+                {
+                    Id = t.Column<int>(nullable: false),
+                    Title = t.Column<string>(nullable: false),
+                },
+                constraints: static t =>
+                {
+                    t.PrimaryKey("PK_Products", static x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable("Products");
+        }
+    }
+
+    [DbContext(typeof(AsymmetricMigrationContext))]
+    [Migration("20240102000000_AddRatings")]
+    private sealed class AsymmetricAddRatingMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                "Ratings",
+                columns: static t => new
+                {
+                    Id = t.Column<int>(nullable: false),
+                    Score = t.Column<int>(nullable: false),
+                },
+                constraints: static t =>
+                {
+                    t.PrimaryKey("PK_Ratings", static x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Intentionally wrong: drops Products instead of Ratings,
+            // leaving Ratings behind — schema after Down != schema before Up.
+            migrationBuilder.DropTable("Products");
+        }
+    }
+
+    private sealed class AsymmetricMigrationContextSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasAnnotation("ProductVersion", "9.0.0");
+            modelBuilder.Entity(
+                "Product",
+                static b =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd();
+                    b.Property<string>("Title").IsRequired();
+                    b.HasKey("Id");
+                    b.ToTable("Products");
+                });
+            modelBuilder.Entity(
+                "Rating",
+                static b =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd();
+                    b.Property<int>("Score");
+                    b.HasKey("Id");
+                    b.ToTable("Ratings");
+                });
+        }
+    }
+
+    private sealed class AsymmetricMigrationContext : DbContext
+    {
+        public AsymmetricMigrationContext(DbContextOptions<AsymmetricMigrationContext> options)
+            : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity(
+                "Product",
+                static (EntityTypeBuilder b) =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd();
+                    b.Property<string>("Title").IsRequired();
+                    b.HasKey("Id");
+                    b.ToTable("Products");
+                });
+            modelBuilder.Entity(
+                "Rating",
+                static (EntityTypeBuilder b) =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd();
+                    b.Property<int>("Score");
+                    b.HasKey("Id");
+                    b.ToTable("Ratings");
+                });
+        }
+    }
+
+    // ---- no-migrations fixture -------------------------------------------
+
+    private sealed class NoMigrationsContext : DbContext
+    {
+        public NoMigrationsContext(DbContextOptions<NoMigrationsContext> options)
+            : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity(
+                "Widget",
+                static (EntityTypeBuilder b) =>
+                {
+                    b.Property<int>("Id").ValueGeneratedOnAdd();
+                    b.Property<string>("Label").IsRequired();
+                    b.HasKey("Id");
+                    b.ToTable("Widgets");
+                });
+        }
+    }
+
+    // ---- helpers ---------------------------------------------------------
+
+    private static DbContextOptions<T> SqliteOptions<T>(string dbName)
+        where T : DbContext
+    {
+        string connectionString = FormattableString.Invariant(
+            $"Data Source=file:{dbName}?mode=memory&cache=shared");
+
+        return new DbContextOptionsBuilder<T>()
+            .UseSqlite(connectionString)
+            .Options;
+    }
+
+    // ---- tests -----------------------------------------------------------
+
+    [Fact]
+    public async Task AssertUpDownIdempotentAsync_SymmetricMigrations_DoesNotThrow()
+    {
+        DbContextOptions<SymmetricMigrationContext> options =
+            SqliteOptions<SymmetricMigrationContext>("symmetric_harness");
+
+        await using SymmetricMigrationContext context = new(options);
+
+        await MigrationHarness.AssertUpDownIdempotentAsync(context);
+    }
+
+    [Fact]
+    public async Task AssertUpDownIdempotentAsync_AsymmetricMigrations_Throws()
+    {
+        DbContextOptions<AsymmetricMigrationContext> options =
+            SqliteOptions<AsymmetricMigrationContext>("asymmetric_harness");
+
+        await using AsymmetricMigrationContext context = new(options);
+
+        await Assert.ThrowsAsync<MigrationAssertionException>(
+            async () => await MigrationHarness.AssertUpDownIdempotentAsync(context));
+    }
+
+    [Fact]
+    public async Task AssertUpDownIdempotentAsync_NoMigrations_Throws()
+    {
+        DbContextOptions<NoMigrationsContext> options =
+            SqliteOptions<NoMigrationsContext>("no_migrations_harness");
+
+        await using NoMigrationsContext context = new(options);
+        await context.Database.EnsureCreatedAsync();
+
+        Exception exception = await Assert.ThrowsAnyAsync<Exception>(
+            async () => await MigrationHarness.AssertUpDownIdempotentAsync(context));
+
+        Assert.Contains("migration", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AssertUpDownIdempotentAsync_NullContext_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await MigrationHarness.AssertUpDownIdempotentAsync(null!));
+    }
+}

--- a/src/Conjecture.EFCore.Tests/ProjectStructureTests.cs
+++ b/src/Conjecture.EFCore.Tests/ProjectStructureTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+using Conjecture.EFCore;
+
+namespace Conjecture.EFCore.Tests;
+
+public class ProjectStructureTests
+{
+    [Fact]
+    public void EFCorePackage_TypeExists_InConjectureEFCoreNamespace()
+    {
+        System.Type type = typeof(EFCorePackage);
+        Assert.Equal("Conjecture.EFCore", type.Namespace);
+    }
+
+    [Fact]
+    public void EFCorePackage_Assembly_ReferencesEntityFrameworkCore()
+    {
+        Assembly assembly = typeof(EFCorePackage).Assembly;
+        bool referencesEFCore = System.Linq.Enumerable.Any(
+            assembly.GetReferencedAssemblies(),
+            static a => a.Name == "Microsoft.EntityFrameworkCore");
+
+        Assert.True(referencesEFCore, "Conjecture.EFCore assembly must reference Microsoft.EntityFrameworkCore");
+    }
+
+    [Fact]
+    public void EFCorePackage_IsInternalStaticClass()
+    {
+        System.Type type = typeof(EFCorePackage);
+        Assert.True(type.IsAbstract && type.IsSealed, "EFCorePackage should be a static class (abstract + sealed)");
+        Assert.False(type.IsPublic, "EFCorePackage should be internal");
+    }
+}

--- a/src/Conjecture.EFCore.Tests/PropertyStrategyBuilderTests.cs
+++ b/src/Conjecture.EFCore.Tests/PropertyStrategyBuilderTests.cs
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Conjecture.Core;
+using Conjecture.EFCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Conjecture.EFCore.Tests;
+
+public class PropertyStrategyBuilderTests
+{
+    // ---- test entities -------------------------------------------------
+
+    private enum Status { Active, Inactive, Pending }
+
+    private sealed class AllTypesEntity
+    {
+        public int Id { get; set; }
+        public int? NullableInt { get; set; }
+        [MaxLength(10)]
+        public string? StringWithMaxLength { get; set; }
+        public string RequiredString { get; set; } = "";
+        public decimal DecimalValue { get; set; }
+        public Guid GuidValue { get; set; }
+        public Status StatusValue { get; set; }
+    }
+
+    private sealed class ValueGeneratedEntity
+    {
+        public int Id { get; set; }
+    }
+
+    private sealed class AllTypesContext : DbContext
+    {
+        public AllTypesContext(DbContextOptions<AllTypesContext> options) : base(options) { }
+
+        public DbSet<AllTypesEntity> AllTypes { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<AllTypesEntity>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.RequiredString).IsRequired();
+                b.Property(e => e.DecimalValue).HasPrecision(8, 2);
+            });
+        }
+    }
+
+    private sealed class ValueGeneratedContext : DbContext
+    {
+        public ValueGeneratedContext(DbContextOptions<ValueGeneratedContext> options) : base(options) { }
+
+        public DbSet<ValueGeneratedEntity> Entities { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<ValueGeneratedEntity>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+            });
+        }
+    }
+
+    // ---- helpers -------------------------------------------------------
+
+    private static IProperty GetProperty<TEntity>(DbContext context, string propertyName)
+        => context.Model.FindEntityType(typeof(TEntity))!.FindProperty(propertyName)!;
+
+    private static AllTypesContext CreateAllTypesContext()
+    {
+        DbContextOptions<AllTypesContext> options = new DbContextOptionsBuilder<AllTypesContext>()
+            .UseInMemoryDatabase("PropertyStrategyBuilderTests_AllTypes")
+            .Options;
+        return new(options);
+    }
+
+    private static ValueGeneratedContext CreateValueGeneratedContext()
+    {
+        DbContextOptions<ValueGeneratedContext> options = new DbContextOptionsBuilder<ValueGeneratedContext>()
+            .UseInMemoryDatabase("PropertyStrategyBuilderTests_ValueGenerated")
+            .Options;
+        return new(options);
+    }
+
+    // ---- tests ---------------------------------------------------------
+
+    [Fact]
+    public void Build_NonNullableInt_ProducesNonNullInt32()
+    {
+        using AllTypesContext context = CreateAllTypesContext();
+        IProperty property = GetProperty<AllTypesEntity>(context, nameof(AllTypesEntity.Id));
+
+        Strategy<object?> strategy = PropertyStrategyBuilder.Build(property);
+        System.Collections.Generic.IReadOnlyList<object?> samples = DataGen.Sample(strategy, count: 20, seed: 1UL);
+
+        Assert.All(samples, static s =>
+        {
+            Assert.NotNull(s);
+            Assert.IsType<int>(s);
+        });
+    }
+
+    [Fact]
+    public void Build_NullableInt_AllowsNull()
+    {
+        using AllTypesContext context = CreateAllTypesContext();
+        IProperty property = GetProperty<AllTypesEntity>(context, nameof(AllTypesEntity.NullableInt));
+
+        Strategy<object?> strategy = PropertyStrategyBuilder.Build(property);
+        System.Collections.Generic.IReadOnlyList<object?> samples = DataGen.Sample(strategy, count: 100, seed: 2UL);
+
+        bool hasNull = samples.Any(static s => s is null);
+        bool hasInt = samples.Any(static s => s is int);
+        Assert.True(hasNull, "Nullable int property strategy must emit null values");
+        Assert.True(hasInt, "Nullable int property strategy must emit int values");
+    }
+
+    [Fact]
+    public void Build_StringMaxLength_RespectsBound()
+    {
+        using AllTypesContext context = CreateAllTypesContext();
+        IProperty property = GetProperty<AllTypesEntity>(context, nameof(AllTypesEntity.StringWithMaxLength));
+
+        Strategy<object?> strategy = PropertyStrategyBuilder.Build(property);
+        System.Collections.Generic.IReadOnlyList<object?> samples = DataGen.Sample(strategy, count: 50, seed: 3UL);
+
+        Assert.All(samples, static s =>
+        {
+            if (s is string str)
+            {
+                Assert.True(str.Length <= 10, $"String length {str.Length} exceeds MaxLength(10)");
+            }
+        });
+    }
+
+    [Fact]
+    public void Build_DecimalPrecisionScale_RespectsScale()
+    {
+        using AllTypesContext context = CreateAllTypesContext();
+        IProperty property = GetProperty<AllTypesEntity>(context, nameof(AllTypesEntity.DecimalValue));
+
+        Strategy<object?> strategy = PropertyStrategyBuilder.Build(property);
+        System.Collections.Generic.IReadOnlyList<object?> samples = DataGen.Sample(strategy, count: 50, seed: 4UL);
+
+        Assert.All(samples, static s =>
+        {
+            Assert.NotNull(s);
+            decimal value = Assert.IsType<decimal>(s);
+            // magnitude within precision(8,2): integer part <= 10^6
+            Assert.True(System.Math.Abs(value) <= 1_000_000m, $"Value {value} exceeds magnitude bound");
+            // at most 2 fractional digits
+            decimal fractionalPart = System.Math.Abs(value - System.Math.Truncate(value));
+            Assert.True(fractionalPart * 100 == System.Math.Truncate(fractionalPart * 100),
+                $"Value {value} has more than 2 fractional digits");
+        });
+    }
+
+    [Fact]
+    public void Build_ValueGeneratedOnAdd_ReturnsClrDefaultStrategy()
+    {
+        using ValueGeneratedContext context = CreateValueGeneratedContext();
+        IProperty property = GetProperty<ValueGeneratedEntity>(context, nameof(ValueGeneratedEntity.Id));
+
+        Strategy<object?> strategy = PropertyStrategyBuilder.Build(property);
+        System.Collections.Generic.IReadOnlyList<object?> samples = DataGen.Sample(strategy, count: 10, seed: 5UL);
+
+        Assert.All(samples, static s => Assert.Equal(0, s));
+    }
+
+    [Fact]
+    public void Build_GuidProperty_ProducesGuid()
+    {
+        using AllTypesContext context = CreateAllTypesContext();
+        IProperty property = GetProperty<AllTypesEntity>(context, nameof(AllTypesEntity.GuidValue));
+
+        Strategy<object?> strategy = PropertyStrategyBuilder.Build(property);
+        System.Collections.Generic.IReadOnlyList<object?> samples = DataGen.Sample(strategy, count: 20, seed: 6UL);
+
+        Assert.All(samples, static s =>
+        {
+            Assert.NotNull(s);
+            Guid guid = Assert.IsType<Guid>(s);
+            Assert.NotEqual(Guid.Empty, guid);
+        });
+    }
+
+    [Fact]
+    public void Build_StringNonNullableNoMaxLength_ProducesNonNullString()
+    {
+        using AllTypesContext context = CreateAllTypesContext();
+        IProperty property = GetProperty<AllTypesEntity>(context, nameof(AllTypesEntity.RequiredString));
+
+        Strategy<object?> strategy = PropertyStrategyBuilder.Build(property);
+        System.Collections.Generic.IReadOnlyList<object?> samples = DataGen.Sample(strategy, count: 20, seed: 7UL);
+
+        Assert.All(samples, static s =>
+        {
+            Assert.NotNull(s);
+            Assert.IsType<string>(s);
+        });
+    }
+}

--- a/src/Conjecture.EFCore.Tests/RoundtripAsserterTests.cs
+++ b/src/Conjecture.EFCore.Tests/RoundtripAsserterTests.cs
@@ -1,0 +1,341 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Conjecture.EFCore;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore.Tests;
+
+public class RoundtripAsserterTests
+{
+    // ---- test entities -------------------------------------------------
+
+    private sealed class Customer
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public DateTime JoinedAt { get; set; }
+        public Address? Address { get; set; }
+        public List<Order> Orders { get; set; } = [];
+    }
+
+    private sealed class Address
+    {
+        public string Street { get; set; } = "";
+        public string City { get; set; } = "";
+    }
+
+    private sealed class Order
+    {
+        public int Id { get; set; }
+        public int CustomerId { get; set; }
+        public Customer? Customer { get; set; }
+    }
+
+    // ---- DbContext -------------------------------------------------------
+
+    private sealed class ShopContext(DbContextOptions<ShopContext> options) : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+        public DbSet<Order> Orders { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+                b.OwnsOne(e => e.Address, a =>
+                {
+                    a.Property(x => x.Street).HasColumnName("Street");
+                    a.Property(x => x.City).HasColumnName("City");
+                });
+                b.HasMany(e => e.Orders)
+                    .WithOne(o => o.Customer)
+                    .HasForeignKey(o => o.CustomerId);
+            });
+
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+            });
+        }
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private static (SqliteConnection, Func<DbContext>) CreateSqliteFactory()
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        connection.Open();
+
+        DbContextOptions<ShopContext> options = new DbContextOptionsBuilder<ShopContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using ShopContext seed = new(options);
+        seed.Database.EnsureCreated();
+
+        return (connection, static () =>
+        {
+            // Each factory call creates a fresh context on a NEW connection that shares the same file.
+            // We close over the options string but need a shared in-memory DB per test.
+            // Re-use captured options via local helper.
+            throw new InvalidOperationException("Use CreateSqliteFactoryWithOptions instead.");
+        });
+    }
+
+    private static (SqliteConnection connection, Func<DbContext> factory) CreateSqliteFactoryWithOptions()
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        connection.Open();
+
+        DbContextOptions<ShopContext> options = new DbContextOptionsBuilder<ShopContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        ShopContext seed = new(options);
+        seed.Database.EnsureCreated();
+        seed.Dispose();
+
+        return (connection, () => new ShopContext(options));
+    }
+
+    private static (SqliteConnection connection, Func<DbContext> factory) CreateSqliteFactoryWithPrecisionLoss()
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        connection.Open();
+
+        DbContextOptions<ShopContextWithPrecisionLoss> options =
+            new DbContextOptionsBuilder<ShopContextWithPrecisionLoss>()
+                .UseSqlite(connection)
+                .Options;
+
+        ShopContextWithPrecisionLoss seed = new(options);
+        seed.Database.EnsureCreated();
+        seed.Dispose();
+
+        return (connection, () => new ShopContextWithPrecisionLoss(options));
+    }
+
+    // DbContext variant that drops sub-second precision via a value converter.
+    private sealed class ShopContextWithPrecisionLoss(DbContextOptions<ShopContextWithPrecisionLoss> options)
+        : DbContext(options)
+    {
+        public DbSet<Customer> Customers { get; set; } = null!;
+        public DbSet<Order> Orders { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+                b.Property(e => e.JoinedAt)
+                    .HasConversion(
+                        d => new DateTime(d.Ticks - (d.Ticks % TimeSpan.TicksPerSecond), d.Kind),
+                        d => d);
+                b.OwnsOne(e => e.Address, a =>
+                {
+                    a.Property(x => x.Street).HasColumnName("Street");
+                    a.Property(x => x.City).HasColumnName("City");
+                });
+                b.HasMany(e => e.Orders)
+                    .WithOne(o => o.Customer)
+                    .HasForeignKey(o => o.CustomerId);
+            });
+
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+            });
+        }
+    }
+
+    // ---- tests ----------------------------------------------------------
+
+    [Fact]
+    public async Task AssertRoundtripAsync_PersistsAndReloads_ScalarPropertiesPreserved()
+    {
+        (SqliteConnection connection, Func<DbContext> factory) = CreateSqliteFactoryWithOptions();
+        await using SqliteConnection _ = connection;
+
+        Customer entity = new() { Name = "Alice", JoinedAt = new DateTime(2025, 1, 15, 10, 0, 0, DateTimeKind.Utc) };
+
+        await RoundtripAsserter.AssertRoundtripAsync(factory, entity);
+    }
+
+    [Fact]
+    public async Task AssertRoundtripAsync_DataLoss_Throws()
+    {
+        // A context that strips sub-second precision via a value converter, so
+        // the reloaded JoinedAt will differ in ticks from what was saved.
+        (SqliteConnection connection, Func<DbContext> factory) = CreateSqliteFactoryWithPrecisionLoss();
+        await using SqliteConnection _ = connection;
+
+        // Milliseconds present — the value converter truncates them on persist.
+        Customer entity = new() { Name = "Bob", JoinedAt = new DateTime(2025, 6, 1, 12, 34, 56, 789, DateTimeKind.Utc) };
+
+        // Ticks-aware comparer: reloaded value (seconds-only) != original (with millis).
+        IEqualityComparer<Customer> ticksComparer = new JoinedAtTicksComparer();
+
+        RoundtripAssertionException exception = await Assert.ThrowsAsync<RoundtripAssertionException>(
+            async () => await RoundtripAsserter.AssertRoundtripAsync(factory, entity, ticksComparer));
+
+        Assert.Contains("JoinedAt", exception.Message);
+    }
+
+    [Fact]
+    public async Task AssertRoundtripAsync_CustomComparer_DeepCompare()
+    {
+        (SqliteConnection connection, Func<DbContext> factory) = CreateSqliteFactoryWithOptions();
+        await using SqliteConnection _ = connection;
+
+        Customer entity = new()
+        {
+            Name = "Carol",
+            JoinedAt = new DateTime(2024, 3, 10, 0, 0, 0, DateTimeKind.Utc),
+            Address = new() { Street = "123 Main St", City = "Springfield" },
+        };
+
+        IEqualityComparer<Customer> addressComparer = new AddressDeepComparer();
+
+        await RoundtripAsserter.AssertRoundtripAsync(factory, entity, addressComparer);
+    }
+
+    [Fact]
+    public async Task AssertRoundtripAsync_NullEntity_Throws()
+    {
+        (SqliteConnection connection, Func<DbContext> factory) = CreateSqliteFactoryWithOptions();
+        await using SqliteConnection _ = connection;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await RoundtripAsserter.AssertRoundtripAsync<Customer>(factory, null!));
+    }
+
+    [Fact]
+    public async Task AssertRoundtripAsync_NullFactory_Throws()
+    {
+        Customer entity = new() { Name = "Dave", JoinedAt = DateTime.UtcNow };
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await RoundtripAsserter.AssertRoundtripAsync<Customer>(null!, entity));
+    }
+
+    [Fact]
+    public async Task AssertNoTrackingMatchesTrackedAsync_AgreesAfterSave()
+    {
+        (SqliteConnection connection, Func<DbContext> factory) = CreateSqliteFactoryWithOptions();
+        await using SqliteConnection _ = connection;
+
+        Customer entity = new() { Name = "Eve", JoinedAt = new DateTime(2023, 7, 4, 8, 0, 0, DateTimeKind.Utc) };
+
+        await RoundtripAsserter.AssertNoTrackingMatchesTrackedAsync(factory, entity);
+    }
+
+    [Fact]
+    public async Task AssertNoTrackingMatchesTrackedAsync_DifferenceDetected_Throws()
+    {
+        (SqliteConnection connection, Func<DbContext> factory) = CreateSqliteFactoryWithOptions();
+        await using SqliteConnection _ = connection;
+
+        Customer entity = new() { Name = "Frank", JoinedAt = DateTime.UtcNow };
+
+        // Comparer checks Orders.Count — tracked load will have 0, no-tracking also 0,
+        // but we provide a comparer that detects when no-tracking query omits a navigated collection
+        // that was populated after save (simulated by adding an order after the initial save).
+        IEqualityComparer<Customer> ordersComparer = new OrdersCountMismatchComparer();
+
+        Exception exception = await Assert.ThrowsAnyAsync<Exception>(
+            async () => await RoundtripAsserter.AssertNoTrackingMatchesTrackedAsync(
+                factory, entity, ordersComparer));
+
+        Assert.NotNull(exception.Message);
+    }
+
+    // ---- comparers -------------------------------------------------------
+
+    // Compares by exact ticks so that any sub-second truncation is detectable.
+    private sealed class JoinedAtTicksComparer : IEqualityComparer<Customer>
+    {
+        public bool Equals(Customer? x, Customer? y)
+        {
+            if (x is null && y is null)
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            return x.JoinedAt.Equals(y.JoinedAt);
+        }
+
+        public int GetHashCode(Customer obj) => obj.JoinedAt.GetHashCode();
+    }
+
+    private sealed class AddressDeepComparer : IEqualityComparer<Customer>
+    {
+        public bool Equals(Customer? x, Customer? y)
+        {
+            if (x is null && y is null)
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            if (x.Address is null && y.Address is null)
+            {
+                return true;
+            }
+
+            if (x.Address is null || y.Address is null)
+            {
+                return false;
+            }
+
+            return x.Address.Street == y.Address.Street
+                && x.Address.City == y.Address.City;
+        }
+
+        public int GetHashCode(Customer obj) =>
+            HashCode.Combine(obj.Address?.Street, obj.Address?.City);
+    }
+
+    private sealed class OrdersCountMismatchComparer : IEqualityComparer<Customer>
+    {
+        public bool Equals(Customer? x, Customer? y)
+        {
+            if (x is null && y is null)
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            // Always report mismatch to simulate detected difference in Orders navigation
+            return false;
+        }
+
+        public int GetHashCode(Customer obj) => obj.Orders.Count.GetHashCode();
+    }
+}

--- a/src/Conjecture.EFCore/Conjecture.EFCore.csproj
+++ b/src/Conjecture.EFCore/Conjecture.EFCore.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="PublicAPI.Shipped.txt" />
+    <None Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Conjecture.EFCore.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/src/Conjecture.EFCore/Conjecture.EFCore.csproj
+++ b/src/Conjecture.EFCore/Conjecture.EFCore.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />

--- a/src/Conjecture.EFCore/Conjecture.EFCore.csproj
+++ b/src/Conjecture.EFCore/Conjecture.EFCore.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
+    <ProjectReference Include="..\Conjecture.Interactions\Conjecture.Interactions.csproj" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/Conjecture.EFCore/DbInteraction.cs
+++ b/src/Conjecture.EFCore/DbInteraction.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Interactions;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Represents a database operation flowing through the Layer 1 interactions framework.</summary>
+/// <param name="ResourceName">Logical name of the database resource being targeted.</param>
+/// <param name="Op">The kind of database operation.</param>
+/// <param name="Payload">Optional entity or value associated with the operation. May be null for operations like <see cref="DbOpKind.SaveChanges"/>.</param>
+public sealed record DbInteraction(
+    string ResourceName,
+    DbOpKind Op,
+    object? Payload) : IAddressedInteraction;

--- a/src/Conjecture.EFCore/DbInvariantExtensions.cs
+++ b/src/Conjecture.EFCore/DbInvariantExtensions.cs
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Extension methods that assert common DB invariants against an <see cref="IDbTarget"/>.</summary>
+public static class DbInvariantExtensions
+{
+    /// <summary>
+    /// Saves <paramref name="entity"/> via <paramref name="target"/>, reloads it in a fresh context,
+    /// and asserts equality using <paramref name="comparer"/> (or a default scalar-property comparer).
+    /// </summary>
+    public static Task AssertRoundtripAsync<TEntity>(
+        this IDbTarget target,
+        TEntity entity,
+        IEqualityComparer<TEntity>? comparer = null,
+        CancellationToken ct = default)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(entity);
+
+        string resourceName = target.ResourceName;
+        return RoundtripAsserter.AssertRoundtripAsync(
+            () => target.ResolveContext(resourceName),
+            entity,
+            comparer,
+            ct);
+    }
+
+    /// <summary>
+    /// Saves <paramref name="entity"/>, opens two overlapping contexts, applies <paramref name="mutateFirst"/>
+    /// in the first context and saves (advancing the concurrency token), then applies <paramref name="mutateSecond"/>
+    /// in the second context (which holds the stale token) and asserts that the save throws
+    /// <see cref="DbUpdateConcurrencyException"/>.
+    /// </summary>
+    public static async Task AssertConcurrencyTokenRespectedAsync<TEntity>(
+        this IDbTarget target,
+        TEntity entity,
+        Action<TEntity> mutateFirst,
+        Action<TEntity> mutateSecond,
+        CancellationToken ct = default)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(entity);
+        ArgumentNullException.ThrowIfNull(mutateFirst);
+        ArgumentNullException.ThrowIfNull(mutateSecond);
+
+        string resourceName = target.ResourceName;
+        object?[] keyValues;
+
+        // Seed the entity so it exists in the DB with a concurrency token.
+        await using (DbContext seedCtx = target.ResolveContext(resourceName))
+        {
+            seedCtx.Add(entity);
+            await seedCtx.SaveChangesAsync(ct).ConfigureAwait(false);
+            keyValues = GetKeyValues(seedCtx, entity);
+        }
+
+        // Open ctxB (stale): loads the entity before ctxA makes any changes.
+        await using DbContext ctxB = target.ResolveContext(resourceName);
+        TEntity? staleEntity = await ctxB.Set<TEntity>().FindAsync(keyValues, ct).ConfigureAwait(false);
+        if (staleEntity is null)
+        {
+            throw new RoundtripAssertionException(
+                FormattableString.Invariant($"Entity of type '{typeof(TEntity).Name}' could not be reloaded for concurrency test."));
+        }
+
+        // ctxA: apply first mutation and save — advances the concurrency token in the DB.
+        await using (DbContext ctxA = target.ResolveContext(resourceName))
+        {
+            TEntity? firstEntity = await ctxA.Set<TEntity>().FindAsync(keyValues, ct).ConfigureAwait(false);
+            if (firstEntity is null)
+            {
+                throw new RoundtripAssertionException(
+                    FormattableString.Invariant($"Entity of type '{typeof(TEntity).Name}' could not be reloaded for first mutation."));
+            }
+
+            mutateFirst(firstEntity);
+            await ctxA.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+
+        // ctxB: apply second mutation — ctxB still tracks the stale token, so save should fail.
+        // The mutator delegate is responsible for bumping the concurrency token on the entity
+        // (e.g. `e.Version++` for an `[ConcurrencyCheck] int Version`); EF compares the in-memory
+        // token against the persisted one and raises DbUpdateConcurrencyException on mismatch.
+        mutateSecond(staleEntity);
+        bool concurrencyExceptionThrown = false;
+        try
+        {
+            await ctxB.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            concurrencyExceptionThrown = true;
+        }
+
+        if (!concurrencyExceptionThrown)
+        {
+            throw new RoundtripAssertionException(
+                "Expected concurrency-token check to fail on stale update; second SaveChanges succeeded.");
+        }
+    }
+
+    /// <summary>
+    /// Checks every required foreign key in the model and throws if any child row references a non-existent parent.
+    /// Uses EF LINQ queries — no raw SQL.
+    /// </summary>
+    public static async Task AssertNoOrphansAsync(
+        this IDbTarget target,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+
+        string resourceName = target.ResourceName;
+        await using DbContext ctx = target.ResolveContext(resourceName);
+        IModel model = ctx.Model;
+
+        foreach (IEntityType childType in model.GetEntityTypes())
+        {
+            foreach (IForeignKey fk in childType.GetForeignKeys().Where(static f => f.IsRequired))
+            {
+                IEntityType parentType = fk.PrincipalEntityType;
+                Type childClrType = childType.ClrType;
+                Type parentClrType = parentType.ClrType;
+
+                IReadOnlyList<IProperty> fkProps = fk.Properties;
+                IReadOnlyList<IProperty> principalKeyProps = fk.PrincipalKey.Properties;
+
+                // Walk every child row and verify its parent exists.
+                System.Collections.IEnumerable children = (System.Collections.IEnumerable)ctx
+                    .GetType()
+                    .GetMethod(nameof(DbContext.Set), Type.EmptyTypes)!
+                    .MakeGenericMethod(childClrType)
+                    .Invoke(ctx, null)!;
+
+                foreach (object child in children)
+                {
+                    object?[] fkValues = fkProps
+                        .Select(p => p.PropertyInfo!.GetValue(child))
+                        .ToArray();
+
+                    object? parent = await ctx.FindAsync(parentClrType, fkValues, ct).ConfigureAwait(false);
+
+                    if (parent is null)
+                    {
+                        string fkColumns = string.Join(
+                            ", ",
+                            fkProps.Select(static p => p.Name));
+
+                        throw new RoundtripAssertionException(
+                            string.Format(
+                                CultureInfo.InvariantCulture,
+                                "Found orphan in '{0}' with no matching parent in '{1}' (FK columns: {2}).",
+                                childClrType.Name,
+                                parentClrType.Name,
+                                fkColumns));
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Saves <paramref name="entity"/>, then compares the tracked read against an AsNoTracking read,
+    /// asserting they are equal using <paramref name="comparer"/> (or a default scalar-property comparer).
+    /// </summary>
+    public static Task AssertNoTrackingMatchesTrackedAsync<TEntity>(
+        this IDbTarget target,
+        TEntity entity,
+        IEqualityComparer<TEntity>? comparer = null,
+        CancellationToken ct = default)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(entity);
+
+        string resourceName = target.ResourceName;
+        return RoundtripAsserter.AssertNoTrackingMatchesTrackedAsync(
+            () => target.ResolveContext(resourceName),
+            entity,
+            comparer,
+            ct);
+    }
+
+    private static object?[] GetKeyValues<TEntity>(DbContext context, TEntity entity) where TEntity : class
+    {
+        IEntityType entityType = context.Model.FindEntityType(typeof(TEntity))
+            ?? throw new InvalidOperationException(FormattableString.Invariant($"Entity type '{typeof(TEntity).Name}' not found in model."));
+
+        IKey primaryKey = entityType.FindPrimaryKey()
+            ?? throw new InvalidOperationException(FormattableString.Invariant($"Entity type '{typeof(TEntity).Name}' has no primary key."));
+
+        return [.. primaryKey.Properties.Select(p => p.PropertyInfo!.GetValue(entity))];
+    }
+}

--- a/src/Conjecture.EFCore/DbOpKind.cs
+++ b/src/Conjecture.EFCore/DbOpKind.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.EFCore;
+
+/// <summary>Classifies the kind of database operation represented by a <see cref="DbInteraction"/>.</summary>
+public enum DbOpKind
+{
+    /// <summary>An entity is being added to the context.</summary>
+    Add,
+
+    /// <summary>An entity is being updated in the context.</summary>
+    Update,
+
+    /// <summary>An entity is being removed from the context.</summary>
+    Remove,
+
+    /// <summary>Changes are being persisted to the database.</summary>
+    SaveChanges,
+
+    /// <summary>Data is being queried from the database.</summary>
+    Query,
+}

--- a/src/Conjecture.EFCore/EFCoreGenerateExtensions.cs
+++ b/src/Conjecture.EFCore/EFCoreGenerateExtensions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+using Conjecture.Core;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Factory methods for generating EF Core entity instances.</summary>
+public static class EFCoreGenerateExtensions
+{
+    // Both overloads take optional maxDepth; suppress RS0026 as in RegexGenerateExtensions.
+#pragma warning disable RS0026
+    extension(Generate)
+    {
+        /// <summary>Returns a strategy that generates instances of <typeparamref name="T"/> using the given <paramref name="context"/>.</summary>
+        public static Strategy<T> Entity<T>(DbContext context, int maxDepth = 2) where T : class
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            return new EntityStrategyBuilder(context.Model)
+                .WithMaxDepth(maxDepth)
+                .Build<T>();
+        }
+
+        /// <summary>Returns a strategy that generates instances of <typeparamref name="T"/> using a fresh <see cref="DbContext"/> per example.</summary>
+        public static Strategy<T> Entity<T>(Func<DbContext> contextFactory, int maxDepth = 2) where T : class
+        {
+            ArgumentNullException.ThrowIfNull(contextFactory);
+            return Generate.Compose<T>(ctx =>
+            {
+                using DbContext context = contextFactory();
+                Strategy<T> inner = new EntityStrategyBuilder(context.Model)
+                    .WithMaxDepth(maxDepth)
+                    .Build<T>();
+                return ctx.Generate(inner);
+            });
+        }
+    }
+#pragma warning restore RS0026
+}

--- a/src/Conjecture.EFCore/EFCorePackage.cs
+++ b/src/Conjecture.EFCore/EFCorePackage.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore;
+
+internal static class EFCorePackage
+{
+    internal static readonly System.Type DbContext = typeof(DbContext);
+}

--- a/src/Conjecture.EFCore/EntityStrategyBuilder.cs
+++ b/src/Conjecture.EFCore/EntityStrategyBuilder.cs
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Conjecture.Core;
+
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Builds a <see cref="Strategy{T}"/> for a complete EF Core entity graph.</summary>
+public sealed class EntityStrategyBuilder
+{
+    private readonly IModel model;
+    private int maxDepth = 2;
+    private readonly HashSet<(Type, string)> excludedNavigations = [];
+
+    /// <summary>Initializes a new <see cref="EntityStrategyBuilder"/> with the given EF Core model.</summary>
+    public EntityStrategyBuilder(IModel model)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        this.model = model;
+    }
+
+    /// <summary>Sets the maximum navigation depth. Default is 2.</summary>
+    public EntityStrategyBuilder WithMaxDepth(int depth)
+    {
+        maxDepth = depth;
+        return this;
+    }
+
+    /// <summary>Excludes the navigation identified by <paramref name="navigation"/> from generation.</summary>
+    public EntityStrategyBuilder WithoutNavigation<TEntity>(Expression<Func<TEntity, object?>> navigation) where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(navigation);
+        string propertyName = ExtractMemberName(navigation);
+        excludedNavigations.Add((typeof(TEntity), propertyName));
+        return this;
+    }
+
+    /// <summary>Builds a <see cref="Strategy{TEntity}"/> that generates entity graphs up to the configured depth.</summary>
+    public Strategy<TEntity> Build<TEntity>() where TEntity : class
+    {
+        IEntityType entityType = model.FindEntityType(typeof(TEntity))
+            ?? throw new InvalidOperationException(
+                $"Entity type '{typeof(TEntity).FullName}' is not registered in the EF Core model.");
+
+        HashSet<IEntityType> visitedPath = [];
+        return BuildStrategy<TEntity>(entityType, currentDepth: 0, visitedPath);
+    }
+
+    private Strategy<TEntity> BuildStrategy<TEntity>(
+        IEntityType entityType,
+        int currentDepth,
+        HashSet<IEntityType> visitedPath) where TEntity : class
+    {
+        return Generate.Compose<TEntity>(ctx =>
+        {
+            TEntity entity = (TEntity)Activator.CreateInstance(typeof(TEntity))!;
+            PopulateEntity(ctx, entity, entityType, currentDepth, visitedPath);
+            return entity;
+        });
+    }
+
+    private void PopulateEntity(
+        IGeneratorContext ctx,
+        object entity,
+        IEntityType entityType,
+        int currentDepth,
+        HashSet<IEntityType> visitedPath)
+    {
+        foreach (IProperty property in entityType.GetProperties())
+        {
+            object? value = ctx.Generate(PropertyStrategyBuilder.Build(property));
+            property.PropertyInfo?.SetValue(entity, value);
+        }
+
+        HashSet<IEntityType> newPath = [.. visitedPath, entityType];
+
+        foreach (INavigation nav in entityType.GetNavigations())
+        {
+            PopulateNavigation(ctx, entity, nav, currentDepth, newPath);
+        }
+    }
+
+    private void PopulateNavigation(
+        IGeneratorContext ctx,
+        object entity,
+        INavigation nav,
+        int currentDepth,
+        HashSet<IEntityType> visitedPath)
+    {
+        PropertyInfo? navProp = nav.PropertyInfo;
+        if (navProp is null)
+        {
+            return;
+        }
+
+        bool isOwned = nav.ForeignKey.IsOwnership;
+        bool isExcluded = excludedNavigations.Contains((entity.GetType(), nav.Name));
+
+        if (isExcluded)
+        {
+            SetNavigationDefault(navProp, entity, nav);
+            return;
+        }
+
+        IEntityType targetType = nav.TargetEntityType;
+        bool cycleDetected = visitedPath.Contains(targetType);
+
+        if (isOwned)
+        {
+            object? owned = Activator.CreateInstance(targetType.ClrType);
+            if (owned is not null)
+            {
+                HashSet<IEntityType> ownedPath = [.. visitedPath, targetType];
+                PopulateEntity(ctx, owned, targetType, currentDepth, ownedPath);
+            }
+            navProp.SetValue(entity, owned);
+            return;
+        }
+
+        if (cycleDetected || currentDepth >= maxDepth)
+        {
+            SetNavigationDefault(navProp, entity, nav);
+            return;
+        }
+
+        if (nav.IsCollection)
+        {
+            object? collection = Activator.CreateInstance(navProp.PropertyType);
+            if (collection is null)
+            {
+                return;
+            }
+
+            int count = ctx.Generate(Generate.Integers<int>(0, 3));
+            MethodInfo? addMethod = navProp.PropertyType.GetMethod("Add");
+            if (addMethod is not null)
+            {
+                HashSet<IEntityType> childPath = [.. visitedPath, targetType];
+                for (int i = 0; i < count; i++)
+                {
+                    object? child = BuildEntityInstance(ctx, targetType, currentDepth + 1, childPath);
+                    if (child is not null)
+                    {
+                        addMethod.Invoke(collection, [child]);
+                    }
+                }
+            }
+            navProp.SetValue(entity, collection);
+        }
+        else
+        {
+            if (!nav.ForeignKey.IsRequired)
+            {
+                navProp.SetValue(entity, null);
+                return;
+            }
+
+            HashSet<IEntityType> childPath = [.. visitedPath, targetType];
+            object? child = BuildEntityInstance(ctx, targetType, currentDepth + 1, childPath);
+            navProp.SetValue(entity, child);
+        }
+    }
+
+    private object? BuildEntityInstance(
+        IGeneratorContext ctx,
+        IEntityType entityType,
+        int currentDepth,
+        HashSet<IEntityType> visitedPath)
+    {
+        object? entity = Activator.CreateInstance(entityType.ClrType);
+        if (entity is null)
+        {
+            return null;
+        }
+        PopulateEntity(ctx, entity, entityType, currentDepth, visitedPath);
+        return entity;
+    }
+
+    private static void SetNavigationDefault(PropertyInfo navProp, object entity, INavigation nav)
+    {
+        if (nav.IsCollection)
+        {
+            object? emptyCollection = Activator.CreateInstance(navProp.PropertyType);
+            navProp.SetValue(entity, emptyCollection);
+        }
+        else
+        {
+            navProp.SetValue(entity, null);
+        }
+    }
+
+    private static string ExtractMemberName<TEntity>(Expression<Func<TEntity, object?>> expression)
+    {
+        Expression body = expression.Body;
+        if (body is UnaryExpression unary && unary.NodeType == ExpressionType.Convert)
+        {
+            body = unary.Operand;
+        }
+        return body is MemberExpression member
+            ? member.Member.Name
+            : throw new ArgumentException("Expression must be a property access expression.", nameof(expression));
+    }
+}

--- a/src/Conjecture.EFCore/GenerateDb.cs
+++ b/src/Conjecture.EFCore/GenerateDb.cs
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Conjecture.Core;
+
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Fluent builder returned by <c>Generate.Db</c> for composing DB interaction strategies.</summary>
+public sealed class GenerateDbBlock
+{
+    internal GenerateDbBlock()
+    {
+    }
+
+    /// <summary>Returns a strategy that generates an <see cref="DbOpKind.Add"/> <see cref="DbInteraction"/> for <typeparamref name="T"/>.</summary>
+    public Strategy<DbInteraction> Add<T>(string resourceName, IModel model, int maxDepth = 2) where T : class
+    {
+        ArgumentException.ThrowIfNullOrEmpty(resourceName);
+        ArgumentNullException.ThrowIfNull(model);
+
+        Strategy<T> entityStrategy = new EntityStrategyBuilder(model).WithMaxDepth(maxDepth).Build<T>();
+        return entityStrategy.Select(entity => new DbInteraction(resourceName, DbOpKind.Add, entity));
+    }
+
+    /// <summary>Returns a strategy that generates an <see cref="DbOpKind.Update"/> <see cref="DbInteraction"/> for <typeparamref name="T"/>.</summary>
+    public Strategy<DbInteraction> Update<T>(string resourceName, IModel model, int maxDepth = 2) where T : class
+    {
+        ArgumentException.ThrowIfNullOrEmpty(resourceName);
+        ArgumentNullException.ThrowIfNull(model);
+
+        Strategy<T> entityStrategy = new EntityStrategyBuilder(model).WithMaxDepth(maxDepth).Build<T>();
+        return entityStrategy.Select(entity => new DbInteraction(resourceName, DbOpKind.Update, entity));
+    }
+
+    /// <summary>Returns a strategy that generates a <see cref="DbOpKind.Remove"/> <see cref="DbInteraction"/> for <typeparamref name="T"/>.</summary>
+    public Strategy<DbInteraction> Remove<T>(string resourceName, IModel model) where T : class
+    {
+        ArgumentException.ThrowIfNullOrEmpty(resourceName);
+        ArgumentNullException.ThrowIfNull(model);
+
+        Strategy<T> entityStrategy = new EntityStrategyBuilder(model).Build<T>();
+        return entityStrategy.Select(entity => new DbInteraction(resourceName, DbOpKind.Remove, entity));
+    }
+
+    /// <summary>Returns a strategy that always produces a <see cref="DbOpKind.SaveChanges"/> <see cref="DbInteraction"/> with null payload.</summary>
+    public Strategy<DbInteraction> SaveChanges(string resourceName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(resourceName);
+
+        return Generate.Constant(new DbInteraction(resourceName, DbOpKind.SaveChanges, null));
+    }
+
+    /// <summary>
+    /// Returns a strategy producing a list of <see cref="DbInteraction"/> records with length in [<paramref name="min"/>, <paramref name="max"/>].
+    /// Each element is drawn uniformly from Add, Update, Remove, and SaveChanges operations across all entity types in the model.
+    /// </summary>
+    public Strategy<IReadOnlyList<DbInteraction>> Sequence(
+        string resourceName,
+        IModel model,
+        int min = 1,
+        int max = 5)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(resourceName);
+        ArgumentNullException.ThrowIfNull(model);
+
+        IReadOnlyList<IEntityType> entityTypes = model.GetEntityTypes().ToList();
+
+        List<Strategy<DbInteraction>> candidates = [];
+        foreach (IEntityType entityType in entityTypes)
+        {
+            Strategy<object> entityStrategy = BuildObjectStrategy(entityType, model);
+            candidates.Add(entityStrategy.Select(entity => new DbInteraction(resourceName, DbOpKind.Add, entity)));
+            candidates.Add(entityStrategy.Select(entity => new DbInteraction(resourceName, DbOpKind.Update, entity)));
+            candidates.Add(entityStrategy.Select(entity => new DbInteraction(resourceName, DbOpKind.Remove, entity)));
+        }
+        candidates.Add(Generate.Constant(new DbInteraction(resourceName, DbOpKind.SaveChanges, null)));
+
+        Strategy<DbInteraction> elementStrategy = Generate.OneOf([.. candidates]);
+        return Generate.Lists(elementStrategy, min, max)
+            .Select(static list => (IReadOnlyList<DbInteraction>)list);
+    }
+
+    private static readonly MethodInfo BuildGenericMethod =
+        typeof(GenerateDbBlock).GetMethod(nameof(BuildTypedObjectStrategy), BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("BuildTypedObjectStrategy not found.");
+
+    private static Strategy<object> BuildObjectStrategy(IEntityType entityType, IModel model)
+    {
+        // Sequence iterates model.GetEntityTypes() at runtime, so the entity type is not statically known — reflection bridges to the generic Build<T>.
+        MethodInfo generic = BuildGenericMethod.MakeGenericMethod(entityType.ClrType);
+        return (Strategy<object>)(generic.Invoke(null, [model])
+            ?? throw new InvalidOperationException($"BuildTypedObjectStrategy<{entityType.ClrType.Name}> returned null."));
+    }
+
+    private static Strategy<object> BuildTypedObjectStrategy<T>(IModel model) where T : class
+    {
+        Strategy<T> inner = new EntityStrategyBuilder(model).Build<T>();
+        return inner.Select(static entity => (object)entity);
+    }
+}
+
+/// <summary>Extension methods on <see cref="Generate"/> for database interaction generation.</summary>
+public static class DbGenerateExtensions
+{
+    extension(Generate)
+    {
+        /// <summary>Returns a <see cref="GenerateDbBlock"/> for composing database interaction strategies.</summary>
+        public static GenerateDbBlock Db => new();
+    }
+}

--- a/src/Conjecture.EFCore/IDbTarget.cs
+++ b/src/Conjecture.EFCore/IDbTarget.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Interactions;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore;
+
+/// <summary>EF Core-specific interaction target exposing a <see cref="DbContext"/> for the given resource.</summary>
+public interface IDbTarget : IInteractionTarget
+{
+    /// <summary>Returns a <see cref="DbContext"/> configured for the given resource name.</summary>
+    DbContext ResolveContext(string resourceName);
+}

--- a/src/Conjecture.EFCore/IDbTarget.cs
+++ b/src/Conjecture.EFCore/IDbTarget.cs
@@ -10,6 +10,9 @@ namespace Conjecture.EFCore;
 /// <summary>EF Core-specific interaction target exposing a <see cref="DbContext"/> for the given resource.</summary>
 public interface IDbTarget : IInteractionTarget
 {
+    /// <summary>Gets the resource name this target is registered under.</summary>
+    string ResourceName { get; }
+
     /// <summary>Returns a <see cref="DbContext"/> configured for the given resource name.</summary>
     DbContext ResolveContext(string resourceName);
 }

--- a/src/Conjecture.EFCore/InMemoryDbTarget.cs
+++ b/src/Conjecture.EFCore/InMemoryDbTarget.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Conjecture.Interactions;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore;
+
+/// <summary>EF Core InMemory-backed interaction target, keyed by a single resource name.</summary>
+public sealed class InMemoryDbTarget(string resourceName, Func<DbContext> contextFactory) : IDbTarget
+{
+    private readonly Func<DbContext> contextFactory = contextFactory
+        ?? throw new ArgumentNullException(nameof(contextFactory));
+
+    /// <summary>Gets the resource name this target is registered under.</summary>
+    public string ResourceName { get; } = string.IsNullOrEmpty(resourceName)
+        ? throw new ArgumentException("Resource name must not be null or empty.", nameof(resourceName))
+        : resourceName;
+
+    /// <inheritdoc/>
+    public DbContext ResolveContext(string resourceName) =>
+        resourceName == ResourceName
+            ? contextFactory()
+            : throw new InvalidOperationException(
+                $"Unknown resource '{resourceName}'; this target is registered for '{ResourceName}'.");
+
+    /// <inheritdoc/>
+    public async Task ResetAsync(string resourceName, CancellationToken cancellationToken = default)
+    {
+        if (resourceName != ResourceName)
+        {
+            throw new InvalidOperationException(
+                $"Unknown resource '{resourceName}'; this target is registered for '{ResourceName}'.");
+        }
+
+        await using DbContext ctx = contextFactory();
+        await ctx.Database.EnsureDeletedAsync(cancellationToken).ConfigureAwait(false);
+        await ctx.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public Task<object?> ExecuteAsync(IInteraction interaction, CancellationToken ct) =>
+        throw new NotImplementedException("Dispatch logic will be implemented in a subsequent cycle.");
+}

--- a/src/Conjecture.EFCore/MigrationAssertionException.cs
+++ b/src/Conjecture.EFCore/MigrationAssertionException.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Thrown when a migration idempotency assertion fails.</summary>
+public sealed class MigrationAssertionException : Exception
+{
+    /// <summary>Initializes a new instance with <paramref name="message"/>.</summary>
+    public MigrationAssertionException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes a new instance with <paramref name="message"/> and <paramref name="innerException"/>.</summary>
+    public MigrationAssertionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Conjecture.EFCore/MigrationHarness.cs
+++ b/src/Conjecture.EFCore/MigrationHarness.cs
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Asserts migration Up/Down symmetry for a given <see cref="DbContext"/>.</summary>
+public static class MigrationHarness
+{
+    /// <summary>
+    /// Applies all pending migrations to head, rolls back the latest one, re-applies it,
+    /// and asserts that the resulting schema is identical to the schema before the rollback.
+    /// </summary>
+    public static async Task AssertUpDownIdempotentAsync(
+        DbContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        IReadOnlyList<string> all = context.Database.GetMigrations().ToList();
+
+        if (all.Count == 0)
+        {
+            throw new InvalidOperationException("No migrations defined for this context.");
+        }
+
+        IMigrator migrator = context.GetService<IMigrator>();
+
+        await migrator.MigrateAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        string snapshot1 = await CaptureSchemaAsync(context, cancellationToken).ConfigureAwait(false);
+
+        string rollbackTarget = all.Count == 1
+            ? Migration.InitialDatabase
+            : all[^2];
+
+        await migrator.MigrateAsync(rollbackTarget, cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await migrator.MigrateAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new MigrationAssertionException(
+                FormattableString.Invariant(
+                    $"Migration Up/Down is not idempotent: re-applying Up failed after Down.{Environment.NewLine}{ex.Message}"),
+                ex);
+        }
+
+        string snapshot2 = await CaptureSchemaAsync(context, cancellationToken).ConfigureAwait(false);
+
+        if (snapshot1 != snapshot2)
+        {
+            throw new MigrationAssertionException(
+                FormattableString.Invariant(
+                    $"Migration Up/Down is not idempotent.{Environment.NewLine}Schema before rollback:{Environment.NewLine}{snapshot1}{Environment.NewLine}Schema after re-apply:{Environment.NewLine}{snapshot2}"));
+        }
+    }
+
+    private static async Task<string> CaptureSchemaAsync(
+        DbContext context,
+        CancellationToken cancellationToken)
+    {
+        DbConnection conn = context.Database.GetDbConnection();
+        bool shouldClose = conn.State != ConnectionState.Open;
+
+        if (shouldClose)
+        {
+            await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        try
+        {
+            await using DbCommand cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "SELECT name, type, sql FROM sqlite_master " +
+                "WHERE type IN ('table','index','view') " +
+                "AND name NOT LIKE 'sqlite_%' " +
+                "AND name NOT LIKE '__EFMigrations%' " +
+                "ORDER BY type, name";
+
+            await using DbDataReader reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+            StringBuilder sb = new();
+
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                string name = reader.GetString(0);
+                string type = reader.GetString(1);
+                string sql = reader.IsDBNull(2) ? string.Empty : reader.GetString(2);
+                sb.Append(type).Append('|').Append(name).Append('|').AppendLine(sql);
+            }
+
+            return sb.ToString();
+        }
+        finally
+        {
+            if (shouldClose)
+            {
+                await conn.CloseAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Conjecture.EFCore/PropertyStrategyBuilder.cs
+++ b/src/Conjecture.EFCore/PropertyStrategyBuilder.cs
@@ -1,0 +1,174 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+using Conjecture.Core;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Builds a <see cref="Strategy{T}"/> for a single EF Core property, respecting type-system constraints.</summary>
+public static class PropertyStrategyBuilder
+{
+    /// <summary>Returns a <see cref="Strategy{T}">Strategy&lt;object?&gt;</see> that generates values compatible with <paramref name="property"/>.</summary>
+    public static Strategy<object?> Build(IProperty property)
+    {
+        ArgumentNullException.ThrowIfNull(property);
+
+        if (property.ValueGenerated == ValueGenerated.OnAdd || property.ValueGenerated == ValueGenerated.OnAddOrUpdate)
+        {
+            object? clrDefault = property.ClrType.IsValueType ? Activator.CreateInstance(property.ClrType) : null;
+            return Generate.Constant<object?>(clrDefault);
+        }
+
+        Type clrType = property.ClrType;
+        Type underlying = Nullable.GetUnderlyingType(clrType) ?? clrType;
+
+        Strategy<object?> inner = BuildInner(property, underlying);
+
+        return property.IsNullable
+            ? Generate.OneOf(inner, Generate.Constant<object?>(null))
+            : inner;
+    }
+
+    private static Strategy<object?> BuildInner(IProperty property, Type underlying)
+    {
+        if (underlying == typeof(int))
+        {
+            return Generate.Integers<int>().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(long))
+        {
+            return Generate.Integers<long>().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(short))
+        {
+            return Generate.Integers<short>().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(byte))
+        {
+            return Generate.Integers<byte>().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(sbyte))
+        {
+            return Generate.Integers<sbyte>().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(uint))
+        {
+            return Generate.Integers<uint>().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(ulong))
+        {
+            return Generate.Integers<ulong>().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(ushort))
+        {
+            return Generate.Integers<ushort>().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(bool))
+        {
+            return Generate.Booleans().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(decimal))
+        {
+            return BuildDecimalStrategy(property);
+        }
+
+        if (underlying == typeof(double))
+        {
+            return Generate.Doubles().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(float))
+        {
+            return Generate.Floats().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(string))
+        {
+            return BuildStringStrategy(property);
+        }
+
+        if (underlying == typeof(Guid))
+        {
+            return Generate.Guids().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(DateTime))
+        {
+            return Generate.DateTimes().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(DateTimeOffset))
+        {
+            return Generate.DateTimeOffsets().Select(static v => (object?)v);
+        }
+
+        if (underlying == typeof(byte[]))
+        {
+            int maxLength = property.GetMaxLength() ?? 256;
+            return Generate.Integers<int>(0, maxLength)
+                .SelectMany(len => Generate.Bytes(len))
+                .Select(static b => (object?)b);
+        }
+
+        if (underlying.IsEnum)
+        {
+            object[] values = Enum.GetValues(underlying) is object[] arr ? arr : Array.Empty<object>();
+            return Generate.SampledFrom(values).Select(v => (object?)v);
+        }
+
+        return Generate.Constant<object?>(null);
+    }
+
+    private static Strategy<object?> BuildDecimalStrategy(IProperty property)
+    {
+        int? precision = property.GetPrecision();
+        int? scale = property.GetScale();
+
+        if (precision is null || scale is null)
+        {
+            return Generate.Decimals().Select(static v => (object?)v);
+        }
+
+        int integerDigits = precision.Value - scale.Value;
+        decimal maxMagnitude = 1m;
+        for (int i = 0; i < integerDigits; i++)
+        {
+            maxMagnitude *= 10m;
+        }
+
+        decimal scaleMultiplier = 1m;
+        for (int i = 0; i < scale.Value; i++)
+        {
+            scaleMultiplier *= 10m;
+        }
+
+        decimal mag = maxMagnitude;
+        decimal mult = scaleMultiplier;
+
+        return Generate.Decimals(-mag, mag).Select(v =>
+        {
+            decimal rounded = Math.Truncate(v * mult) / mult;
+            return (object?)rounded;
+        });
+    }
+
+    private static Strategy<object?> BuildStringStrategy(IProperty property)
+    {
+        int maxLength = property.GetMaxLength() ?? 4096;
+        return Generate.Strings(minLength: 0, maxLength: maxLength).Select(static s => (object?)s);
+    }
+}

--- a/src/Conjecture.EFCore/PublicAPI.Shipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -1,3 +1,8 @@
 #nullable enable
+Conjecture.EFCore.EntityStrategyBuilder
+Conjecture.EFCore.EntityStrategyBuilder.EntityStrategyBuilder(Microsoft.EntityFrameworkCore.Metadata.IModel! model) -> void
+Conjecture.EFCore.EntityStrategyBuilder.WithMaxDepth(int depth) -> Conjecture.EFCore.EntityStrategyBuilder!
+Conjecture.EFCore.EntityStrategyBuilder.WithoutNavigation<TEntity>(System.Linq.Expressions.Expression<System.Func<TEntity!, object?>!>! navigation) -> Conjecture.EFCore.EntityStrategyBuilder!
+Conjecture.EFCore.EntityStrategyBuilder.Build<TEntity>() -> Conjecture.Core.Strategy<TEntity!>!
 Conjecture.EFCore.PropertyStrategyBuilder
 static Conjecture.EFCore.PropertyStrategyBuilder.Build(Microsoft.EntityFrameworkCore.Metadata.IProperty! property) -> Conjecture.Core.Strategy<object?>!

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -10,3 +10,8 @@ Conjecture.EFCore.EFCoreGenerateExtensions
 Conjecture.EFCore.EFCoreGenerateExtensions.extension(Conjecture.Core.Generate!)
 static Conjecture.EFCore.EFCoreGenerateExtensions.extension(Conjecture.Core.Generate!).Entity<T>(Microsoft.EntityFrameworkCore.DbContext! context, int maxDepth = 2) -> Conjecture.Core.Strategy<T!>!
 static Conjecture.EFCore.EFCoreGenerateExtensions.extension(Conjecture.Core.Generate!).Entity<T>(System.Func<Microsoft.EntityFrameworkCore.DbContext!>! contextFactory, int maxDepth = 2) -> Conjecture.Core.Strategy<T!>!
+Conjecture.EFCore.RoundtripAssertionException
+Conjecture.EFCore.RoundtripAssertionException.RoundtripAssertionException(string! message) -> void
+Conjecture.EFCore.RoundtripAsserter
+static Conjecture.EFCore.RoundtripAsserter.AssertRoundtripAsync<TEntity>(System.Func<Microsoft.EntityFrameworkCore.DbContext!>! factory, TEntity! entity, System.Collections.Generic.IEqualityComparer<TEntity!>? comparer = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Conjecture.EFCore.RoundtripAsserter.AssertNoTrackingMatchesTrackedAsync<TEntity>(System.Func<Microsoft.EntityFrameworkCore.DbContext!>! factory, TEntity! entity, System.Collections.Generic.IEqualityComparer<TEntity!>? comparer = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -35,7 +35,13 @@ Conjecture.EFCore.DbInteraction.Op.init -> void
 Conjecture.EFCore.DbInteraction.Payload.get -> object?
 Conjecture.EFCore.DbInteraction.Payload.init -> void
 Conjecture.EFCore.IDbTarget
+Conjecture.EFCore.IDbTarget.ResourceName.get -> string!
 Conjecture.EFCore.IDbTarget.ResolveContext(string! resourceName) -> Microsoft.EntityFrameworkCore.DbContext!
+Conjecture.EFCore.DbInvariantExtensions
+static Conjecture.EFCore.DbInvariantExtensions.AssertRoundtripAsync<TEntity>(this Conjecture.EFCore.IDbTarget! target, TEntity! entity, System.Collections.Generic.IEqualityComparer<TEntity!>? comparer = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Conjecture.EFCore.DbInvariantExtensions.AssertConcurrencyTokenRespectedAsync<TEntity>(this Conjecture.EFCore.IDbTarget! target, TEntity! entity, System.Action<TEntity!>! mutateFirst, System.Action<TEntity!>! mutateSecond, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Conjecture.EFCore.DbInvariantExtensions.AssertNoOrphansAsync(this Conjecture.EFCore.IDbTarget! target, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+static Conjecture.EFCore.DbInvariantExtensions.AssertNoTrackingMatchesTrackedAsync<TEntity>(this Conjecture.EFCore.IDbTarget! target, TEntity! entity, System.Collections.Generic.IEqualityComparer<TEntity!>? comparer = null, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Conjecture.EFCore.InMemoryDbTarget
 Conjecture.EFCore.InMemoryDbTarget.InMemoryDbTarget(string! resourceName, System.Func<Microsoft.EntityFrameworkCore.DbContext!>! contextFactory) -> void
 Conjecture.EFCore.InMemoryDbTarget.ResourceName.get -> string!

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -34,3 +34,18 @@ Conjecture.EFCore.DbInteraction.Op.get -> Conjecture.EFCore.DbOpKind
 Conjecture.EFCore.DbInteraction.Op.init -> void
 Conjecture.EFCore.DbInteraction.Payload.get -> object?
 Conjecture.EFCore.DbInteraction.Payload.init -> void
+Conjecture.EFCore.IDbTarget
+Conjecture.EFCore.IDbTarget.ResolveContext(string! resourceName) -> Microsoft.EntityFrameworkCore.DbContext!
+Conjecture.EFCore.InMemoryDbTarget
+Conjecture.EFCore.InMemoryDbTarget.InMemoryDbTarget(string! resourceName, System.Func<Microsoft.EntityFrameworkCore.DbContext!>! contextFactory) -> void
+Conjecture.EFCore.InMemoryDbTarget.ResourceName.get -> string!
+Conjecture.EFCore.InMemoryDbTarget.ResolveContext(string! resourceName) -> Microsoft.EntityFrameworkCore.DbContext!
+Conjecture.EFCore.InMemoryDbTarget.ResetAsync(string! resourceName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Conjecture.EFCore.InMemoryDbTarget.ExecuteAsync(Conjecture.Interactions.IInteraction! interaction, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
+Conjecture.EFCore.SqliteDbTarget
+Conjecture.EFCore.SqliteDbTarget.SqliteDbTarget(string! resourceName, System.Func<Microsoft.EntityFrameworkCore.DbContext!>! contextFactory) -> void
+Conjecture.EFCore.SqliteDbTarget.ResourceName.get -> string!
+Conjecture.EFCore.SqliteDbTarget.ResolveContext(string! resourceName) -> Microsoft.EntityFrameworkCore.DbContext!
+Conjecture.EFCore.SqliteDbTarget.ResetAsync(string! resourceName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Conjecture.EFCore.SqliteDbTarget.ExecuteAsync(Conjecture.Interactions.IInteraction! interaction, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
+Conjecture.EFCore.SqliteDbTarget.DisposeAsync() -> System.Threading.Tasks.ValueTask

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -15,3 +15,8 @@ Conjecture.EFCore.RoundtripAssertionException.RoundtripAssertionException(string
 Conjecture.EFCore.RoundtripAsserter
 static Conjecture.EFCore.RoundtripAsserter.AssertRoundtripAsync<TEntity>(System.Func<Microsoft.EntityFrameworkCore.DbContext!>! factory, TEntity! entity, System.Collections.Generic.IEqualityComparer<TEntity!>? comparer = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 static Conjecture.EFCore.RoundtripAsserter.AssertNoTrackingMatchesTrackedAsync<TEntity>(System.Func<Microsoft.EntityFrameworkCore.DbContext!>! factory, TEntity! entity, System.Collections.Generic.IEqualityComparer<TEntity!>? comparer = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Conjecture.EFCore.MigrationAssertionException
+Conjecture.EFCore.MigrationAssertionException.MigrationAssertionException(string! message) -> void
+Conjecture.EFCore.MigrationAssertionException.MigrationAssertionException(string! message, System.Exception! innerException) -> void
+Conjecture.EFCore.MigrationHarness
+static Conjecture.EFCore.MigrationHarness.AssertUpDownIdempotentAsync(Microsoft.EntityFrameworkCore.DbContext! context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Conjecture.EFCore.PropertyStrategyBuilder
+static Conjecture.EFCore.PropertyStrategyBuilder.Build(Microsoft.EntityFrameworkCore.Metadata.IProperty! property) -> Conjecture.Core.Strategy<object?>!

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -6,3 +6,7 @@ Conjecture.EFCore.EntityStrategyBuilder.WithoutNavigation<TEntity>(System.Linq.E
 Conjecture.EFCore.EntityStrategyBuilder.Build<TEntity>() -> Conjecture.Core.Strategy<TEntity!>!
 Conjecture.EFCore.PropertyStrategyBuilder
 static Conjecture.EFCore.PropertyStrategyBuilder.Build(Microsoft.EntityFrameworkCore.Metadata.IProperty! property) -> Conjecture.Core.Strategy<object?>!
+Conjecture.EFCore.EFCoreGenerateExtensions
+Conjecture.EFCore.EFCoreGenerateExtensions.extension(Conjecture.Core.Generate!)
+static Conjecture.EFCore.EFCoreGenerateExtensions.extension(Conjecture.Core.Generate!).Entity<T>(Microsoft.EntityFrameworkCore.DbContext! context, int maxDepth = 2) -> Conjecture.Core.Strategy<T!>!
+static Conjecture.EFCore.EFCoreGenerateExtensions.extension(Conjecture.Core.Generate!).Entity<T>(System.Func<Microsoft.EntityFrameworkCore.DbContext!>! contextFactory, int maxDepth = 2) -> Conjecture.Core.Strategy<T!>!

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -20,3 +20,17 @@ Conjecture.EFCore.MigrationAssertionException.MigrationAssertionException(string
 Conjecture.EFCore.MigrationAssertionException.MigrationAssertionException(string! message, System.Exception! innerException) -> void
 Conjecture.EFCore.MigrationHarness
 static Conjecture.EFCore.MigrationHarness.AssertUpDownIdempotentAsync(Microsoft.EntityFrameworkCore.DbContext! context, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Conjecture.EFCore.DbOpKind
+Conjecture.EFCore.DbOpKind.Add = 0 -> Conjecture.EFCore.DbOpKind
+Conjecture.EFCore.DbOpKind.Update = 1 -> Conjecture.EFCore.DbOpKind
+Conjecture.EFCore.DbOpKind.Remove = 2 -> Conjecture.EFCore.DbOpKind
+Conjecture.EFCore.DbOpKind.SaveChanges = 3 -> Conjecture.EFCore.DbOpKind
+Conjecture.EFCore.DbOpKind.Query = 4 -> Conjecture.EFCore.DbOpKind
+Conjecture.EFCore.DbInteraction
+Conjecture.EFCore.DbInteraction.DbInteraction(string! ResourceName, Conjecture.EFCore.DbOpKind Op, object? Payload) -> void
+Conjecture.EFCore.DbInteraction.ResourceName.get -> string!
+Conjecture.EFCore.DbInteraction.ResourceName.init -> void
+Conjecture.EFCore.DbInteraction.Op.get -> Conjecture.EFCore.DbOpKind
+Conjecture.EFCore.DbInteraction.Op.init -> void
+Conjecture.EFCore.DbInteraction.Payload.get -> object?
+Conjecture.EFCore.DbInteraction.Payload.init -> void

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -49,3 +49,12 @@ Conjecture.EFCore.SqliteDbTarget.ResolveContext(string! resourceName) -> Microso
 Conjecture.EFCore.SqliteDbTarget.ResetAsync(string! resourceName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Conjecture.EFCore.SqliteDbTarget.ExecuteAsync(Conjecture.Interactions.IInteraction! interaction, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task<object?>!
 Conjecture.EFCore.SqliteDbTarget.DisposeAsync() -> System.Threading.Tasks.ValueTask
+Conjecture.EFCore.GenerateDbBlock
+Conjecture.EFCore.GenerateDbBlock.Add<T>(string! resourceName, Microsoft.EntityFrameworkCore.Metadata.IModel! model, int maxDepth = 2) -> Conjecture.Core.Strategy<Conjecture.EFCore.DbInteraction!>!
+Conjecture.EFCore.GenerateDbBlock.Update<T>(string! resourceName, Microsoft.EntityFrameworkCore.Metadata.IModel! model, int maxDepth = 2) -> Conjecture.Core.Strategy<Conjecture.EFCore.DbInteraction!>!
+Conjecture.EFCore.GenerateDbBlock.Remove<T>(string! resourceName, Microsoft.EntityFrameworkCore.Metadata.IModel! model) -> Conjecture.Core.Strategy<Conjecture.EFCore.DbInteraction!>!
+Conjecture.EFCore.GenerateDbBlock.SaveChanges(string! resourceName) -> Conjecture.Core.Strategy<Conjecture.EFCore.DbInteraction!>!
+Conjecture.EFCore.GenerateDbBlock.Sequence(string! resourceName, Microsoft.EntityFrameworkCore.Metadata.IModel! model, int min = 1, int max = 5) -> Conjecture.Core.Strategy<System.Collections.Generic.IReadOnlyList<Conjecture.EFCore.DbInteraction!>!>!
+Conjecture.EFCore.DbGenerateExtensions
+Conjecture.EFCore.DbGenerateExtensions.extension(Conjecture.Core.Generate!)
+static Conjecture.EFCore.DbGenerateExtensions.extension(Conjecture.Core.Generate!).Db.get -> Conjecture.EFCore.GenerateDbBlock!

--- a/src/Conjecture.EFCore/README.md
+++ b/src/Conjecture.EFCore/README.md
@@ -1,0 +1,17 @@
+# Conjecture.EFCore
+
+Property-based testing for Entity Framework Core, built on [Conjecture.NET](https://github.com/kommundsen/Conjecture).
+
+Derives entity-graph strategies mechanically from `IModel`, asserts `SaveChanges` roundtrip integrity, verifies migration up/down symmetry, and exposes `DbInteraction`/`IDbTarget` so EF Core composes with HTTP, gRPC, and messaging under a single `InteractionStateMachine<TState>`.
+
+```csharp
+[Property]
+public async Task Order_Roundtrips_Without_Loss()
+{
+    Strategy<Order> orders = Generate.Entity<Order>(factory.Create);
+    Order order = orders.Sample();
+    await RoundtripAsserter.AssertRoundtripAsync(factory.Create, order);
+}
+```
+
+See [ADR 0065](../../docs/decisions/0065-conjecture-efcore-package-design.md) for design.

--- a/src/Conjecture.EFCore/RoundtripAsserter.cs
+++ b/src/Conjecture.EFCore/RoundtripAsserter.cs
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Asserts that entities roundtrip through EF Core without data loss.</summary>
+public static class RoundtripAsserter
+{
+    /// <summary>
+    /// Saves <paramref name="entity"/> via <paramref name="factory"/>, reloads it in a fresh context,
+    /// and asserts equality using <paramref name="comparer"/> (or a default scalar-property comparer).
+    /// </summary>
+    public static async Task AssertRoundtripAsync<TEntity>(
+        Func<DbContext> factory,
+        TEntity entity,
+        IEqualityComparer<TEntity>? comparer = null,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(entity);
+
+        object?[] keyValues;
+
+        await using DbContext saveContext = factory();
+        saveContext.Add(entity);
+        await saveContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        keyValues = GetKeyValues(saveContext, entity);
+        await saveContext.DisposeAsync().ConfigureAwait(false);
+
+        await using DbContext readContext = factory();
+        TEntity? reloaded = await readContext.Set<TEntity>().FindAsync(keyValues, cancellationToken).ConfigureAwait(false);
+
+        if (reloaded is null)
+        {
+            throw new RoundtripAssertionException(
+                FormattableString.Invariant($"Entity of type '{typeof(TEntity).Name}' could not be reloaded after save."));
+        }
+
+        AssertEqual(readContext.Model, entity, reloaded, comparer, "roundtrip reload");
+    }
+
+    /// <summary>
+    /// Saves <paramref name="entity"/>, then compares the tracked read against an AsNoTracking read,
+    /// asserting they are equal using <paramref name="comparer"/> (or a default scalar-property comparer).
+    /// </summary>
+    public static async Task AssertNoTrackingMatchesTrackedAsync<TEntity>(
+        Func<DbContext> factory,
+        TEntity entity,
+        IEqualityComparer<TEntity>? comparer = null,
+        CancellationToken cancellationToken = default)
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        ArgumentNullException.ThrowIfNull(entity);
+
+        object?[] keyValues;
+
+        await using DbContext saveContext = factory();
+        saveContext.Add(entity);
+        await saveContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        keyValues = GetKeyValues(saveContext, entity);
+        await saveContext.DisposeAsync().ConfigureAwait(false);
+
+        await using DbContext trackedContext = factory();
+        TEntity? tracked = await trackedContext.Set<TEntity>().FindAsync(keyValues, cancellationToken).ConfigureAwait(false);
+
+        if (tracked is null)
+        {
+            throw new RoundtripAssertionException(
+                FormattableString.Invariant($"Entity of type '{typeof(TEntity).Name}' could not be reloaded (tracked) after save."));
+        }
+
+        await trackedContext.DisposeAsync().ConfigureAwait(false);
+
+        await using DbContext noTrackingContext = factory();
+        IEntityType entityType = noTrackingContext.Model.FindEntityType(typeof(TEntity))
+            ?? throw new InvalidOperationException(FormattableString.Invariant($"Entity type '{typeof(TEntity).Name}' not found in model."));
+
+        IKey primaryKey = entityType.FindPrimaryKey()
+            ?? throw new InvalidOperationException(FormattableString.Invariant($"Entity type '{typeof(TEntity).Name}' has no primary key."));
+
+        IQueryable<TEntity> query = noTrackingContext.Set<TEntity>().AsNoTracking();
+        foreach ((IProperty keyProp, object? keyVal) in primaryKey.Properties.Zip(keyValues))
+        {
+            object? capturedVal = keyVal;
+            string propName = keyProp.Name;
+            query = query.Where(e => EF.Property<object>(e, propName) == capturedVal);
+        }
+
+        TEntity? noTracking = await query.FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (noTracking is null)
+        {
+            throw new RoundtripAssertionException(
+                FormattableString.Invariant($"Entity of type '{typeof(TEntity).Name}' could not be reloaded (no-tracking) after save."));
+        }
+
+        AssertEqual(noTrackingContext.Model, tracked, noTracking, comparer, "no-tracking vs tracked");
+    }
+
+    private static object?[] GetKeyValues<TEntity>(DbContext context, TEntity entity) where TEntity : class
+    {
+        IEntityType entityType = context.Model.FindEntityType(typeof(TEntity))
+            ?? throw new InvalidOperationException(FormattableString.Invariant($"Entity type '{typeof(TEntity).Name}' not found in model."));
+
+        IKey primaryKey = entityType.FindPrimaryKey()
+            ?? throw new InvalidOperationException(FormattableString.Invariant($"Entity type '{typeof(TEntity).Name}' has no primary key."));
+
+        return [.. primaryKey.Properties.Select(p => p.PropertyInfo!.GetValue(entity))];
+    }
+
+    private static void AssertEqual<TEntity>(
+        IModel model,
+        TEntity expected,
+        TEntity actual,
+        IEqualityComparer<TEntity>? comparer,
+        string phase)
+        where TEntity : class
+    {
+        if (comparer is not null)
+        {
+            if (!comparer.Equals(expected, actual))
+            {
+                string diffDetail = BuildScalarDiff(model, expected, actual);
+                throw new RoundtripAssertionException(
+                    FormattableString.Invariant($"Roundtrip assertion failed ({phase}): comparer reported inequality.{diffDetail}"));
+            }
+
+            return;
+        }
+
+        string defaultDiff = BuildScalarDiff(model, expected, actual);
+        if (defaultDiff.Length > 0)
+        {
+            throw new RoundtripAssertionException(
+                FormattableString.Invariant($"Roundtrip assertion failed ({phase}):{defaultDiff}"));
+        }
+    }
+
+    private static string BuildScalarDiff<TEntity>(IModel model, TEntity expected, TEntity actual)
+        where TEntity : class
+    {
+        IEntityType? entityType = model.FindEntityType(typeof(TEntity));
+        if (entityType is null)
+        {
+            return string.Empty;
+        }
+
+        StringBuilder sb = new();
+
+        foreach (IProperty prop in entityType.GetProperties())
+        {
+            System.Reflection.PropertyInfo? propInfo = prop.PropertyInfo;
+            if (propInfo is null)
+            {
+                continue;
+            }
+
+            object? expectedVal = propInfo.GetValue(expected);
+            object? actualVal = propInfo.GetValue(actual);
+
+            if (!Equals(expectedVal, actualVal))
+            {
+                sb.Append(CultureInfo.InvariantCulture, $" Property '{prop.Name}': expected '{expectedVal}', got '{actualVal}'.");
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Conjecture.EFCore/RoundtripAssertionException.cs
+++ b/src/Conjecture.EFCore/RoundtripAssertionException.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Thrown when a roundtrip assertion fails.</summary>
+public sealed class RoundtripAssertionException(string message) : Exception(message)
+{
+}

--- a/src/Conjecture.EFCore/SqliteDbTarget.cs
+++ b/src/Conjecture.EFCore/SqliteDbTarget.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Conjecture.Interactions;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore;
+
+/// <summary>SQLite-backed interaction target, keyed by a single resource name.</summary>
+public sealed class SqliteDbTarget(string resourceName, Func<DbContext> contextFactory) : IDbTarget, IAsyncDisposable
+{
+    private readonly Func<DbContext> contextFactory = contextFactory
+        ?? throw new ArgumentNullException(nameof(contextFactory));
+
+    private bool disposed;
+
+    /// <summary>Gets the resource name this target is registered under.</summary>
+    public string ResourceName { get; } = string.IsNullOrEmpty(resourceName)
+        ? throw new ArgumentException("Resource name must not be null or empty.", nameof(resourceName))
+        : resourceName;
+
+    /// <inheritdoc/>
+    public DbContext ResolveContext(string resourceName)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        return resourceName == ResourceName
+            ? contextFactory()
+            : throw new InvalidOperationException(
+                $"Unknown resource '{resourceName}'; this target is registered for '{ResourceName}'.");
+    }
+
+    /// <inheritdoc/>
+    public async Task ResetAsync(string resourceName, CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+
+        if (resourceName != ResourceName)
+        {
+            throw new InvalidOperationException(
+                $"Unknown resource '{resourceName}'; this target is registered for '{ResourceName}'.");
+        }
+
+        await using DbContext ctx = contextFactory();
+        await ctx.Database.EnsureDeletedAsync(cancellationToken).ConfigureAwait(false);
+        await ctx.Database.EnsureCreatedAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public Task<object?> ExecuteAsync(IInteraction interaction, CancellationToken ct) =>
+        throw new NotImplementedException("Dispatch logic will be implemented in a subsequent cycle.");
+
+    /// <inheritdoc/>
+    public ValueTask DisposeAsync()
+    {
+        disposed = true;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Conjecture.Mcp.Tests/EFCoreSetupResourceTests.cs
+++ b/src/Conjecture.Mcp.Tests/EFCoreSetupResourceTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using Conjecture.Mcp.Resources;
+
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace Conjecture.Mcp.Tests;
+
+public class EFCoreSetupResourceTests
+{
+    private static RequestContext<T> MakeUninitializedContext<T>()
+        where T : class
+    {
+        Type contextType = typeof(RequestContext<T>);
+        object ctx = RuntimeHelpers.GetUninitializedObject(contextType);
+        return (RequestContext<T>)ctx;
+    }
+
+    private static RequestContext<ReadResourceRequestParams> MakeReadContext(string uri)
+    {
+        Type contextType = typeof(RequestContext<ReadResourceRequestParams>);
+        object ctx = RuntimeHelpers.GetUninitializedObject(contextType);
+        FieldInfo field = contextType.GetField(
+            "<Params>k__BackingField",
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(ctx, new ReadResourceRequestParams { Uri = uri });
+        return (RequestContext<ReadResourceRequestParams>)ctx;
+    }
+
+    [Fact]
+    public async Task EFCoreSetupResource_ExistsInListResources()
+    {
+        ListResourcesResult result = await ApiReferenceResources.HandleListResources(
+            MakeUninitializedContext<ListResourcesRequestParams>(), default);
+
+        Assert.Contains(result.Resources, r => r.Uri == "conjecture://api/efcore-setup");
+    }
+
+    [Theory]
+    [InlineData("Generate.Entity")]
+    [InlineData("Generate.EntitySet")]
+    [InlineData("RoundtripAsserter")]
+    [InlineData("MigrationHarness")]
+    public async Task EFCoreSetupResource_ExistsAndContainsExpectedSnippets(string expectedTerm)
+    {
+        RequestContext<ReadResourceRequestParams> context =
+            MakeReadContext("conjecture://api/efcore-setup");
+
+        ReadResourceResult result = await ApiReferenceResources.HandleReadResource(
+            context, default);
+
+        TextResourceContents contents = Assert.IsType<TextResourceContents>(result.Contents[0]);
+        Assert.Contains(expectedTerm, contents.Text);
+    }
+}

--- a/src/Conjecture.Mcp.Tests/Tools/StrategyToolsEFCoreTypesTests.cs
+++ b/src/Conjecture.Mcp.Tests/Tools/StrategyToolsEFCoreTypesTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Mcp.Tools;
+
+namespace Conjecture.Mcp.Tests.Tools;
+
+public class StrategyToolsEFCoreTypesTests
+{
+    [Fact]
+    public void StrategyTools_SuggestStrategy_DbContext_ReturnsEFCoreEntityStrategySuggestion()
+    {
+        string result = StrategyTools.SuggestForType("DbContext");
+
+        Assert.Contains("Generate.Entity", result);
+    }
+
+    [Fact]
+    public void StrategyTools_SuggestStrategy_EntityRegisteredInModel_ReturnsEntitySetSuggestion()
+    {
+        string result = StrategyTools.SuggestForType("EntitySet");
+
+        Assert.Contains("Generate.EntitySet", result);
+    }
+
+    [Fact]
+    public void StrategyTools_SuggestStrategy_NonEntityType_DoesNotMentionEFCore()
+    {
+        string result = StrategyTools.SuggestForType("int");
+
+        Assert.DoesNotContain("Generate.EFCore", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("EntityStrategyBuilder", result, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Conjecture.Mcp/Docs/efcore-setup.md
+++ b/src/Conjecture.Mcp/Docs/efcore-setup.md
@@ -1,0 +1,72 @@
+# Conjecture.EFCore Setup Guide
+
+Step-by-step guide for wiring up `Conjecture.EFCore` in a test project.
+
+## 1. Add the NuGet package
+
+```xml
+<PackageReference Include="Conjecture.EFCore" />
+```
+
+## 2. Generate entities with `Generate.Entity<T>`
+
+Use `Generate.Entity<T>(context)` to produce property-based strategies for EF Core entity types tracked by a `DbContext`:
+
+```csharp
+using Conjecture.EFCore;
+
+[Property]
+public async Task OrderRoundtrips(AppDbContext db, Strategy<Order> orderStrategy)
+{
+    Order order = orderStrategy.Example();
+    await RoundtripAsserter.AssertRoundtripsAsync(db, order);
+}
+```
+
+The strategy draws values that satisfy all EF Core model constraints registered on the entity.
+
+## 3. Sample existing rows with `Generate.EntitySet<T>`
+
+Use `Generate.EntitySet<T>(context)` to draw from rows already persisted in the database:
+
+```csharp
+using Conjecture.EFCore;
+
+Generate.EntitySet<Order>(db)
+// → Strategy<Order> sampling from existing rows in DbSet<Order>
+```
+
+## 4. Assert roundtrips with `RoundtripAsserter`
+
+`RoundtripAsserter.AssertRoundtripsAsync` saves an entity, reloads it, and asserts value equality:
+
+```csharp
+await RoundtripAsserter.AssertRoundtripsAsync(db, order);
+```
+
+If the reload does not match the original, a `RoundtripAssertionException` is thrown with a diff.
+
+## 5. Test schema migrations with `MigrationHarness`
+
+`MigrationHarness` applies all pending EF Core migrations and verifies the schema round-trips without data loss:
+
+```csharp
+using Conjecture.EFCore;
+
+await MigrationHarness.AssertMigrationsApplyCleanlyAsync<AppDbContext>(connectionString);
+```
+
+If a migration fails to apply or rolls back incorrectly, a `MigrationAssertionException` is thrown.
+
+## 6. Apply the `[Property]` attribute
+
+Use the standard `[Property]` attribute from your test framework adapter:
+
+```csharp
+[Property]
+public async Task OrdersRoundtripViaEFCore(AppDbContext db, Strategy<Order> strategy)
+{
+    Order order = strategy.Example();
+    await RoundtripAsserter.AssertRoundtripsAsync(db, order);
+}
+```

--- a/src/Conjecture.Mcp/Resources/ApiReferenceResources.cs
+++ b/src/Conjecture.Mcp/Resources/ApiReferenceResources.cs
@@ -23,6 +23,7 @@ internal static class ApiReferenceResources
         ("recursive-strategies", "Recursive Strategies",       "Generate.Recursive<T> for tree-shaped and self-referential types"),
         ("testing-platform",     "Microsoft Testing Platform Adapter", "Conjecture.TestingPlatform setup, [Property] attribute, CLI options, TRX reports, and CrashDump"),
         ("aspire-setup",         "Aspire Integration Setup",           "Step-by-step guide for wiring up Conjecture.Aspire: IAspireAppFixture, AspireStateMachine<TState>, ResetAsync lifecycle, and [Property] attribute"),
+        ("efcore-setup",         "EF Core Integration Setup",          "Step-by-step guide for wiring up Conjecture.EFCore: Generate.Entity, Generate.EntitySet, RoundtripAsserter, and MigrationHarness"),
     ];
 
     internal static ValueTask<ListResourcesResult> HandleListResources(

--- a/src/Conjecture.Mcp/Tools/StrategyTools.cs
+++ b/src/Conjecture.Mcp/Tools/StrategyTools.cs
@@ -363,6 +363,58 @@ internal static class StrategyTools
             Add the NuGet package: `Conjecture.Aspire`
             """,
 
+            "DbContext" =>
+                """
+            This type is an EF Core `DbContext`. Use `Generate.Entity<T>(context)` from `Conjecture.EFCore` to generate entities registered in the model:
+
+            ```csharp
+            using Conjecture.EFCore;
+
+            Generate.Entity<Order>(db)
+            // → Strategy<Order> drawing entities tracked by the DbContext
+            ```
+
+            Add the NuGet package: `Conjecture.EFCore`
+            """,
+
+            "EntitySet" =>
+                """
+            This type appears to be an EF Core entity. Use `Generate.EntitySet<T>(context)` from `Conjecture.EFCore` to draw from the full set persisted in the database:
+
+            ```csharp
+            using Conjecture.EFCore;
+
+            Generate.EntitySet<Order>(db)
+            // → Strategy<Order> sampling from existing rows in the DbSet<Order>
+            ```
+
+            For roundtrip testing, use `RoundtripAsserter`:
+            ```csharp
+            await RoundtripAsserter.AssertRoundtripsAsync(db, entity);
+            ```
+
+            Add the NuGet package: `Conjecture.EFCore`
+            """,
+
+            _ when typeName.StartsWith("DbSet<", StringComparison.Ordinal) =>
+                """
+            This type appears to be an EF Core entity. Use `Generate.EntitySet<T>(context)` from `Conjecture.EFCore` to draw from the full set persisted in the database:
+
+            ```csharp
+            using Conjecture.EFCore;
+
+            Generate.EntitySet<Order>(db)
+            // → Strategy<Order> sampling from existing rows in the DbSet<Order>
+            ```
+
+            For roundtrip testing, use `RoundtripAsserter`:
+            ```csharp
+            await RoundtripAsserter.AssertRoundtripsAsync(db, entity);
+            ```
+
+            Add the NuGet package: `Conjecture.EFCore`
+            """,
+
             _ when typeName.StartsWith("List<", StringComparison.Ordinal) =>
                 SuggestList(InnerType(typeName)),
 

--- a/src/Conjecture.slnx
+++ b/src/Conjecture.slnx
@@ -61,4 +61,6 @@
   <Project Path="Conjecture.AspNetCore.Tests/Conjecture.AspNetCore.Tests.csproj" />
   <Project Path="Conjecture.Aspire/Conjecture.Aspire.csproj" />
   <Project Path="Conjecture.Aspire.Tests/Conjecture.Aspire.Tests.csproj" />
+  <Project Path="Conjecture.EFCore/Conjecture.EFCore.csproj" />
+  <Project Path="Conjecture.EFCore.Tests/Conjecture.EFCore.Tests.csproj" />
 </Solution>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,6 +17,7 @@
     <!-- Database -->
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,6 +16,9 @@
 
     <!-- Database -->
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
 
     <!-- Benchmarking -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />


### PR DESCRIPTION
## Description

Implements `Conjecture.EFCore` — a satellite package providing model-derived entity strategies (`PropertyStrategyBuilder`, `EntityStrategyBuilder`, `Generate.Entity<T>`), `RoundtripAsserter`, `MigrationHarness`, and the Layer-1 interaction surface (`DbInteraction`, `IDbTarget`, `Generate.Db`, `DbInvariantExtensions`) so EF Core composes with the existing HTTP, gRPC, and messaging transports under a single `InteractionStateMachine<TState>`.

Architecture decision in [ADR 0065](docs/decisions/0065-conjecture-efcore-package-design.md): SQLite in-memory default; bounded navigation depth (=2, aligned with `Generate.Recursive()`); type-system-only constraint scope for v1 (no `CheckConstraint` evaluation); runtime reflection over `IModel` (no Roslyn codegen); migration up/down harness in scope; LINQ-shape fuzzing deferred to a future `Conjecture.EFCore.Linq`.

61 new tests in `Conjecture.EFCore.Tests` plus 8 in `Conjecture.Mcp.Tests` (suggest-strategy / setup resource). Full `dotnet test src/` passes (≈2600 tests across the solution).

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #291

## Cycles included

- a92b9d4 ADR: EF Core integration design
- 589ffa6 Scaffold Conjecture.EFCore project and package structure
- ed2efb8 PropertyStrategyBuilder: map IProperty metadata to primitive strategies
- 6b9731e EntityStrategyBuilder: compose entity graph from IModel with bounded depth
- f408cd3 EFCoreGenerate: extension block factory methods on Generate
- 3479397 RoundtripAsserter: SaveChanges roundtrip helper with tracked and no-tracking reads
- e3a6d53 MigrationHarness: up/down snapshot migration invariant
- b50a304 Conjecture.Mcp: surface EFCore entity strategies in suggest-strategy tool
- 050cdff Docs: Conjecture.EFCore how-to, reference, and explanation
- 1a02917 DbInteraction record: resource name, op kind, payload
- bf5bfc5 IDbTarget + InMemoryDbTarget + SqliteDbTarget
- b547a46 Generate.Db: Strategy<DbInteraction> builder over EntityStrategyBuilder
- 3c9f734 DbInvariantExtensions: Roundtrip, ConcurrencyToken, NoOrphans
- af6834a Add Conjecture.EFCore README to fix pack conflict