### PR TITLE
[582] Conjecture.EFCore: hardening for composite scenarios

### DIFF
--- a/src/Conjecture.Aspire.Tests/AspirePropertyRunnerTests.cs
+++ b/src/Conjecture.Aspire.Tests/AspirePropertyRunnerTests.cs
@@ -249,7 +249,7 @@ public class AspirePropertyRunnerTests
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/", null))];
 
         public override string RunCommand(string state, Interaction cmd)
         {
@@ -311,7 +311,7 @@ public class AspirePropertyRunnerTests
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/", null))];
 
         public override string RunCommand(string state, Interaction cmd)
             => throw new InvalidOperationException("example failure");
@@ -326,7 +326,7 @@ public class AspirePropertyRunnerTests
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/", null))];
 
         public override string RunCommand(string state, Interaction cmd)
         {
@@ -346,7 +346,7 @@ public class AspirePropertyRunnerTests
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/", null))];
 
         public override string RunCommand(string state, Interaction cmd) => state;
 

--- a/src/Conjecture.Aspire.Tests/Samples/ExpectoWiringSampleTests.cs
+++ b/src/Conjecture.Aspire.Tests/Samples/ExpectoWiringSampleTests.cs
@@ -119,7 +119,7 @@ public sealed class ExpectoWiringSampleTests
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/health", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/health", null))];
 
         public override string RunCommand(string state, Interaction cmd) => state;
 

--- a/src/Conjecture.Aspire.Tests/Samples/MSTestWiringSampleTests.cs
+++ b/src/Conjecture.Aspire.Tests/Samples/MSTestWiringSampleTests.cs
@@ -101,7 +101,7 @@ public sealed class MSTestWiringSampleTests
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/health", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/health", null))];
 
         public override string RunCommand(string state, Interaction cmd) => state;
 

--- a/src/Conjecture.Aspire.Tests/Samples/NUnitWiringSampleTests.cs
+++ b/src/Conjecture.Aspire.Tests/Samples/NUnitWiringSampleTests.cs
@@ -101,7 +101,7 @@ public sealed class NUnitWiringSampleTests
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/health", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/health", null))];
 
         public override string RunCommand(string state, Interaction cmd) => state;
 

--- a/src/Conjecture.Aspire.Tests/Samples/TestingPlatformWiringSampleTests.cs
+++ b/src/Conjecture.Aspire.Tests/Samples/TestingPlatformWiringSampleTests.cs
@@ -109,7 +109,7 @@ public sealed class TestingPlatformWiringSampleTests
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/health", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/health", null))];
 
         public override string RunCommand(string state, Interaction cmd) => state;
 

--- a/src/Conjecture.Aspire.Tests/Samples/XunitV2WiringSampleTests.cs
+++ b/src/Conjecture.Aspire.Tests/Samples/XunitV2WiringSampleTests.cs
@@ -71,7 +71,7 @@ public sealed class XunitV2WiringSampleTests(SampleAspireFixture fixture)
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/health", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/health", null))];
 
         public override string RunCommand(string state, Interaction cmd) => state;
 

--- a/src/Conjecture.Aspire.Tests/Samples/XunitV3WiringSampleTests.cs
+++ b/src/Conjecture.Aspire.Tests/Samples/XunitV3WiringSampleTests.cs
@@ -74,7 +74,7 @@ public sealed class XunitV3WiringSampleTests
         public override string InitialState() => string.Empty;
 
         public override IEnumerable<Strategy<Interaction>> Commands(string state)
-            => [Generate.Constant(new Interaction("svc", "GET", "/health", null))];
+            => [Generate.Just(new Interaction("svc", "GET", "/health", null))];
 
         public override string RunCommand(string state, Interaction cmd) => state;
 

--- a/src/Conjecture.Core/Generate.cs
+++ b/src/Conjecture.Core/Generate.cs
@@ -35,9 +35,6 @@ public static class Generate
     /// <summary>Returns a strategy that always produces <paramref name="value"/>.</summary>
     public static Strategy<T> Just<T>(T value) => new JustStrategy<T>(value);
 
