### PR TITLE
Migrate test projects to xUnit v3

### DIFF
--- a/src/Conjecture.Analyzers.Tests/Conjecture.Analyzers.Tests.csproj
+++ b/src/Conjecture.Analyzers.Tests/Conjecture.Analyzers.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.Aspire.Abstractions.Tests/Conjecture.Aspire.Abstractions.Tests.csproj
+++ b/src/Conjecture.Aspire.Abstractions.Tests/Conjecture.Aspire.Abstractions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Aspire.EFCore.Tests/AspireDbTargetTests.cs
+++ b/src/Conjecture.Aspire.EFCore.Tests/AspireDbTargetTests.cs
@@ -23,7 +23,7 @@ public sealed class AspireDbTargetTests : IAsyncLifetime
 {
     private SqliteConnection connection = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         // Keep a single open connection — SQLite :memory: databases live only as long as the connection.
         connection = new("DataSource=:memory:");
@@ -34,7 +34,7 @@ public sealed class AspireDbTargetTests : IAsyncLifetime
         await seed.Database.EnsureCreatedAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await connection.DisposeAsync();
     }

--- a/src/Conjecture.Aspire.EFCore.Tests/AspireEFCoreInvariantsTests.cs
+++ b/src/Conjecture.Aspire.EFCore.Tests/AspireEFCoreInvariantsTests.cs
@@ -27,7 +27,7 @@ public sealed class AspireEFCoreInvariantsTests : IAsyncLifetime
 {
     private SqliteConnection connection = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         connection = new("DataSource=:memory:");
         await connection.OpenAsync();
@@ -37,7 +37,7 @@ public sealed class AspireEFCoreInvariantsTests : IAsyncLifetime
         await seed.Database.EnsureCreatedAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await connection.DisposeAsync();
     }

--- a/src/Conjecture.Aspire.EFCore.Tests/Conjecture.Aspire.EFCore.Tests.csproj
+++ b/src/Conjecture.Aspire.EFCore.Tests/Conjecture.Aspire.EFCore.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -9,7 +9,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Aspire.EFCore.Tests/DbSnapshotInteractionTests.cs
+++ b/src/Conjecture.Aspire.EFCore.Tests/DbSnapshotInteractionTests.cs
@@ -16,7 +16,7 @@ public sealed class DbSnapshotInteractionTests : IAsyncLifetime
 {
     private SqliteConnection connection = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         connection = new("DataSource=:memory:");
         await connection.OpenAsync();
@@ -26,7 +26,7 @@ public sealed class DbSnapshotInteractionTests : IAsyncLifetime
         await seed.Database.EnsureCreatedAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await connection.DisposeAsync();
     }

--- a/src/Conjecture.Aspire.EFCore.Tests/IDbTargetWaitForExtensionsTests.cs
+++ b/src/Conjecture.Aspire.EFCore.Tests/IDbTargetWaitForExtensionsTests.cs
@@ -24,7 +24,7 @@ public sealed class IDbTargetWaitForExtensionsTests : IAsyncLifetime
 {
     private SqliteConnection connection = null!;
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         connection = new("DataSource=:memory:");
         await connection.OpenAsync();
@@ -34,7 +34,7 @@ public sealed class IDbTargetWaitForExtensionsTests : IAsyncLifetime
         await seed.Database.EnsureCreatedAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await connection.DisposeAsync();
     }

