### PR TITLE
Terminology cleanup in XML docs and comments

### DIFF
--- a/CONTEXT.MD
+++ b/CONTEXT.MD
@@ -18,8 +18,11 @@ This file overrides Hypothesis-Python vocabulary, and any informal synonyms used
 ### Generation
 
 - **Strategy** — value-producing abstraction. `Strategy<T>` is the generic type; the non-generic `Strategy` static class exposes built-in factories (`Strategy.Integers`, `Strategy.Strings`, …). _Avoid:_ generator, generate, arbitrary, producer, gen, arb, factory.
+  _Note (F# carve-out):_ `Conjecture.FSharp` exposes `Gen<'a>`, `Gen.bind`, `GenBuilder` etc. as idiomatic F#. These wrap `Strategy<T>` internally and do not bleed into C# public API.
 - **IGenerationContext** — imperative draw API used inside `Compose` (`Generate<T>()`, `Assume()`, `Target()`). _Avoid:_ IGeneratorContext, context, ctx, source, sink.
 - **Compose** — strategy built by drawing from other strategies imperatively via `IGenerationContext`. _Avoid:_ build, combine, monad, bind.
+  _Note (`*Builder` rule):_ A `*Builder` type is permitted **only** when it accumulates state across chained calls and produces the strategy via a terminal `Build()` (e.g. `HttpStrategyBuilder`, `AspNetCoreRequestBuilder`, `DbInteractionSequenceBuilder`). Single-op DTO factories that return `Strategy<T>` directly do **not** use the `*Builder` suffix — they use `*Strategies` (see below).
+  _Note (`*Strategies` rule):_ Adapters expose their single-op factory clusters via a `*Strategies` access object (`DbStrategies`, `MessagingStrategies`). Plural-as-collection signals "a holder for related factory methods." The entry-point lives on `Strategy` itself (`Strategy.Db`, `Strategy.Messaging`).
 - **IStrategyProvider\<T\>** — source-generated strategy adapter emitted from `[Arbitrary]`. _Avoid:_ factory, registration, adapter.
 - **`[Arbitrary]`** — attribute marking a type for `IStrategyProvider` generation. _Avoid:_ `[Generate]`, `[Strategy]`, `[Gen]`.
 
@@ -59,6 +62,7 @@ This file overrides Hypothesis-Python vocabulary, and any informal synonyms used
 - **`[Property]`** — per-framework test attribute (Xunit, Xunit.V3, NUnit, MSTest, TestingPlatform). All implement `IPropertyTest`. _Avoid:_ `[Conjecture]`, `[Test]`, `[Theory]`, `[Fact]`.
 - **`[Sample]`** — attribute supplying pre-canned inputs that become Examples when run (e.g. `[Sample(1, 2, 3)]`). _Avoid:_ `[Example]`, `[InlineData]`, `[TestCase]`.
 - **IPropertyTest** — common configuration interface across adapters (`MaxExamples`, `Seed`, `Database`, `MaxStrategyRejections`, `DeadlineMs`, `Targeting`, `TargetingProportion`). _Avoid:_ ITest, IConfig, IRunner.
+- **Interaction** — a single discrete action on a domain-specific target (HTTP, messaging, gRPC, database). Implements `IInteraction`; data DTOs use the `*Interaction` postfix (`HttpInteraction`, `MessageInteraction`, `GrpcInteraction`, `DbInteraction`). A Property Example may execute many Interactions in sequence or state-machine order. _Avoid:_ action, step, operation.
 
 ### Internals
 
@@ -77,6 +81,10 @@ Names that are `internal` to `Conjecture.Core`. Use only when discussing impleme
 - A successfully shrunk `Interesting` **Example** is persisted to the **Example Database** and may be exported as a **Reproduction**.
 - **Targeting** consumes **Observations** recorded by `Target` calls during the **Generation** phase to bias subsequent draws.
 - An `[Arbitrary]`-annotated type produces an **IStrategyProvider\<T\>** at compile time, which yields a **Strategy\<T\>** at runtime.
+
+## Layering convention
+
+End-user contracts live in `Conjecture.{Pkg}` (e.g., `Conjecture.Core`, `Conjecture.Aspire`). Extension-author contracts live in the matching `Conjecture.{Pkg}.Abstractions` package, under namespace `Conjecture.Abstractions.{Sub}`, and are marked `[EditorBrowsable(EditorBrowsableState.Never)]`. Internal engine implementation stays in the `Internal/` sub-namespace and is never publicly visible.
 
 ## Flagged ambiguities
 

--- a/src/Conjecture.Core/Assume.cs
+++ b/src/Conjecture.Core/Assume.cs
@@ -9,7 +9,7 @@ namespace Conjecture.Core;
 /// <summary>Provides assumption helpers for filtering property test inputs.</summary>
 public static class Assume
 {
-    /// <summary>Skips the current example if <paramref name="condition"/> is <see langword="false"/>.</summary>
+    /// <summary>Rejects the current example if <paramref name="condition"/> is <see langword="false"/>.</summary>
     public static void That(bool condition)
     {
         if (!condition)

--- a/src/Conjecture.Core/ConjectureStrategyRegistrar.cs
+++ b/src/Conjecture.Core/ConjectureStrategyRegistrar.cs
@@ -17,7 +17,7 @@ public static class ConjectureStrategyRegistrar
 {
     private static Func<Type, ConjectureData, object?>? activeResolver;
 
-    /// <summary>Registers a generated strategy factory. Called by source-generated module initializers.</summary>
+    /// <summary>Registers a generated <see cref="IStrategyProvider{T}"/>. Called by source-generated module initializers.</summary>
     /// <param name="strategyFactory">Returns a boxed <see cref="Strategy{T}"/> for the given type, or <see langword="null"/> if unsupported.</param>
     public static void Register(Func<Type, object?> strategyFactory)
     {

--- a/src/Conjecture.Core/ConjectureStrategyRegistrar.cs
+++ b/src/Conjecture.Core/ConjectureStrategyRegistrar.cs
@@ -24,7 +24,7 @@ public static class ConjectureStrategyRegistrar
         activeResolver = (type, data) =>
         {
             object? strategy = strategyFactory(type);
-            return strategy is IGeneratableStrategy gen ? gen.GenerateBoxed(data) : null;
+            return strategy is IGeneratableStrategy generatable ? generatable.GenerateBoxed(data) : null;
         };
     }
 

--- a/src/Conjecture.Core/GenerateForRegistry.cs
+++ b/src/Conjecture.Core/GenerateForRegistry.cs
@@ -23,20 +23,20 @@ public static class GenerateForRegistry
     // Parallel dictionary holding AOT-safe boxed strategies for use via ResolveBoxed.
     private static readonly ConcurrentDictionary<Type, Strategy<object?>> BoxedStrategies = new();
 
-    /// <summary>Registers an override-aware factory for <paramref name="type"/>. Called by source-generated module initializers.</summary>
+    /// <summary>Registers an override-aware <see cref="IStrategyProvider"/> for <paramref name="type"/>. Called by source-generated module initializers.</summary>
     public static void RegisterOverride(Type type, Func<object, object> factory)
     {
         OverrideProviders[type] = factory;
     }
 
-    /// <summary>Registers a provider factory for <paramref name="type"/>. Called by source-generated module initializers.</summary>
+    /// <summary>Registers an <see cref="IStrategyProvider"/> for <paramref name="type"/>. Called by source-generated module initializers.</summary>
     public static void Register(Type type, Func<IStrategyProvider> factory)
     {
         Providers[type] = factory;
     }
 
     /// <summary>
-    /// Registers a provider factory together with a pre-built boxed strategy for <paramref name="type"/>.
+    /// Registers an <see cref="IStrategyProvider"/> together with a pre-built boxed strategy for <paramref name="type"/>.
     /// Enables <see cref="ResolveBoxed"/> for callers that only know the type at runtime.
     /// </summary>
     public static void Register(Type type, Func<IStrategyProvider> factory, Strategy<object?> boxedStrategy)
@@ -48,7 +48,7 @@ public static class GenerateForRegistry
         BoxedStrategies[type] = boxedStrategy;
     }
 
-    /// <summary>Returns <see langword="true"/> when a provider factory for <paramref name="type"/> has been registered.</summary>
+    /// <summary>Returns <see langword="true"/> when an <see cref="IStrategyProvider"/> for <paramref name="type"/> has been registered.</summary>
     public static bool IsRegistered(Type type) => Providers.ContainsKey(type);
 
     /// <summary>
@@ -74,7 +74,7 @@ public static class GenerateForRegistry
             : ((IStrategyProvider<T>)factory()).Create();
     }
 
-    /// <summary>Resolves an override-aware strategy for <typeparamref name="T"/> using the registered factory and the provided <paramref name="cfg"/>. Throws if the type is not registered.</summary>
+    /// <summary>Resolves an override-aware strategy for <typeparamref name="T"/> using the registered <see cref="IStrategyProvider"/> and the provided <paramref name="cfg"/>. Throws if the type is not registered.</summary>
     public static Strategy<T> ResolveWithOverrides<T>(ForConfiguration<T> cfg)
     {
         Type key = typeof(T);

--- a/src/Conjecture.Core/IGenerationContext.cs
+++ b/src/Conjecture.Core/IGenerationContext.cs
@@ -7,7 +7,7 @@
 
 namespace Conjecture.Core;
 
-/// <summary>Provides imperative draw and assume operations within a <c>Strategy.Compose</c> factory.</summary>
+/// <summary>Provides imperative draw and assume operations within a <c>Strategy.Compose</c> body.</summary>
 public interface IGenerationContext
 {
     /// <summary>Generates a value from <paramref name="strategy"/>.</summary>
@@ -18,6 +18,6 @@ public interface IGenerationContext
 
     /// <summary>Records a numeric observation to guide targeted generation.</summary>
     /// <param name="observation">The value to maximize. Must be finite (not NaN or Infinity).</param>
-    /// <param name="label">Identifies this observation label. Multiple labels are optimized independently.</param>
+    /// <param name="label">Identifies this observation label. Multiple labels are targeted independently.</param>
     void Target(double observation, string label = "default");
 }

--- a/src/Conjecture.Core/Internal/ConjectureData.cs
+++ b/src/Conjecture.Core/Internal/ConjectureData.cs
@@ -184,7 +184,7 @@ internal sealed class ConjectureData
         if (cursor >= replayNodes!.Count)
         {
             Status = Status.Overrun;
-            throw new InvalidOperationException("Replay buffer exhausted.");
+            throw new InvalidOperationException("Replay IR exhausted.");
         }
         return replayNodes[cursor++];
     }

--- a/src/Conjecture.Core/Internal/IShrinkPass.cs
+++ b/src/Conjecture.Core/Internal/IShrinkPass.cs
@@ -8,6 +8,6 @@ internal interface IShrinkPass
     /// <summary>Gets the stable metric tag name for this pass (snake_case, never changes).</summary>
     string PassName { get; }
 
-    /// <summary>Attempt one reduction step. Returns true if progress was made.</summary>
+    /// <summary>Attempt one shrink step. Returns true if progress was made.</summary>
     ValueTask<bool> TryReduce(ShrinkState state);
 }

--- a/src/Conjecture.Core/Internal/NumericAwareShrinkPass.cs
+++ b/src/Conjecture.Core/Internal/NumericAwareShrinkPass.cs
@@ -87,7 +87,7 @@ internal sealed class NumericAwareShrinkPass : IShrinkPass
         int runEnd,
         ulong currentValue)
     {
-        // Try 0 first — the most aggressive reduction.
+        // Try 0 first — the most aggressive shrink.
         if (await TryCandidateValue(state, lenIndex, charStart, charCount, runStart, runEnd, 0))
         {
             return true;

--- a/src/Conjecture.Core/Internal/ZeroBlocksPass.cs
+++ b/src/Conjecture.Core/Internal/ZeroBlocksPass.cs
@@ -14,7 +14,7 @@ internal sealed class ZeroBlocksPass : IShrinkPass
     {
         bool progress = false;
         // Right-to-left: early-drawn nodes (low indices) survive zeroing last, so they
-        // remain non-minimum when later passes try to reduce the length/count node that
+        // remain non-minimum when later passes try to shrink the length/count node that
         // controls how many of them are consumed. This is essential for collection shrinking.
         for (int i = state.Nodes.Count - 1; i >= 0; i--)
         {

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -3,7 +3,7 @@ Conjecture.Core.IGenerationContext
 Conjecture.Core.IGenerationContext.Assume(bool condition) -> void
 Conjecture.Core.IGenerationContext.Generate<T>(Conjecture.Core.Strategy<T>! strategy) -> T
 Conjecture.Core.IGenerationContext.Target(double observation, string! label = "default") -> void
-static Conjecture.Core.Strategy.Compose<T>(System.Func<Conjecture.Core.IGenerationContext!, T>! factory) -> Conjecture.Core.Strategy<T>!
+static Conjecture.Core.Strategy.Compose<T>(System.Func<Conjecture.Core.IGenerationContext!, T>! body) -> Conjecture.Core.Strategy<T>!
 static Conjecture.Core.PartialConstructorContext.Current.get -> Conjecture.Core.IGenerationContext!
 static Conjecture.Core.PartialConstructorContext.Use(Conjecture.Core.IGenerationContext! ctx) -> System.IDisposable!
 Conjecture.Core.Strategy

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -227,7 +227,7 @@ public static class Strategy
     public static Strategy<TimeOnly> TimeOnlyValues(TimeOnly min, TimeOnly max)
         => new TimeOnlyStrategy(min, max);
 
-    /// <summary>Returns a strategy that generates identifier strings of the form <c>[a-z]+\d+</c>. The alpha prefix is drawn via IR string nodes so <c>StringAwarePass</c> can simplify it toward 'a', and the digit suffix is drawn so <c>NumericAwareShrinkPass</c> can shrink it.</summary>
+    /// <summary>Returns a strategy that generates identifier strings of the form <c>[a-z]+\d+</c>. The alpha prefix is drawn via IR string nodes so <c>StringAwarePass</c> can shrink it toward 'a', and the digit suffix is drawn so <c>NumericAwareShrinkPass</c> can shrink it.</summary>
     public static Strategy<string> Identifiers(
         int minPrefixLength = 1,
         int maxPrefixLength = 6,

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -136,7 +136,7 @@ public static class Strategy
     /// <param name="maxDepth">Maximum recursion depth. Generated values have depth in [0, maxDepth]. Must be ≥ 0.</param>
     /// <returns>
     ///   A <see cref="Strategy{T}"/> whose generated values have depth at most <paramref name="maxDepth"/>.
-    ///   The depth draw is an IR integer, so the shrinker reduces it toward 0, producing shallower structures
+    ///   The depth draw is an IR integer, so the shrinker shrinks it toward 0, producing shallower structures
     ///   when shrinking a counterexample.
     /// </returns>
     /// <example>

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -11,11 +11,11 @@ namespace Conjecture.Core;
 /// <summary>Static methods for creating and composing Conjecture strategies.</summary>
 public static class Strategy
 {
-    /// <summary>Creates a strategy from an imperative factory function using <see cref="IGenerationContext"/>.</summary>
-    public static Strategy<T> Compose<T>(Func<IGenerationContext, T> factory)
+    /// <summary>Creates a strategy from an imperative body using <see cref="IGenerationContext"/>.</summary>
+    public static Strategy<T> Compose<T>(Func<IGenerationContext, T> body)
     {
-        ArgumentNullException.ThrowIfNull(factory);
-        return new ComposeStrategy<T>(factory);
+        ArgumentNullException.ThrowIfNull(body);
+        return new ComposeStrategy<T>(body);
     }
 
     /// <summary>Returns a strategy that generates random <see cref="bool"/> values.</summary>

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -8,7 +8,7 @@ using System.Numerics;
 
 namespace Conjecture.Core;
 
-/// <summary>Factory methods for creating and composing Conjecture strategies.</summary>
+/// <summary>Static methods for creating and composing Conjecture strategies.</summary>
 public static class Strategy
 {
     /// <summary>Creates a strategy from an imperative factory function using <see cref="IGenerationContext"/>.</summary>

--- a/src/Conjecture.Core/Target.cs
+++ b/src/Conjecture.Core/Target.cs
@@ -15,7 +15,7 @@ public static class Target
 
     /// <summary>Records a numeric observation to maximize during the targeting phase.</summary>
     /// <param name="observation">The value to maximize. Must be finite (not NaN or Infinity).</param>
-    /// <param name="label">Identifies this observation label. Multiple labels are optimized independently.</param>
+    /// <param name="label">Identifies this observation label. Multiple labels are targeted independently.</param>
     public static void Maximize(double observation, string label = "default")
     {
         ConjectureData data = CurrentData.Value
@@ -25,7 +25,7 @@ public static class Target
 
     /// <summary>Records a numeric observation to minimize during the targeting phase.</summary>
     /// <param name="observation">The value to minimize. Must be finite (not NaN or Infinity).</param>
-    /// <param name="label">Identifies this observation label. Multiple labels are optimized independently.</param>
+    /// <param name="label">Identifies this observation label. Multiple labels are targeted independently.</param>
     public static void Minimize(double observation, string label = "default")
     {
         Maximize(-observation, label);

--- a/src/Conjecture.EFCore/EFCoreGenerateExtensions.cs
+++ b/src/Conjecture.EFCore/EFCoreGenerateExtensions.cs
@@ -9,7 +9,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Conjecture.EFCore;
 
-/// <summary>Factory methods for generating EF Core entity instances.</summary>
+/// <summary>Extension methods for generating EF Core entity instances.</summary>
 public static class EFCoreGenerateExtensions
 {
     // Both overloads take optional maxDepth; suppress RS0026 as in RegexGenerateExtensions.

--- a/src/Conjecture.Grpc/GenerateGrpc.cs
+++ b/src/Conjecture.Grpc/GenerateGrpc.cs
@@ -10,7 +10,7 @@ using Grpc.Core;
 
 namespace Conjecture.Grpc;
 
-/// <summary>Strategy factory methods for gRPC interactions.</summary>
+/// <summary>Extension methods for generating gRPC interactions.</summary>
 public static class GenerateGrpc
 {
     private static readonly IReadOnlyDictionary<string, string> EmptyMetadata =

--- a/src/Conjecture.Regex/RegexGenerateExtensions.cs
+++ b/src/Conjecture.Regex/RegexGenerateExtensions.cs
@@ -10,7 +10,7 @@ using DotNetRegex = System.Text.RegularExpressions.Regex;
 
 namespace Conjecture.Core;
 
-/// <summary>Factory methods for generating strings that match (or do not match) a regular expression.</summary>
+/// <summary>Extension methods for generating strings that match (or do not match) a regular expression.</summary>
 public static class RegexGenerateExtensions
 {
     private const int CacheCapacity = 256;


### PR DESCRIPTION
## Description

Sweeps the codebase for terminology that violates the rules established in `CONTEXT.MD` (batch 1) — purges \`factory\` / \`reduce\` / \`simplify\` / \`optimize\` from XML docs and comments in favour of the project's chosen vocabulary (\`IStrategyProvider<T>\` / \`shrink\` / \`target\`).

**Highlights:**
- Adds `Interaction` term, `*Builder`/`*Strategies` rules, F# carve-out, and layering convention to `CONTEXT.MD`.
- 14 small, surgical comment/XML-doc rewrites across `Strategy.Factory`, `IGenerationContext`, `Target`, `Assume`, `ConjectureStrategyRegistrar`, `GenerateForRegistry`, shrink passes, and ConjectureData error messages.
- Renames `Strategy.Compose` parameter `factory` → `body` (the only public-API touch in this batch).

Pure terminology work — no behavioural change, no public API breakage beyond the one parameter rename.

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [x] Refactor (no behavior change)
- [x] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] \`dotnet test src/\` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows \`.editorconfig\` code style