-    /// <summary>Returns a strategy that always produces <paramref name="value"/>. Alias for <see cref="Just{T}"/>.</summary>
-    public static Strategy<T> Constant<T>(T value) => new JustStrategy<T>(value);
-
     /// <summary>Returns a strategy that picks uniformly among <paramref name="strategies"/>.</summary>
     public static Strategy<T> OneOf<T>(params Strategy<T>[] strategies)
     {

--- a/src/Conjecture.Core/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Shipped.txt
@@ -227,4 +227,3 @@ static Conjecture.Core.GenerateForRegistry.Register(System.Type! type, System.Fu
 static Conjecture.Core.GenerateForRegistry.RegisterOverride(System.Type! type, System.Func<object!, object!>! factory) -> void
 static Conjecture.Core.GenerateForRegistry.ResolveBoxed(System.Type! type) -> Conjecture.Core.Strategy<object?>!
 static Conjecture.Core.GenerateForRegistry.ResolveWithOverrides<T>(Conjecture.Core.ForConfiguration<T>! cfg) -> Conjecture.Core.Strategy<T>!
-static Conjecture.Core.Generate.Constant<T>(T value) -> Conjecture.Core.Strategy<T>!

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+*REMOVED*static Conjecture.Core.Generate.Constant<T>(T value) -> Conjecture.Core.Strategy<T>!

--- a/src/Conjecture.EFCore.Tests/DbInvariantExceptionHierarchyTests.cs
+++ b/src/Conjecture.EFCore.Tests/DbInvariantExceptionHierarchyTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+using Conjecture.EFCore;
+
+using Xunit;
+
+namespace Conjecture.EFCore.Tests;
+
+public class DbInvariantExceptionHierarchyTests
+{
+    [Fact]
+    public void DbInvariantException_TypeExists()
+    {
+        Type type = typeof(DbInvariantException);
+        Assert.Equal("Conjecture.EFCore", type.Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void DbInvariantException_IsNotSealed()
+    {
+        Assert.False(typeof(DbInvariantException).IsSealed);
+    }
+
+    [Fact]
+    public void DbInvariantException_DerivesFromException()
+    {
+        Assert.True(typeof(Exception).IsAssignableFrom(typeof(DbInvariantException)));
+    }
+
+    [Fact]
+    public void DbInvariantException_Message_Roundtrips()
+    {
+        DbInvariantException ex = new("hello");
+        Assert.Equal("hello", ex.Message);
+    }
+
+    [Fact]
+    public void DbInvariantException_InnerException_Roundtrips()
+    {
+        DbInvariantException ex = new("outer", new InvalidOperationException("inner"));
+        Assert.True(ex.InnerException is InvalidOperationException ioe && ioe.Message == "inner");
+    }
+
+    [Fact]
+    public void RoundtripAssertionException_IsDbInvariantException()
+    {
+        Assert.True(typeof(DbInvariantException).IsAssignableFrom(typeof(RoundtripAssertionException)));
+    }
+
+    [Fact]
+    public void MigrationAssertionException_IsDbInvariantException()
+    {
+        Assert.True(typeof(DbInvariantException).IsAssignableFrom(typeof(MigrationAssertionException)));
+    }
+
+    [Fact]
+    public void Catch_DbInvariantException_HandlesBothDerivedTypes()
+    {
+        static void ThrowRoundtrip() => throw new RoundtripAssertionException("rt");
+        static void ThrowMigration() => throw new MigrationAssertionException("mg");
+
+        DbInvariantException caught1 = Assert.ThrowsAny<DbInvariantException>((Action)ThrowRoundtrip);
+        Assert.Equal("rt", caught1.Message);
+
+        DbInvariantException caught2 = Assert.ThrowsAny<DbInvariantException>((Action)ThrowMigration);
+        Assert.Equal("mg", caught2.Message);
+    }
+
+    [Fact]
+    public void RoundtripAssertionException_StillSealed()
+    {
+        Assert.True(typeof(RoundtripAssertionException).IsSealed);
+    }
+
+    [Fact]
+    public void MigrationAssertionException_StillSealed()
+    {
+        Assert.True(typeof(MigrationAssertionException).IsSealed);
+    }
+}

--- a/src/Conjecture.EFCore.Tests/DbTargetExecuteAsyncTests.cs
+++ b/src/Conjecture.EFCore.Tests/DbTargetExecuteAsyncTests.cs
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Conjecture.EFCore;
+using Conjecture.Interactions;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore.Tests;
+
+public class DbTargetExecuteAsyncTests
+{
+    // ---- test entities ----------------------------------------------------
+
+    private sealed class Order
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class OrderDbContext(DbContextOptions options) : DbContext(options)
+    {
+        public DbSet<Order> Orders => Set<Order>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+            });
+        }
+    }
+
+    // ---- stub interaction (not a DbInteraction) --------------------------
+
+    private sealed class StubInteraction : IInteraction { }
+
+    private sealed class StubInteractionTarget : IInteractionTarget
+    {
+        public Task<object?> ExecuteAsync(IInteraction interaction, CancellationToken ct) =>
+            Task.FromResult<object?>(null);
+    }
+
+    // ---- factories -------------------------------------------------------
+
+    private static InMemoryDbTarget CreateInMemoryTarget(string name = "test-db")
+    {
+        return new(name, () =>
+        {
+            DbContextOptions<OrderDbContext> opts = new DbContextOptionsBuilder<OrderDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new OrderDbContext(opts);
+        });
+    }
+
+    private static (SqliteDbTarget target, SqliteConnection connection) CreateSqliteTarget(string name = "test-db")
+    {
+        SqliteConnection conn = new("Data Source=:memory:");
+        conn.Open();
+        SqliteDbTarget target = new(name, () =>
+        {
+            DbContextOptions<OrderDbContext> opts = new DbContextOptionsBuilder<OrderDbContext>()
+                .UseSqlite(conn)
+                .Options;
+            return new OrderDbContext(opts);
+        });
+        DbContext setupCtx = target.ResolveContext(name);
+        setupCtx.Database.EnsureCreated();
+        return (target, conn);
+    }
+
+    // ---- InMemoryDbTarget tests ------------------------------------------
+
+    [Fact]
+    public async Task InMemory_ExecuteAsync_SaveChanges_OnEmptyContext_ReturnsZero()
+    {
+        InMemoryDbTarget target = CreateInMemoryTarget();
+        DbInteraction interaction = new("test-db", DbOpKind.SaveChanges, null);
+
+        object? result = await target.ExecuteAsync(interaction, CancellationToken.None);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public async Task InMemory_ExecuteAsync_Add_OnFreshContext_ReturnsNull()
+    {
+        InMemoryDbTarget target = CreateInMemoryTarget();
+        Order order = new() { Name = "Widget" };
+        DbInteraction interaction = new("test-db", DbOpKind.Add, order);
+
+        object? result = await target.ExecuteAsync(interaction, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    // ---- SqliteDbTarget tests --------------------------------------------
+
+    [Fact]
+    public async Task Sqlite_ExecuteAsync_Add_OnFreshContext_ReturnsNull()
+    {
+        (SqliteDbTarget target, SqliteConnection conn) = CreateSqliteTarget();
+        await using SqliteConnection _ = conn;
+        await using SqliteDbTarget __ = target;
+        Order order = new() { Name = "Widget" };
+        DbInteraction interaction = new("test-db", DbOpKind.Add, order);
+
+        object? result = await target.ExecuteAsync(interaction, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    // ---- validation tests (both targets) ---------------------------------
+
+    [Fact]
+    public async Task ExecuteAsync_NullInteraction_Throws_InMemory()
+    {
+        InMemoryDbTarget target = CreateInMemoryTarget();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => target.ExecuteAsync(null!, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullInteraction_Throws_Sqlite()
+    {
+        (SqliteDbTarget target, SqliteConnection conn) = CreateSqliteTarget();
+        await using SqliteConnection _ = conn;
+        await using SqliteDbTarget __ = target;
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => target.ExecuteAsync(null!, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonDbInteraction_Throws_InMemory()
+    {
+        InMemoryDbTarget target = CreateInMemoryTarget();
+        StubInteraction stub = new();
+
+        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => target.ExecuteAsync(stub, CancellationToken.None));
+        Assert.Contains(nameof(StubInteraction), ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NonDbInteraction_Throws_Sqlite()
+    {
+        (SqliteDbTarget target, SqliteConnection conn) = CreateSqliteTarget();
+        await using SqliteConnection _ = conn;
+        await using SqliteDbTarget __ = target;
+        StubInteraction stub = new();
+
+        InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => target.ExecuteAsync(stub, CancellationToken.None));
+        Assert.Contains(nameof(StubInteraction), ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_QueryOp_Throws_InMemory()
+    {
+        InMemoryDbTarget target = CreateInMemoryTarget();
+        DbInteraction interaction = new("test-db", DbOpKind.Query, null);
+
+        NotSupportedException ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => target.ExecuteAsync(interaction, CancellationToken.None));
+        Assert.Contains("Query", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_QueryOp_Throws_Sqlite()
+    {
+        (SqliteDbTarget target, SqliteConnection conn) = CreateSqliteTarget();
+        await using SqliteConnection _ = conn;
+        await using SqliteDbTarget __ = target;
+        DbInteraction interaction = new("test-db", DbOpKind.Query, null);
+
+        NotSupportedException ex = await Assert.ThrowsAsync<NotSupportedException>(
+            () => target.ExecuteAsync(interaction, CancellationToken.None));
+        Assert.Contains("Query", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Sqlite_ExecuteAsync_AfterDispose_Throws()
+    {
+        (SqliteDbTarget target, SqliteConnection conn) = CreateSqliteTarget();
+        await using SqliteConnection _ = conn;
+        await target.DisposeAsync();
+        DbInteraction interaction = new("test-db", DbOpKind.SaveChanges, null);
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => target.ExecuteAsync(interaction, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Composite_RoutesDbInteraction_SaveChanges_DoesNotThrow()
+    {
+        (SqliteDbTarget dbTarget, SqliteConnection conn) = CreateSqliteTarget("orders-db");
+        await using SqliteConnection _ = conn;
+        await using SqliteDbTarget __ = dbTarget;
+        StubInteractionTarget stub = new();
+
+        CompositeInteractionTarget composite = new(
+            ("other-target", stub),
+            ("orders-db", dbTarget));
+
+        DbInteraction interaction = new("orders-db", DbOpKind.SaveChanges, null);
+
+        object? result = await composite.ExecuteAsync(interaction, CancellationToken.None);
+
+        Assert.Equal(0, result);
+    }
+}

--- a/src/Conjecture.EFCore.Tests/EntitySnapshotTests.cs
+++ b/src/Conjecture.EFCore.Tests/EntitySnapshotTests.cs
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Threading.Tasks;
+
+using Conjecture.EFCore;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore.Tests;
+
+public class EntitySnapshotTests
+{
+    // ---- test entities ---------------------------------------------------
+
+    private sealed class Order
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+    }
+
+    // ---- DbContext -------------------------------------------------------
+
+    private sealed class OrderDbContext(DbContextOptions<OrderDbContext> options) : DbContext(options)
+    {
+        public DbSet<Order> Orders { get; set; } = null!;
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Order>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Id).ValueGeneratedOnAdd();
+                b.Property(e => e.Name).IsRequired();
+            });
+        }
+    }
+
+    // ---- helpers ---------------------------------------------------------
+
+    private static (SqliteConnection connection, SqliteDbTarget target) CreateTarget()
+    {
+        SqliteConnection connection = new("DataSource=:memory:");
+        connection.Open();
+
+        DbContextOptions<OrderDbContext> options = new DbContextOptionsBuilder<OrderDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        OrderDbContext seed = new(options);
+        seed.Database.EnsureCreated();
+        seed.Dispose();
+
+        SqliteDbTarget target = new("orders", () => new OrderDbContext(options));
+        return (connection, target);
+    }
+
+    // ---- tests -----------------------------------------------------------
+
+    [Fact]
+    public async Task CaptureAsync_EmptyDb_ReturnsZeroCounts()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget();
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        EntitySnapshot snapshot = await EntitySnapshotter.CaptureAsync(target);
+
+        Assert.Equal(0, snapshot.Counts[typeof(Order)]);
+        Assert.Empty(snapshot.Keys[typeof(Order)]);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_AfterAdd_ReflectsRow()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget();
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        await using (DbContext ctx = target.ResolveContext("orders"))
+        {
+            ctx.Set<Order>().Add(new Order { Name = "First" });
+            await ctx.SaveChangesAsync();
+        }
+
+        EntitySnapshot snapshot = await EntitySnapshotter.CaptureAsync(target);
+
+        Assert.Equal(1, snapshot.Counts[typeof(Order)]);
+        Assert.Single(snapshot.Keys[typeof(Order)]);
+    }
+
+    [Fact]
+    public async Task Diff_NoChange_IsEmpty()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget();
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        EntitySnapshot before = await EntitySnapshotter.CaptureAsync(target);
+        EntitySnapshot after = await EntitySnapshotter.CaptureAsync(target);
+
+        EntitySnapshotDiff diff = EntitySnapshotter.Diff(before, after);
+
+        Assert.True(diff.IsEmpty);
+    }
+
+    [Fact]
+    public async Task Diff_AddedRow_ReportsPositiveDelta()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget();
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        EntitySnapshot before = await EntitySnapshotter.CaptureAsync(target);
+
+        Order added = new() { Name = "New" };
+        await using (DbContext ctx = target.ResolveContext("orders"))
+        {
+            ctx.Set<Order>().Add(added);
+            await ctx.SaveChangesAsync();
+        }
+
+        EntitySnapshot after = await EntitySnapshotter.CaptureAsync(target);
+
+        EntitySnapshotDiff diff = EntitySnapshotter.Diff(before, after);
+
+        Assert.Equal(1, diff.CountDeltas[typeof(Order)]);
+        Assert.Contains(added.Id, diff.AddedKeys[typeof(Order)]);
+        Assert.False(diff.IsEmpty);
+    }
+
+    [Fact]
+    public async Task Diff_RemovedRow_ReportsNegativeDelta()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget();
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        Order existing = new() { Name = "ToRemove" };
+        await using (DbContext ctx = target.ResolveContext("orders"))
+        {
+            ctx.Set<Order>().Add(existing);
+            await ctx.SaveChangesAsync();
+        }
+
+        EntitySnapshot before = await EntitySnapshotter.CaptureAsync(target);
+
+        await using (DbContext ctx = target.ResolveContext("orders"))
+        {
+            ctx.Set<Order>().Remove(existing);
+            await ctx.SaveChangesAsync();
+        }
+
+        EntitySnapshot after = await EntitySnapshotter.CaptureAsync(target);
+
+        EntitySnapshotDiff diff = EntitySnapshotter.Diff(before, after);
+
+        Assert.Equal(-1, diff.CountDeltas[typeof(Order)]);
+        Assert.Contains(existing.Id, diff.RemovedKeys[typeof(Order)]);
+    }
+
+    [Fact]
+    public async Task Diff_NetZero_ButKeyChange_StillFlagsKeyDiff()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget();
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        Order rowA = new() { Name = "RowA" };
+        await using (DbContext ctx = target.ResolveContext("orders"))
+        {
+            ctx.Set<Order>().Add(rowA);
+            await ctx.SaveChangesAsync();
+        }
+
+        EntitySnapshot before = await EntitySnapshotter.CaptureAsync(target);
+
+        await using (DbContext ctx = target.ResolveContext("orders"))
+        {
+            ctx.Set<Order>().Remove(rowA);
+            ctx.Set<Order>().Add(new Order { Name = "RowB" });
+            await ctx.SaveChangesAsync();
+        }
+
+        EntitySnapshot after = await EntitySnapshotter.CaptureAsync(target);
+
+        EntitySnapshotDiff diff = EntitySnapshotter.Diff(before, after);
+
+        Assert.Equal(0, diff.CountDeltas[typeof(Order)]);
+        Assert.Contains(rowA.Id, diff.RemovedKeys[typeof(Order)]);
+        Assert.NotEmpty(diff.AddedKeys[typeof(Order)]);
+        Assert.False(diff.IsEmpty);
+    }
+
+    [Fact]
+    public async Task ToReport_IncludesEntityNamesAndKeys()
+    {
+        (SqliteConnection connection, SqliteDbTarget target) = CreateTarget();
+        await using SqliteConnection _ = connection;
+        await using SqliteDbTarget __ = target;
+
+        EntitySnapshot before = await EntitySnapshotter.CaptureAsync(target);
+
+        await using (DbContext ctx = target.ResolveContext("orders"))
+        {
+            ctx.Set<Order>().Add(new Order { Name = "Reported" });
+            await ctx.SaveChangesAsync();
+        }
+
+        EntitySnapshot after = await EntitySnapshotter.CaptureAsync(target);
+
+        EntitySnapshotDiff diff = EntitySnapshotter.Diff(before, after);
+        string report = diff.ToReport();
+
+        Assert.Contains("Order", report);
+        Assert.Contains("+1", report);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_NullTarget_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await EntitySnapshotter.CaptureAsync(null!));
+    }
+}

--- a/src/Conjecture.EFCore.Tests/IDbTargetExtensionsTests.cs
+++ b/src/Conjecture.EFCore.Tests/IDbTargetExtensionsTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+using Conjecture.EFCore;
+
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore.Tests;
+
+public class IDbTargetExtensionsTests
+{
+    private sealed class OrderItem
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private class OrdersDbContext(DbContextOptions options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<OrderItem>();
+        }
+    }
+
+    private sealed class UnrelatedDbContext(DbContextOptions options) : DbContext(options)
+    {
+    }
+
+    private sealed class TrackingOrdersDbContext(DbContextOptions options) : OrdersDbContext(options)
+    {
+        public bool WasDisposed { get; private set; }
+
+        public override void Dispose()
+        {
+            WasDisposed = true;
+            base.Dispose();
+        }
+    }
+
+    private static SqliteDbTarget CreateOrdersTarget(SqliteConnection connection)
+    {
+        return new("orders-db", () =>
+        {
+            DbContextOptions<OrdersDbContext> opts = new DbContextOptionsBuilder<OrdersDbContext>()
+                .UseSqlite(connection)
+                .Options;
+            return new OrdersDbContext(opts);
+        });
+    }
+
+    [Fact]
+    public void Resolve_TypedContext_ReturnsExpectedInstance()
+    {
+        using SqliteConnection conn = new("Data Source=:memory:");
+        conn.Open();
+        SqliteDbTarget target = CreateOrdersTarget(conn);
+
+        OrdersDbContext ctx = target.Resolve<OrdersDbContext>();
+
+        Assert.NotNull(ctx);
+        Assert.Equal(typeof(OrdersDbContext), ctx.GetType());
+    }
+
+    [Fact]
+    public void Resolve_WrongTypeArgument_Throws()
+    {
+        using SqliteConnection conn = new("Data Source=:memory:");
+        conn.Open();
+        SqliteDbTarget target = CreateOrdersTarget(conn);
+
+        InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
+            () => { target.Resolve<UnrelatedDbContext>(); });
+
+        Assert.Contains("orders-db", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(nameof(UnrelatedDbContext), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolve_NullTarget_Throws()
+    {
+        IDbTarget? nullTarget = null;
+
+        Assert.Throws<ArgumentNullException>(
+            () => { nullTarget!.Resolve<DbContext>(); });
+    }
+
+    [Fact]
+    public void Resolve_BaseDbContext_AlsoWorks()
+    {
+        using SqliteConnection conn = new("Data Source=:memory:");
+        conn.Open();
+        SqliteDbTarget target = CreateOrdersTarget(conn);
+
+        DbContext ctx = target.Resolve<DbContext>();
+
+        Assert.NotNull(ctx);
+        Assert.True(ctx is OrdersDbContext);
+    }
+
+    [Fact]
+    public void Resolve_DisposesContextOnTypeMismatch()
+    {
+        TrackingOrdersDbContext? produced = null;
+
+        SqliteDbTarget target = new("orders-db", () =>
+        {
+            using SqliteConnection conn = new("Data Source=:memory:");
+            conn.Open();
+            DbContextOptions<TrackingOrdersDbContext> opts =
+                new DbContextOptionsBuilder<TrackingOrdersDbContext>()
+                    .UseSqlite(conn)
+                    .Options;
+            produced = new(opts);
+            return produced;
+        });
+
+        Assert.Throws<InvalidOperationException>(
+            () => { target.Resolve<UnrelatedDbContext>(); });
+
+        Assert.NotNull(produced);
+        Assert.True(produced.WasDisposed);
+    }
+}

--- a/src/Conjecture.EFCore/DbInvariantException.cs
+++ b/src/Conjecture.EFCore/DbInvariantException.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+
+namespace Conjecture.EFCore;
+
+/// <summary>
+/// Base type for all Conjecture.EFCore invariant assertions. Catch this to handle any DB-shape
+/// invariant failure (Roundtrip, Migration, or future composite invariants) uniformly.
+/// </summary>
+public class DbInvariantException : Exception
+{
+    /// <summary>Initializes a new instance with the specified message.</summary>
+    public DbInvariantException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>Initializes a new instance with the specified message and inner exception.</summary>
+    public DbInvariantException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Conjecture.EFCore/EntitySnapshot.cs
+++ b/src/Conjecture.EFCore/EntitySnapshot.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+
+namespace Conjecture.EFCore;
+
+/// <summary>A point-in-time snapshot of entity counts and primary keys captured from a <see cref="IDbTarget"/>.</summary>
+public sealed record EntitySnapshot(
+    IReadOnlyDictionary<Type, int> Counts,
+    IReadOnlyDictionary<Type, IReadOnlySet<object>> Keys);

--- a/src/Conjecture.EFCore/EntitySnapshotDiff.cs
+++ b/src/Conjecture.EFCore/EntitySnapshotDiff.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace Conjecture.EFCore;
+
+/// <summary>The difference between two <see cref="EntitySnapshot"/> instances.</summary>
+public sealed record EntitySnapshotDiff(
+    IReadOnlyDictionary<Type, int> CountDeltas,
+    IReadOnlyDictionary<Type, IReadOnlyList<object>> AddedKeys,
+    IReadOnlyDictionary<Type, IReadOnlyList<object>> RemovedKeys)
+{
+    /// <summary>Returns <see langword="true"/> when no counts changed and no keys were added or removed.</summary>
+    public bool IsEmpty => CountDeltas.Values.All(static d => d == 0)
+                           && AddedKeys.Count == 0
+                           && RemovedKeys.Count == 0;
+
+    /// <summary>Returns a human-readable summary of all changes.</summary>
+    public string ToReport()
+    {
+        if (IsEmpty)
+        {
+            return "(no changes)";
+        }
+
+        StringBuilder sb = new();
+        foreach ((Type t, int delta) in CountDeltas.Where(static kv => kv.Value != 0))
+        {
+            sb.Append(CultureInfo.InvariantCulture, $"{t.Name}: {(delta > 0 ? "+" : "")}{delta}");
+            if (AddedKeys.TryGetValue(t, out IReadOnlyList<object>? added) && added.Count > 0)
+            {
+                sb.Append(CultureInfo.InvariantCulture, $" (added [{string.Join(", ", added)}])");
+            }
+
+            if (RemovedKeys.TryGetValue(t, out IReadOnlyList<object>? removed) && removed.Count > 0)
+            {
+                sb.Append(CultureInfo.InvariantCulture, $" (removed [{string.Join(", ", removed)}])");
+            }
+
+            sb.Append("; ");
+        }
+
+        return sb.ToString().TrimEnd(';', ' ');
+    }
+}

--- a/src/Conjecture.EFCore/EntitySnapshotter.cs
+++ b/src/Conjecture.EFCore/EntitySnapshotter.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Captures and diffs <see cref="EntitySnapshot"/> instances from an <see cref="IDbTarget"/>.</summary>
+public static class EntitySnapshotter
+{
+    /// <summary>Captures a snapshot of all entity types and their primary keys from the target.</summary>
+    public static async Task<EntitySnapshot> CaptureAsync(
+        IDbTarget target,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await using DbContext ctx = target.ResolveContext(target.ResourceName);
+        IModel model = ctx.Model;
+        Dictionary<Type, int> counts = [];
+        Dictionary<Type, IReadOnlySet<object>> keys = [];
+
+        foreach (IEntityType entityType in model.GetEntityTypes())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Type clr = entityType.ClrType;
+            IKey? pk = entityType.FindPrimaryKey();
+            if (pk is null)
+            {
+                continue;
+            }
+
+            MethodInfo setMethod = typeof(DbContext)
+                .GetMethod(nameof(DbContext.Set), Type.EmptyTypes)!
+                .MakeGenericMethod(clr);
+            object? dbSet = setMethod.Invoke(ctx, null);
+
+            HashSet<object> keySet = [];
+            int count = 0;
+
+            foreach (object entity in (IEnumerable)dbSet!)
+            {
+                count++;
+                object?[] keyValues = pk.Properties
+                    .Select(p => p.PropertyInfo!.GetValue(entity))
+                    .ToArray();
+                object keyObj = keyValues.Length == 1
+                    ? keyValues[0]!
+                    : (object)string.Join("|", keyValues.Select(static v => v?.ToString() ?? "null"));
+                keySet.Add(keyObj);
+            }
+
+            counts[clr] = count;
+            keys[clr] = keySet;
+        }
+
+        return new EntitySnapshot(counts, keys);
+    }
+
+    /// <summary>Computes the diff between two snapshots.</summary>
+    public static EntitySnapshotDiff Diff(EntitySnapshot before, EntitySnapshot after)
+    {
+        ArgumentNullException.ThrowIfNull(before);
+        ArgumentNullException.ThrowIfNull(after);
+
+        Dictionary<Type, int> countDeltas = [];
+        Dictionary<Type, IReadOnlyList<object>> addedKeys = [];
+        Dictionary<Type, IReadOnlyList<object>> removedKeys = [];
+
+        HashSet<Type> allTypes = [.. before.Counts.Keys.Concat(after.Counts.Keys).Distinct()];
+
+        foreach (Type t in allTypes)
+        {
+            int b = before.Counts.GetValueOrDefault(t);
+            int a = after.Counts.GetValueOrDefault(t);
+            countDeltas[t] = a - b;
+
+            IReadOnlySet<object> bk = before.Keys.GetValueOrDefault(t) ?? new HashSet<object>();
+            IReadOnlySet<object> ak = after.Keys.GetValueOrDefault(t) ?? new HashSet<object>();
+
+            IReadOnlyList<object> added = ak.Except(bk).ToList();
+            IReadOnlyList<object> removed = bk.Except(ak).ToList();
+
+            if (added.Count > 0)
+            {
+                addedKeys[t] = added;
+            }
+
+            if (removed.Count > 0)
+            {
+                removedKeys[t] = removed;
+            }
+        }
+
+        return new EntitySnapshotDiff(countDeltas, addedKeys, removedKeys);
+    }
+}

--- a/src/Conjecture.EFCore/GenerateDb.cs
+++ b/src/Conjecture.EFCore/GenerateDb.cs
@@ -54,7 +54,7 @@ public sealed class GenerateDbBlock
     {
         ArgumentException.ThrowIfNullOrEmpty(resourceName);
 
-        return Generate.Constant(new DbInteraction(resourceName, DbOpKind.SaveChanges, null));
+        return Generate.Just(new DbInteraction(resourceName, DbOpKind.SaveChanges, null));
     }
 
     /// <summary>
@@ -80,7 +80,7 @@ public sealed class GenerateDbBlock
             candidates.Add(entityStrategy.Select(entity => new DbInteraction(resourceName, DbOpKind.Update, entity)));
             candidates.Add(entityStrategy.Select(entity => new DbInteraction(resourceName, DbOpKind.Remove, entity)));
         }
-        candidates.Add(Generate.Constant(new DbInteraction(resourceName, DbOpKind.SaveChanges, null)));
+        candidates.Add(Generate.Just(new DbInteraction(resourceName, DbOpKind.SaveChanges, null)));
 
         Strategy<DbInteraction> elementStrategy = Generate.OneOf([.. candidates]);
         return Generate.Lists(elementStrategy, min, max)

--- a/src/Conjecture.EFCore/IDbTargetExtensions.cs
+++ b/src/Conjecture.EFCore/IDbTargetExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Conjecture.EFCore;
+
+/// <summary>Extension methods on <see cref="IDbTarget"/>.</summary>
+public static class IDbTargetExtensions
+{
+    /// <summary>
+    /// Resolves the target's <see cref="DbContext"/> and casts to <typeparamref name="TContext"/>.
+    /// Throws <see cref="InvalidOperationException"/> if the resolved context is not assignable to
+    /// <typeparamref name="TContext"/>.
+    /// </summary>
+    public static TContext Resolve<TContext>(this IDbTarget target)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        DbContext ctx = target.ResolveContext(target.ResourceName);
+        if (ctx is not TContext typed)
+        {
+            ctx.Dispose();
+            throw new InvalidOperationException(
+                FormattableString.Invariant($"IDbTarget '{target.ResourceName}' resolved a {ctx.GetType().Name}, not a {typeof(TContext).Name}."));
+        }
+        return typed;
+    }
+}

--- a/src/Conjecture.EFCore/InMemoryDbTarget.cs
+++ b/src/Conjecture.EFCore/InMemoryDbTarget.cs
@@ -44,6 +44,51 @@ public sealed class InMemoryDbTarget(string resourceName, Func<DbContext> contex
     }
 
     /// <inheritdoc/>
-    public Task<object?> ExecuteAsync(IInteraction interaction, CancellationToken ct) =>
-        throw new NotImplementedException("Dispatch logic will be implemented in a subsequent cycle.");
+    /// <remarks>
+    /// Each <see cref="ExecuteAsync"/> call opens its own <see cref="DbContext"/>. Sequencing an
+    /// <see cref="DbOpKind.Add"/> and a separate <see cref="DbOpKind.SaveChanges"/> across two
+    /// <c>ExecuteAsync</c> calls will NOT see each other through the change tracker — the second
+    /// call sees an empty context. Use <c>Generate.Db.Sequence</c> to produce a single state-machine
+    /// run that batches operations correctly.
+    /// </remarks>
+    public async Task<object?> ExecuteAsync(IInteraction interaction, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(interaction);
+
+        if (interaction is not DbInteraction db)
+        {
+            throw new InvalidOperationException(
+                $"InMemoryDbTarget cannot execute interactions of type '{interaction.GetType().Name}'.");
+        }
+
+        await using DbContext ctx = ResolveContext(db.ResourceName);
+
+        return db.Op switch
+        {
+            DbOpKind.Add => AddEntity(ctx, db.Payload!),
+            DbOpKind.Update => UpdateEntity(ctx, db.Payload!),
+            DbOpKind.Remove => RemoveEntity(ctx, db.Payload!),
+            DbOpKind.SaveChanges => (object)await ctx.SaveChangesAsync(ct).ConfigureAwait(false),
+            DbOpKind.Query => throw new NotSupportedException("Query op is not supported in v1."),
+            _ => throw new InvalidOperationException($"Unknown DbOpKind '{db.Op}'.")
+        };
+    }
+
+    private static object? AddEntity(DbContext ctx, object payload)
+    {
+        ctx.Add(payload);
+        return null;
+    }
+
+    private static object? UpdateEntity(DbContext ctx, object payload)
+    {
+        ctx.Update(payload);
+        return null;
+    }
+
+    private static object? RemoveEntity(DbContext ctx, object payload)
+    {
+        ctx.Remove(payload);
+        return null;
+    }
 }

--- a/src/Conjecture.EFCore/MigrationAssertionException.cs
+++ b/src/Conjecture.EFCore/MigrationAssertionException.cs
@@ -6,7 +6,7 @@ using System;
 namespace Conjecture.EFCore;
 
 /// <summary>Thrown when a migration idempotency assertion fails.</summary>
-public sealed class MigrationAssertionException : Exception
+public sealed class MigrationAssertionException : DbInvariantException
 {
     /// <summary>Initializes a new instance with <paramref name="message"/>.</summary>
     public MigrationAssertionException(string message)

--- a/src/Conjecture.EFCore/PropertyStrategyBuilder.cs
+++ b/src/Conjecture.EFCore/PropertyStrategyBuilder.cs
@@ -21,7 +21,7 @@ public static class PropertyStrategyBuilder
         if (property.ValueGenerated == ValueGenerated.OnAdd || property.ValueGenerated == ValueGenerated.OnAddOrUpdate)
         {
             object? clrDefault = property.ClrType.IsValueType ? Activator.CreateInstance(property.ClrType) : null;
-            return Generate.Constant<object?>(clrDefault);
+            return Generate.Just<object?>(clrDefault);
         }
 
         Type clrType = property.ClrType;
@@ -30,7 +30,7 @@ public static class PropertyStrategyBuilder
         Strategy<object?> inner = BuildInner(property, underlying);
 
         return property.IsNullable
-            ? Generate.OneOf(inner, Generate.Constant<object?>(null))
+            ? Generate.OneOf(inner, Generate.Just<object?>(null))
             : inner;
     }
 
@@ -130,7 +130,7 @@ public static class PropertyStrategyBuilder
             return Generate.SampledFrom(values).Select(v => (object?)v);
         }
 
-        return Generate.Constant<object?>(null);
+        return Generate.Just<object?>(null);
     }
 
     private static Strategy<object?> BuildDecimalStrategy(IProperty property)

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 #nullable enable
+Conjecture.EFCore.DbInvariantException
+Conjecture.EFCore.DbInvariantException.DbInvariantException(string! message) -> void
+Conjecture.EFCore.DbInvariantException.DbInvariantException(string! message, System.Exception! innerException) -> void

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -2,3 +2,22 @@
 Conjecture.EFCore.DbInvariantException
 Conjecture.EFCore.DbInvariantException.DbInvariantException(string! message) -> void
 Conjecture.EFCore.DbInvariantException.DbInvariantException(string! message, System.Exception! innerException) -> void
+Conjecture.EFCore.EntitySnapshot
+Conjecture.EFCore.EntitySnapshot.EntitySnapshot(System.Collections.Generic.IReadOnlyDictionary<System.Type!, int>! Counts, System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Collections.Generic.IReadOnlySet<object!>!>! Keys) -> void
+Conjecture.EFCore.EntitySnapshot.Counts.get -> System.Collections.Generic.IReadOnlyDictionary<System.Type!, int>!
+Conjecture.EFCore.EntitySnapshot.Counts.init -> void
+Conjecture.EFCore.EntitySnapshot.Keys.get -> System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Collections.Generic.IReadOnlySet<object!>!>!
+Conjecture.EFCore.EntitySnapshot.Keys.init -> void
+Conjecture.EFCore.EntitySnapshotDiff
+Conjecture.EFCore.EntitySnapshotDiff.EntitySnapshotDiff(System.Collections.Generic.IReadOnlyDictionary<System.Type!, int>! CountDeltas, System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Collections.Generic.IReadOnlyList<object!>!>! AddedKeys, System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Collections.Generic.IReadOnlyList<object!>!>! RemovedKeys) -> void
+Conjecture.EFCore.EntitySnapshotDiff.CountDeltas.get -> System.Collections.Generic.IReadOnlyDictionary<System.Type!, int>!
+Conjecture.EFCore.EntitySnapshotDiff.CountDeltas.init -> void
+Conjecture.EFCore.EntitySnapshotDiff.AddedKeys.get -> System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Collections.Generic.IReadOnlyList<object!>!>!
+Conjecture.EFCore.EntitySnapshotDiff.AddedKeys.init -> void
+Conjecture.EFCore.EntitySnapshotDiff.RemovedKeys.get -> System.Collections.Generic.IReadOnlyDictionary<System.Type!, System.Collections.Generic.IReadOnlyList<object!>!>!
+Conjecture.EFCore.EntitySnapshotDiff.RemovedKeys.init -> void
+Conjecture.EFCore.EntitySnapshotDiff.IsEmpty.get -> bool
+Conjecture.EFCore.EntitySnapshotDiff.ToReport() -> string!
+Conjecture.EFCore.EntitySnapshotter
+static Conjecture.EFCore.EntitySnapshotter.CaptureAsync(Conjecture.EFCore.IDbTarget! target, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Conjecture.EFCore.EntitySnapshot!>!
+static Conjecture.EFCore.EntitySnapshotter.Diff(Conjecture.EFCore.EntitySnapshot! before, Conjecture.EFCore.EntitySnapshot! after) -> Conjecture.EFCore.EntitySnapshotDiff!

--- a/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.EFCore/PublicAPI.Unshipped.txt
@@ -21,3 +21,5 @@ Conjecture.EFCore.EntitySnapshotDiff.ToReport() -> string!
 Conjecture.EFCore.EntitySnapshotter
 static Conjecture.EFCore.EntitySnapshotter.CaptureAsync(Conjecture.EFCore.IDbTarget! target, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Conjecture.EFCore.EntitySnapshot!>!
 static Conjecture.EFCore.EntitySnapshotter.Diff(Conjecture.EFCore.EntitySnapshot! before, Conjecture.EFCore.EntitySnapshot! after) -> Conjecture.EFCore.EntitySnapshotDiff!
+Conjecture.EFCore.IDbTargetExtensions
+static Conjecture.EFCore.IDbTargetExtensions.Resolve<TContext>(this Conjecture.EFCore.IDbTarget! target) -> TContext!

--- a/src/Conjecture.EFCore/RoundtripAssertionException.cs
+++ b/src/Conjecture.EFCore/RoundtripAssertionException.cs
@@ -1,11 +1,9 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
-using System;
-
 namespace Conjecture.EFCore;
 
 /// <summary>Thrown when a roundtrip assertion fails.</summary>
-public sealed class RoundtripAssertionException(string message) : Exception(message)
+public sealed class RoundtripAssertionException(string message) : DbInvariantException(message)
 {
 }

--- a/src/Conjecture.EFCore/SqliteDbTarget.cs
+++ b/src/Conjecture.EFCore/SqliteDbTarget.cs
@@ -52,8 +52,54 @@ public sealed class SqliteDbTarget(string resourceName, Func<DbContext> contextF
     }
 
     /// <inheritdoc/>
-    public Task<object?> ExecuteAsync(IInteraction interaction, CancellationToken ct) =>
-        throw new NotImplementedException("Dispatch logic will be implemented in a subsequent cycle.");
+    /// <remarks>
+    /// Each <see cref="ExecuteAsync"/> call opens its own <see cref="DbContext"/>. Sequencing an
+    /// <see cref="DbOpKind.Add"/> and a separate <see cref="DbOpKind.SaveChanges"/> across two
+    /// <c>ExecuteAsync</c> calls will NOT see each other through the change tracker — the second
+    /// call sees an empty context. Use <c>Generate.Db.Sequence</c> to produce a single state-machine
+    /// run that batches operations correctly.
+    /// </remarks>
+    public async Task<object?> ExecuteAsync(IInteraction interaction, CancellationToken ct)
+    {
+        ObjectDisposedException.ThrowIf(disposed, this);
+        ArgumentNullException.ThrowIfNull(interaction);
+
+        if (interaction is not DbInteraction db)
+        {
+            throw new InvalidOperationException(
+                $"SqliteDbTarget cannot execute interactions of type '{interaction.GetType().Name}'.");
+        }
+
+        await using DbContext ctx = ResolveContext(db.ResourceName);
+
+        return db.Op switch
+        {
+            DbOpKind.Add => AddEntity(ctx, db.Payload!),
+            DbOpKind.Update => UpdateEntity(ctx, db.Payload!),
+            DbOpKind.Remove => RemoveEntity(ctx, db.Payload!),
+            DbOpKind.SaveChanges => (object)await ctx.SaveChangesAsync(ct).ConfigureAwait(false),
+            DbOpKind.Query => throw new NotSupportedException("Query op is not supported in v1."),
+            _ => throw new InvalidOperationException($"Unknown DbOpKind '{db.Op}'.")
+        };
+    }
+
+    private static object? AddEntity(DbContext ctx, object payload)
+    {
+        ctx.Add(payload);
+        return null;
+    }
+
+    private static object? UpdateEntity(DbContext ctx, object payload)
+    {
+        ctx.Update(payload);
+        return null;
+    }
+
+    private static object? RemoveEntity(DbContext ctx, object payload)
+    {
+        ctx.Remove(payload);
+        return null;
+    }
 
     /// <inheritdoc/>
     public ValueTask DisposeAsync()


### PR DESCRIPTION
## Description

Five mechanical adjustments to `Conjecture.EFCore` (v0.25.0) plus the `Generate.Just`/`Generate.Constant` consolidation. Surfaced while planning [#553](https://github.com/kommundsen/Conjecture/issues/553) (ASP.NET Core + EF Core composite integration); landing them first keeps the EFCore foundation consistent and removes the only API duplicate before external adoption.

- **#583** — `IDbTarget.ExecuteAsync` dispatch on `DbOpKind` for both `InMemoryDbTarget` and `SqliteDbTarget` (was `NotImplementedException`; blocked all `CompositeInteractionTarget` scenarios).
- **#584** — `DbInvariantException` base in `Conjecture.EFCore`; re-base `RoundtripAssertionException` + `MigrationAssertionException` (both stay `sealed`).
- **#585** — relocate `EntitySnapshot` / `EntitySnapshotter` / `EntitySnapshotDiff` into `Conjecture.EFCore` for reuse across the upcoming AspNetCore.EFCore and Aspire.EFCore satellites.
- **#586** — typed `IDbTarget.Resolve<TContext>()` extension method.
- **#587** — consolidate `Generate.Constant` (v0.24.0 alias) → `Generate.Just`; remove the alias and emit `*REMOVED*` in `Conjecture.Core`'s `PublicAPI.Unshipped.txt`.

`Conjecture.EFCore.Tests` now carries 95 tests (up from 61); full `dotnet test src/` clean.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #582

## Cycles included

- 521b8b3 IDbTarget.ExecuteAsync: dispatch DbInteraction through InMemoryDbTarget and SqliteDbTarget
- ca0eaba DbInvariantException base: unify RoundtripAssertionException + MigrationAssertionException
- 6a0e2c6 EntitySnapshot: capture and diff DbContext state for before/after assertions
- 2f3b836 IDbTargetExtensions: typed Resolve<TContext>() extension
- b2e2db0 Generate.Just / Generate.Constant: consolidate to Just; remove Constant alias