--- a/src/Conjecture.Aspire.Http.Tests/Conjecture.Aspire.Http.Tests.csproj
+++ b/src/Conjecture.Aspire.Http.Tests/Conjecture.Aspire.Http.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,12 +7,12 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Aspire.Http\Conjecture.Aspire.Http.csproj" />
-    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
+    <ProjectReference Include="..\Conjecture.Xunit.V3\Conjecture.Xunit.V3.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/src/Conjecture.Aspire.Tests/Conjecture.Aspire.Tests.csproj
+++ b/src/Conjecture.Aspire.Tests/Conjecture.Aspire.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,7 +10,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Platform" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.Benchmarks.Tests/Conjecture.Benchmarks.Tests.csproj
+++ b/src/Conjecture.Benchmarks.Tests/Conjecture.Benchmarks.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.Core.Abstractions.Tests/Conjecture.Core.Abstractions.Tests.csproj
+++ b/src/Conjecture.Core.Abstractions.Tests/Conjecture.Core.Abstractions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Core.Tests/Conjecture.Core.Tests.csproj
+++ b/src/Conjecture.Core.Tests/Conjecture.Core.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,17 +9,19 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
     <ProjectReference Include="..\Conjecture.Interactions\Conjecture.Interactions.csproj" />
+    <ProjectReference Include="..\Conjecture.Xunit.V3\Conjecture.Xunit.V3.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
+    <Using Include="Conjecture.Xunit.V3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.EFCore.Tests/Conjecture.EFCore.Tests.csproj
+++ b/src/Conjecture.EFCore.Tests/Conjecture.EFCore.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
@@ -15,7 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.EFCore\Conjecture.EFCore.csproj" />
     <ProjectReference Include="..\Conjecture.Interactions\Conjecture.Interactions.csproj" />
-    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
+    <ProjectReference Include="..\Conjecture.Xunit.V3\Conjecture.Xunit.V3.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/src/Conjecture.Formatters.Tests/Conjecture.Formatters.Tests.csproj
+++ b/src/Conjecture.Formatters.Tests/Conjecture.Formatters.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.Generators.Tests/Conjecture.Generators.Tests.csproj
+++ b/src/Conjecture.Generators.Tests/Conjecture.Generators.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,7 +10,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.Grpc.Tests/Conjecture.Grpc.Tests.csproj
+++ b/src/Conjecture.Grpc.Tests/Conjecture.Grpc.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -12,7 +12,7 @@
     <PackageReference Include="Grpc.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Http.Tests/Conjecture.Http.Tests.csproj
+++ b/src/Conjecture.Http.Tests/Conjecture.Http.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
   </ItemGroup>

--- a/src/Conjecture.Interactions.Abstractions.Tests/Conjecture.Interactions.Abstractions.Tests.csproj
+++ b/src/Conjecture.Interactions.Abstractions.Tests/Conjecture.Interactions.Abstractions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Interactions.Tests/Conjecture.Interactions.Tests.csproj
+++ b/src/Conjecture.Interactions.Tests/Conjecture.Interactions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Interactive.Tests/Conjecture.Interactive.Tests.csproj
+++ b/src/Conjecture.Interactive.Tests/Conjecture.Interactive.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.JsonSchema.Abstractions.Tests/Conjecture.JsonSchema.Abstractions.Tests.csproj
+++ b/src/Conjecture.JsonSchema.Abstractions.Tests/Conjecture.JsonSchema.Abstractions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.JsonSchema.Tests/Conjecture.JsonSchema.Tests.csproj
+++ b/src/Conjecture.JsonSchema.Tests/Conjecture.JsonSchema.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.LinqPad.Tests/Conjecture.LinqPad.Tests.csproj
+++ b/src/Conjecture.LinqPad.Tests/Conjecture.LinqPad.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.Mcp.Tests/Conjecture.Mcp.Tests.csproj
+++ b/src/Conjecture.Mcp.Tests/Conjecture.Mcp.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.Messaging.AzureServiceBus.Tests/Conjecture.Messaging.AzureServiceBus.Tests.csproj
+++ b/src/Conjecture.Messaging.AzureServiceBus.Tests/Conjecture.Messaging.AzureServiceBus.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Messaging.RabbitMq.Tests/Conjecture.Messaging.RabbitMq.Tests.csproj
+++ b/src/Conjecture.Messaging.RabbitMq.Tests/Conjecture.Messaging.RabbitMq.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Messaging.Tests/Conjecture.Messaging.Tests.csproj
+++ b/src/Conjecture.Messaging.Tests/Conjecture.Messaging.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Money.Tests/Conjecture.Money.Tests.csproj
+++ b/src/Conjecture.Money.Tests/Conjecture.Money.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,12 +7,12 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Money\Conjecture.Money.csproj" />
-    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
+    <ProjectReference Include="..\Conjecture.Xunit.V3\Conjecture.Xunit.V3.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/src/Conjecture.OpenApi.Tests/Conjecture.OpenApi.Tests.csproj
+++ b/src/Conjecture.OpenApi.Tests/Conjecture.OpenApi.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.OpenApi" />
     <PackageReference Include="Microsoft.OpenApi.Readers" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.Protobuf.Tests/Conjecture.Protobuf.Tests.csproj
+++ b/src/Conjecture.Protobuf.Tests/Conjecture.Protobuf.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -10,7 +10,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 

--- a/src/Conjecture.Regex.Tests/Conjecture.Regex.Tests.csproj
+++ b/src/Conjecture.Regex.Tests/Conjecture.Regex.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -8,12 +8,12 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Regex\Conjecture.Regex.csproj" />
-    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
+    <ProjectReference Include="..\Conjecture.Xunit.V3\Conjecture.Xunit.V3.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/src/Conjecture.Testing.Abstractions.Tests/Conjecture.Testing.Abstractions.Tests.csproj
+++ b/src/Conjecture.Testing.Abstractions.Tests/Conjecture.Testing.Abstractions.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Conjecture.Time.Tests/Conjecture.Time.Tests.csproj
+++ b/src/Conjecture.Time.Tests/Conjecture.Time.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,12 +7,12 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Conjecture.Time\Conjecture.Time.csproj" />
-    <ProjectReference Include="..\Conjecture.Xunit\Conjecture.Xunit.csproj" />
+    <ProjectReference Include="..\Conjecture.Xunit.V3\Conjecture.Xunit.V3.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/src/Conjecture.Time.Tests/TimeProviderArbitraryTests.cs
+++ b/src/Conjecture.Time.Tests/TimeProviderArbitraryTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Concurrent;
 
 using Conjecture.Core;
 using Conjecture.Time;
-using Conjecture.Xunit;
+using Conjecture.Xunit.V3;
 
 using Microsoft.Extensions.Time.Testing;
 

--- a/src/Conjecture.Tool.Tests/Conjecture.Tool.Tests.csproj
+++ b/src/Conjecture.Tool.Tests/Conjecture.Tool.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,6 +5,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <NoWarn>$(NoWarn);CS1573</NoWarn> <!-- Allow undocumented params on overrides -->
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn> <!-- xUnit v3: don't enforce TestContext.Current.CancellationToken -->
 
     <!-- Nullability -->
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Description

Migrates every test project in the solution from xUnit v2 to xUnit v3, picking up async-aware test contexts, `IAsyncLifetime` returning `ValueTask`, and the Microsoft Testing Platform runner.

**Project-by-project migration order:**
1. `Conjecture.Analyzers.Tests`
2. `Conjecture.Mcp.Tests`
3. `Conjecture.Core.Tests`
4. `Conjecture.Generators.Tests`
5. Remaining `[Property]`-using test projects (one commit, batched)
6. Aspire test projects (one commit, batched)
7. Abstractions test projects (one commit, batched)
8. Remaining fact-only test projects (one commit, batched)

Each commit swaps `xunit` → `xunit.v3` package references, keeps `xunit.runner.visualstudio` (which works for both), and updates any `IAsyncLifetime` impls to the v3 `ValueTask`-returning shape. The `Conjecture.Xunit.Tests` (v2 adapter tests) project intentionally stays on xUnit v2 — it's testing the v2 adapter against v2 itself.

No behavioural change to production code or to test assertions; pure framework upgrade.

## Type of change

- [ ] Bug fix
- [ ] New feature / strategy
- [x] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] \`dotnet test src/\` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows \`.editorconfig\` code style