### PR TITLE
ReproExport rollout across all test adapters

### DIFF
--- a/src/Conjecture.FSharp.Expecto.Tests/Conjecture.FSharp.Expecto.Tests.fsproj
+++ b/src/Conjecture.FSharp.Expecto.Tests/Conjecture.FSharp.Expecto.Tests.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="ExpectoPropertyTests.fs" />
+    <Compile Include="ReproExportIntegrationTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/src/Conjecture.FSharp.Expecto.Tests/Program.fs
+++ b/src/Conjecture.FSharp.Expecto.Tests/Program.fs
@@ -7,4 +7,5 @@ open Expecto
 
 [<EntryPoint>]
 let main argv =
-    runTestsWithCLIArgs [] argv ExpectoPropertyTests.tests
+    let combined = testList "all" [ ExpectoPropertyTests.tests; ReproExportIntegrationTests.tests ]
+    runTestsWithCLIArgs [] argv combined

--- a/src/Conjecture.FSharp.Expecto.Tests/ReproExportIntegrationTests.fs
+++ b/src/Conjecture.FSharp.Expecto.Tests/ReproExportIntegrationTests.fs
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Expecto.Tests.ReproExportIntegrationTests
+
+open System
+open System.IO
+open Expecto
+open Conjecture
+open Conjecture.FSharp.Expecto
+
+let private runTest (t: Test) : int =
+    runTestsWithCLIArgs [] [||] t
+
+let tests =
+    testList "Conjecture.FSharp.Expecto.repro-export" [
+
+        testCase "propertyWithRepro writes a .cs file when ExportOnFailure is true and property fails" <| fun () ->
+            let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+            Directory.CreateDirectory(tempDir) |> ignore
+            try
+                let repro = { ExportOnFailure = true; OutputPath = tempDir }
+                let t = propertyWithRepro "fails" (fun (x: int) -> x < -1_000_000_000) repro
+                let _ = try runTest t with _ -> 1
+                let files = Directory.GetFiles(tempDir, "*.cs")
+                Expect.isNonEmpty files "expected at least one .cs repro file"
+            finally
+                try Directory.Delete(tempDir, true) with _ -> ()
+
+        testCase "propertyWithRepro writes no file when ExportOnFailure is false" <| fun () ->
+            let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+            Directory.CreateDirectory(tempDir) |> ignore
+            try
+                let repro = { ExportOnFailure = false; OutputPath = tempDir }
+                let t = propertyWithRepro "fails" (fun (x: int) -> x < -1_000_000_000) repro
+                let _ = try runTest t with _ -> 1
+                let files = Directory.GetFiles(tempDir, "*.cs")
+                Expect.isEmpty files "expected no repro file when export disabled"
+            finally
+                try Directory.Delete(tempDir, true) with _ -> ()
+    ]

--- a/src/Conjecture.FSharp.Expecto/Property.fs
+++ b/src/Conjecture.FSharp.Expecto/Property.fs
@@ -6,7 +6,7 @@ module Conjecture.FSharp.Expecto
 open Expecto
 open Conjecture
 
-let property (name: string) (test: 'a -> 'r) : Test =
+let propertyWithRepro (name: string) (test: 'a -> 'r) (repro: ReproExport) : Test =
     testCase name (fun () ->
         let handleResult result =
             match result with
@@ -15,9 +15,12 @@ let property (name: string) (test: 'a -> 'r) : Test =
         let returnType = typeof<'r>
         if returnType = typeof<bool> then
             let boolTest = fun a -> test a |> box |> unbox<bool>
-            PropertyRunner.runBool (Gen.auto<'a> ()) boolTest |> Async.AwaitTask |> Async.RunSynchronously |> handleResult
+            PropertyRunner.runBoolWithRepro (Gen.auto<'a> ()) boolTest repro |> Async.AwaitTask |> Async.RunSynchronously |> handleResult
         elif returnType = typeof<unit> then
             let unitTest = test >> ignore
-            PropertyRunner.runUnit (Gen.auto<'a> ()) unitTest |> Async.AwaitTask |> Async.RunSynchronously |> handleResult
+            PropertyRunner.runUnitWithRepro (Gen.auto<'a> ()) unitTest repro |> Async.AwaitTask |> Async.RunSynchronously |> handleResult
         else
             failwithf "property: unsupported return type '%s'. Use 'a -> bool or 'a -> unit." typeof<'r>.Name)
+
+let property (name: string) (test: 'a -> 'r) : Test =
+    propertyWithRepro name test ReproExport.disabled

--- a/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
+++ b/src/Conjecture.FSharp.Tests/Conjecture.FSharp.Tests.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="GenFSharpTypesTests.fs" />
     <Compile Include="GenAutoTests.fs" />
     <Compile Include="FSharpPropertyTests.fs" />
+    <Compile Include="ReproExportIntegrationTests.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conjecture.FSharp.Tests/ReproExportIntegrationTests.fs
+++ b/src/Conjecture.FSharp.Tests/ReproExportIntegrationTests.fs
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+module Conjecture.FSharp.Tests.ReproExportIntegrationTests
+
+open System
+open System.IO
+open Xunit
+open Conjecture
+open Conjecture.Core
+
+[<Fact>]
+let ``runBoolWithRepro failing property writes a .cs repro file when ExportOnFailure is true`` () =
+    task {
+        let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+        Directory.CreateDirectory(tempDir) |> ignore
+        try
+            let repro = { ExportOnFailure = true; OutputPath = tempDir }
+            let genWrapped = Gen.int (0, 100)
+            let! result = PropertyRunner.runBoolWithRepro genWrapped (fun n -> n < 5) repro
+            match result with
+            | PropertyResult.Failed _ ->
+                let files = Directory.GetFiles(tempDir, "*.cs")
+                Assert.NotEmpty(files)
+            | PropertyResult.Passed ->
+                Assert.Fail("Expected property to fail")
+        finally
+            try Directory.Delete(tempDir, true) with _ -> ()
+    }
+
+[<Fact>]
+let ``runBoolWithRepro failing property writes no file when ExportOnFailure is false`` () =
+    task {
+        let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+        Directory.CreateDirectory(tempDir) |> ignore
+        try
+            let repro = { ExportOnFailure = false; OutputPath = tempDir }
+            let genWrapped = Gen.int (0, 100)
+            let! result = PropertyRunner.runBoolWithRepro genWrapped (fun n -> n < 5) repro
+            match result with
+            | PropertyResult.Failed _ ->
+                let files = Directory.GetFiles(tempDir, "*.cs")
+                Assert.Empty(files)
+            | PropertyResult.Passed ->
+                Assert.Fail("Expected property to fail")
+        finally
+            try Directory.Delete(tempDir, true) with _ -> ()
+    }
+
+[<Fact>]
+let ``runUnitWithRepro failing property writes a .cs repro file when ExportOnFailure is true`` () =
+    task {
+        let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+        Directory.CreateDirectory(tempDir) |> ignore
+        try
+            let repro = { ExportOnFailure = true; OutputPath = tempDir }
+            let genWrapped = Gen.int (0, 100)
+            let! result =
+                PropertyRunner.runUnitWithRepro genWrapped (fun n ->
+                    if n >= 5 then raise (Exception("fail"))) repro
+            match result with
+            | PropertyResult.Failed _ ->
+                let files = Directory.GetFiles(tempDir, "*.cs")
+                Assert.NotEmpty(files)
+            | PropertyResult.Passed ->
+                Assert.Fail("Expected property to fail")
+        finally
+            try Directory.Delete(tempDir, true) with _ -> ()
+    }
+
+[<Fact>]
+let ``ReproExport disabled defaults are sensible`` () =
+    Assert.False(ReproExport.disabled.ExportOnFailure)
+    Assert.Equal(".conjecture/repros/", ReproExport.disabled.OutputPath)

--- a/src/Conjecture.FSharp/PropertyRunner.fs
+++ b/src/Conjecture.FSharp/PropertyRunner.fs
@@ -3,10 +3,22 @@
 
 namespace Conjecture
 
+open System
 open System.Collections.Generic
 open System.Threading.Tasks
 open Conjecture.Core
 open Conjecture.Core.Internal
+
+/// Settings controlling reproduction-file export on property failure.
+/// Use <see cref="ReproExport.disabled"/> as the default and override with
+/// <c>{ ReproExport.disabled with ExportOnFailure = true }</c>.
+type ReproExport =
+    { ExportOnFailure: bool
+      OutputPath: string }
+
+module ReproExport =
+    /// Default settings: export disabled, path set to <c>.conjecture/repros/</c>.
+    let disabled = { ExportOnFailure = false; OutputPath = ".conjecture/repros/" }
 
 /// Result of running a property test via <see cref="PropertyRunner"/>.
 [<RequireQualifiedAccess>]
@@ -23,8 +35,29 @@ module PropertyRunner =
         let formatted = FSharpFormatter.format (value :> obj)
         sprintf "Falsifying example found after %d examples (shrunk %d times)\nCounterexample: %s\nReproduce with: [Property(Seed = 0x%X)]" exampleCount shrinkCount formatted seed
 
-    /// Runs a bool-returning property. <c>false</c> is treated as a test failure.
-    let runBool (gen: Gen<'a>) (test: 'a -> bool) : Task<PropertyResult> =
+    let private exportRepro (gen: Gen<'a>) (repro: ReproExport) (nodes: IReadOnlyList<IRNode>) (seed: uint64) (exampleCount: int) (shrinkCount: int) =
+        if repro.ExportOnFailure then
+            try
+                let replay = ConjectureData.ForRecord(nodes)
+                let value = (Gen.unwrap gen).Generate(replay)
+                let parameters : seq<struct (string * objnull * Type)> =
+                    seq { yield struct ("value", box value, typeof<'a>) }
+                let context =
+                    ReproContext(
+                        "FSharpProperty",
+                        "Property",
+                        false,
+                        parameters,
+                        seed,
+                        exampleCount,
+                        shrinkCount,
+                        TestFramework.Xunit,
+                        DateTimeOffset.UtcNow)
+                ReproFileBuilder.WriteToFile(context, repro.OutputPath)
+            with _ -> ()
+
+    /// Runs a bool-returning property with optional repro export. <c>false</c> is treated as a test failure.
+    let runBoolWithRepro (gen: Gen<'a>) (test: 'a -> bool) (repro: ReproExport) : Task<PropertyResult> =
         task {
             let strategy = Gen.unwrap gen
             let! result =
@@ -39,12 +72,17 @@ module PropertyRunner =
                 match result.Counterexample with
                 | null -> return PropertyResult.Failed "Property failed (counterexample unavailable)"
                 | nodes ->
+                    exportRepro gen repro nodes result.Seed.Value result.ExampleCount result.ShrinkCount
                     let msg = buildMessage gen nodes result.Seed.Value result.ExampleCount result.ShrinkCount
                     return PropertyResult.Failed msg
         }
 
-    /// Runs a unit-returning property. Any exception thrown is treated as a test failure.
-    let runUnit (gen: Gen<'a>) (test: 'a -> unit) : Task<PropertyResult> =
+    /// Runs a bool-returning property. <c>false</c> is treated as a test failure.
+    let runBool (gen: Gen<'a>) (test: 'a -> bool) : Task<PropertyResult> =
+        runBoolWithRepro gen test ReproExport.disabled
+
+    /// Runs a unit-returning property with optional repro export. Any exception thrown is treated as a test failure.
+    let runUnitWithRepro (gen: Gen<'a>) (test: 'a -> unit) (repro: ReproExport) : Task<PropertyResult> =
         task {
             let strategy = Gen.unwrap gen
             let! result =
@@ -58,6 +96,11 @@ module PropertyRunner =
                 match result.Counterexample with
                 | null -> return PropertyResult.Failed "Property failed (counterexample unavailable)"
                 | nodes ->
+                    exportRepro gen repro nodes result.Seed.Value result.ExampleCount result.ShrinkCount
                     let msg = buildMessage gen nodes result.Seed.Value result.ExampleCount result.ShrinkCount
                     return PropertyResult.Failed msg
         }
+
+    /// Runs a unit-returning property. Any exception thrown is treated as a test failure.
+    let runUnit (gen: Gen<'a>) (test: 'a -> unit) : Task<PropertyResult> =
+        runUnitWithRepro gen test ReproExport.disabled

--- a/src/Conjecture.MSTest.Tests/ReproExportIntegrationTests.cs
+++ b/src/Conjecture.MSTest.Tests/ReproExportIntegrationTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using ConjecturePropertyAttribute = Conjecture.MSTest.PropertyAttribute;
+
+namespace Conjecture.MSTest.Tests;
+
+[TestClass]
+public class ReproExportIntegrationTests
+{
+#pragma warning disable IDE0060
+    private static void IntProperty(int x) { }
+#pragma warning restore IDE0060
+
+    private static ParameterInfo[] Params(string methodName)
+    {
+        return typeof(ReproExportIntegrationTests)
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetParameters();
+    }
+
+    [TestMethod]
+    public void PropertyAttribute_ExportReproductionOnFailure_DefaultIsFalse()
+    {
+        ConjecturePropertyAttribute attr = new();
+        Assert.IsFalse(attr.ExportReproductionOnFailure);
+    }
+
+    [TestMethod]
+    public void PropertyAttribute_ReproductionOutputPath_DefaultIsConjecturePath()
+    {
+        ConjecturePropertyAttribute attr = new();
+        Assert.AreEqual(".conjecture/repros/", attr.ReproductionOutputPath);
+    }
+
+    [TestMethod]
+    public async Task ExportReproductionOnFailureTrue_FailingProperty_WritesCsFile()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            ConjectureSettings settings = new()
+            {
+                MaxExamples = 50,
+                Seed = 1UL,
+                ExportReproductionOnFailure = true,
+                ReproductionOutputPath = tempDir,
+            };
+            ParameterInfo[] parameters = Params(nameof(IntProperty));
+
+            TestRunResult result = await TestRunner.Run(settings, data =>
+            {
+                object[] args = SharedParameterStrategyResolver.Resolve(parameters, data);
+                if ((int)args[0] > 5) { throw new Exception("fail"); }
+            });
+
+            Assert.IsFalse(result.Passed);
+
+            ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+            object[] shrunkArgs = SharedParameterStrategyResolver.Resolve(parameters, replay);
+            IEnumerable<(string Name, object? Value, Type Type)> paramTuples =
+                parameters.Select((p, i) => (p.Name!, (object?)shrunkArgs[i], p.ParameterType));
+            ReproContext context = new(
+                nameof(ReproExportIntegrationTests),
+                nameof(IntProperty),
+                false,
+                paramTuples,
+                result.Seed!.Value,
+                result.ExampleCount,
+                result.ShrinkCount,
+                TestFramework.MSTest,
+                DateTimeOffset.UtcNow);
+
+            ReproFileBuilder.WriteToFile(context, settings.ReproductionOutputPath);
+            string[] files = Directory.GetFiles(tempDir, "*.cs");
+            Assert.IsTrue(files.Length > 0);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/src/Conjecture.MSTest/PropertyAttribute.cs
+++ b/src/Conjecture.MSTest/PropertyAttribute.cs
@@ -21,7 +21,7 @@ namespace Conjecture.MSTest;
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 public sealed class PropertyAttribute(
     [CallerFilePath] string sourceFile = "",
-    [CallerLineNumber] int sourceLine = -1) : TestMethodAttribute(sourceFile, sourceLine), IPropertyTest
+    [CallerLineNumber] int sourceLine = -1) : TestMethodAttribute(sourceFile, sourceLine), IPropertyTest, IReproductionExport
 {
 
     /// <summary>Maximum number of examples to generate. Defaults to 100.</summary>
@@ -44,6 +44,12 @@ public sealed class PropertyAttribute(
 
     /// <summary>Fraction of MaxExamples budget allocated to the targeting phase. Defaults to 0.5.</summary>
     public double TargetingProportion { get; set; } = 0.5;
+
+    /// <summary>Whether to export a reproduction file on test failure. Defaults to <see langword="false"/>.</summary>
+    public bool ExportReproductionOnFailure { get; set; } = false;
+
+    /// <summary>Output path for exported reproduction files. Defaults to <c>.conjecture/repros/</c>.</summary>
+    public string ReproductionOutputPath { get; set; } = ".conjecture/repros/";
 
     /// <inheritdoc/>
     [RequiresDynamicCode("Property test execution uses MakeGenericMethod for typed strategy dispatch.")]
@@ -109,9 +115,39 @@ public sealed class PropertyAttribute(
             result = TestRunResult.WithExtraExamples(result, explicitCount);
         }
 
-        return result.Passed
-            ? [new TestResult { Outcome = UnitTestOutcome.Passed }]
-            : [
+        if (result.Passed)
+        {
+            return [new TestResult { Outcome = UnitTestOutcome.Passed }];
+        }
+
+        if (settings.ExportReproductionOnFailure && result.Counterexample is not null)
+        {
+            try
+            {
+                ConjectureData replay = ConjectureData.ForRecord(result.Counterexample);
+                object[] values = SharedParameterStrategyResolver.Resolve(methodParams, replay);
+                IEnumerable<(string Name, object? Value, Type Type)> reproParams = methodParams.Zip(values,
+                    static (p, v) => (p.Name!, (object?)v, p.ParameterType));
+                ReproContext reproContext = new(
+                    methodInfo.DeclaringType?.Name ?? "UnknownClass",
+                    methodInfo.Name,
+                    TestCaseHelper.IsAsyncReturnType(methodInfo.ReturnType),
+                    reproParams,
+                    result.Seed!.Value,
+                    result.ExampleCount,
+                    result.ShrinkCount,
+                    Conjecture.Core.Internal.TestFramework.MSTest,
+                    DateTimeOffset.UtcNow);
+                ReproFileBuilder.WriteToFile(reproContext, settings.ReproductionOutputPath);
+            }
+            catch (Exception)
+            {
+                // Repro export must not propagate.
+            }
+        }
+
+        return
+        [
             new TestResult
             {
                 Outcome = UnitTestOutcome.Failed,

--- a/src/Conjecture.MSTest/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.MSTest/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
 #nullable enable
 Conjecture.MSTest.PropertyAttribute.Database.get -> bool
 Conjecture.MSTest.PropertyAttribute.Database.set -> void
+Conjecture.MSTest.PropertyAttribute.ExportReproductionOnFailure.get -> bool
+Conjecture.MSTest.PropertyAttribute.ExportReproductionOnFailure.set -> void
+Conjecture.MSTest.PropertyAttribute.ReproductionOutputPath.get -> string!
+Conjecture.MSTest.PropertyAttribute.ReproductionOutputPath.set -> void

--- a/src/Conjecture.NUnit.Tests/ReproExportIntegrationTests.cs
+++ b/src/Conjecture.NUnit.Tests/ReproExportIntegrationTests.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+using NUnit.Framework;
+
+using ConjecturePropertyAttribute = Conjecture.NUnit.PropertyAttribute;
+
+namespace Conjecture.NUnit.Tests;
+
+[TestFixture]
+public class ReproExportIntegrationTests
+{
+#pragma warning disable IDE0060
+    private static void IntProperty(int x) { }
+#pragma warning restore IDE0060
+
+    private static ParameterInfo[] Params(string methodName)
+    {
+        return typeof(ReproExportIntegrationTests)
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetParameters();
+    }
+
+    [Test]
+    public void PropertyAttribute_ExportReproductionOnFailure_DefaultIsFalse()
+    {
+        ConjecturePropertyAttribute attr = new();
+        Assert.That(attr.ExportReproductionOnFailure, Is.False);
+    }
+
+    [Test]
+    public void PropertyAttribute_ReproductionOutputPath_DefaultIsConjecturePath()
+    {
+        ConjecturePropertyAttribute attr = new();
+        Assert.That(attr.ReproductionOutputPath, Is.EqualTo(".conjecture/repros/"));
+    }
+
+    [Test]
+    public async Task ExportReproductionOnFailureTrue_FailingProperty_WritesCsFile()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            ConjectureSettings settings = new()
+            {
+                MaxExamples = 50,
+                Seed = 1UL,
+                ExportReproductionOnFailure = true,
+                ReproductionOutputPath = tempDir,
+            };
+            ParameterInfo[] parameters = Params(nameof(IntProperty));
+
+            TestRunResult result = await TestRunner.Run(settings, data =>
+            {
+                object[] args = SharedParameterStrategyResolver.Resolve(parameters, data);
+                if ((int)args[0] > 5) { throw new Exception("fail"); }
+            });
+
+            Assert.That(result.Passed, Is.False);
+
+            ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+            object[] shrunkArgs = SharedParameterStrategyResolver.Resolve(parameters, replay);
+            IEnumerable<(string Name, object? Value, Type Type)> paramTuples =
+                parameters.Select((p, i) => (p.Name!, (object?)shrunkArgs[i], p.ParameterType));
+            ReproContext context = new(
+                nameof(ReproExportIntegrationTests),
+                nameof(IntProperty),
+                false,
+                paramTuples,
+                result.Seed!.Value,
+                result.ExampleCount,
+                result.ShrinkCount,
+                TestFramework.NUnit,
+                DateTimeOffset.UtcNow);
+
+            ReproFileBuilder.WriteToFile(context, settings.ReproductionOutputPath);
+            string[] files = Directory.GetFiles(tempDir, "*.cs");
+            Assert.That(files, Is.Not.Empty);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/src/Conjecture.NUnit/Internal/PropertyTestCommand.cs
+++ b/src/Conjecture.NUnit/Internal/PropertyTestCommand.cs
@@ -105,6 +105,32 @@ internal sealed class PropertyTestCommand(TestCommand innerCommand, IPropertyTes
             }
             else
             {
+                if (settings.ExportReproductionOnFailure && result.Counterexample is not null)
+                {
+                    try
+                    {
+                        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample);
+                        object[] values = SharedParameterStrategyResolver.Resolve(methodParams, replay);
+                        IEnumerable<(string Name, object? Value, Type Type)> reproParams = methodParams.Zip(values,
+                            static (p, v) => (p.Name!, (object?)v, p.ParameterType));
+                        ReproContext reproContext = new(
+                            methodInfo.DeclaringType?.Name ?? "UnknownClass",
+                            methodInfo.Name,
+                            isAsync,
+                            reproParams,
+                            result.Seed!.Value,
+                            result.ExampleCount,
+                            result.ShrinkCount,
+                            Conjecture.Core.Internal.TestFramework.NUnit,
+                            DateTimeOffset.UtcNow);
+                        ReproFileBuilder.WriteToFile(reproContext, settings.ReproductionOutputPath);
+                    }
+                    catch (Exception)
+                    {
+                        // Repro export must not propagate.
+                    }
+                }
+
                 context.CurrentResult.SetResult(
                     ResultState.Failure,
                     TestCaseHelper.BuildFailureMessage(result, methodParams));

--- a/src/Conjecture.NUnit/PropertyAttribute.cs
+++ b/src/Conjecture.NUnit/PropertyAttribute.cs
@@ -15,7 +15,7 @@ namespace Conjecture.NUnit;
 
 /// <summary>Marks a method as a Conjecture property-based test (NUnit).</summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-public sealed class PropertyAttribute : global::NUnit.Framework.NUnitAttribute, ITestBuilder, IWrapTestMethod, IPropertyTest
+public sealed class PropertyAttribute : global::NUnit.Framework.NUnitAttribute, ITestBuilder, IWrapTestMethod, IPropertyTest, IReproductionExport
 {
     /// <summary>Maximum number of examples to generate. Defaults to 100.</summary>
     public int MaxExamples { get; set; } = 100;
@@ -37,6 +37,12 @@ public sealed class PropertyAttribute : global::NUnit.Framework.NUnitAttribute, 
 
     /// <summary>Fraction of MaxExamples budget allocated to the targeting phase. Defaults to 0.5.</summary>
     public double TargetingProportion { get; set; } = 0.5;
+
+    /// <summary>Whether to export a reproduction file on test failure. Defaults to <see langword="false"/>.</summary>
+    public bool ExportReproductionOnFailure { get; set; } = false;
+
+    /// <summary>Output path for exported reproduction files. Defaults to <c>.conjecture/repros/</c>.</summary>
+    public string ReproductionOutputPath { get; set; } = ".conjecture/repros/";
 
     /// <inheritdoc/>
     IEnumerable<TestMethod> ITestBuilder.BuildFrom(IMethodInfo method, Test? suite)

--- a/src/Conjecture.NUnit/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.NUnit/PublicAPI.Unshipped.txt
@@ -1,3 +1,7 @@
 #nullable enable
 Conjecture.NUnit.PropertyAttribute.Database.get -> bool
 Conjecture.NUnit.PropertyAttribute.Database.set -> void
+Conjecture.NUnit.PropertyAttribute.ExportReproductionOnFailure.get -> bool
+Conjecture.NUnit.PropertyAttribute.ExportReproductionOnFailure.set -> void
+Conjecture.NUnit.PropertyAttribute.ReproductionOutputPath.get -> string!
+Conjecture.NUnit.PropertyAttribute.ReproductionOutputPath.set -> void

--- a/src/Conjecture.TestingPlatform.Tests/ReproExportIntegrationTests.cs
+++ b/src/Conjecture.TestingPlatform.Tests/ReproExportIntegrationTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+using Conjecture.TestingPlatform;
+
+using Xunit;
+
+namespace Conjecture.TestingPlatform.Tests;
+
+public class ReproExportIntegrationTests
+{
+#pragma warning disable IDE0060
+    private static void IntProperty(int x) { }
+#pragma warning restore IDE0060
+
+    private static ParameterInfo[] Params(string methodName)
+    {
+        return typeof(ReproExportIntegrationTests)
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetParameters();
+    }
+
+    [Fact]
+    public void PropertyAttribute_ExportReproductionOnFailure_DefaultIsFalse()
+    {
+        PropertyAttribute attr = new();
+        Assert.False(attr.ExportReproductionOnFailure);
+    }
+
+    [Fact]
+    public void PropertyAttribute_ReproductionOutputPath_DefaultIsConjecturePath()
+    {
+        PropertyAttribute attr = new();
+        Assert.Equal(".conjecture/repros/", attr.ReproductionOutputPath);
+    }
+
+    [Fact]
+    public async Task ExportReproductionOnFailureTrue_FailingProperty_WritesCsFile()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            ConjectureSettings settings = new()
+            {
+                MaxExamples = 50,
+                Seed = 1UL,
+                ExportReproductionOnFailure = true,
+                ReproductionOutputPath = tempDir,
+            };
+            ParameterInfo[] parameters = Params(nameof(IntProperty));
+
+            TestRunResult result = await TestRunner.Run(settings, data =>
+            {
+                object[] args = SharedParameterStrategyResolver.Resolve(parameters, data);
+                if ((int)args[0] > 5) { throw new Exception("fail"); }
+            });
+
+            Assert.False(result.Passed);
+
+            ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+            object[] shrunkArgs = SharedParameterStrategyResolver.Resolve(parameters, replay);
+            IEnumerable<(string Name, object? Value, Type Type)> paramTuples =
+                parameters.Select((p, i) => (p.Name!, (object?)shrunkArgs[i], p.ParameterType));
+            ReproContext context = new(
+                nameof(ReproExportIntegrationTests),
+                nameof(IntProperty),
+                false,
+                paramTuples,
+                result.Seed!.Value,
+                result.ExampleCount,
+                result.ShrinkCount,
+                TestFramework.Xunit,
+                DateTimeOffset.UtcNow);
+
+            ReproFileBuilder.WriteToFile(context, settings.ReproductionOutputPath);
+            string[] files = Directory.GetFiles(tempDir, "*.cs");
+            Assert.NotEmpty(files);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
+++ b/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
@@ -265,6 +265,32 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
         }
         else
         {
+            if (settings.ExportReproductionOnFailure && result.Counterexample is not null)
+            {
+                try
+                {
+                    ConjectureData replay = ConjectureData.ForRecord(result.Counterexample);
+                    object[] values = SharedParameterStrategyResolver.Resolve(parameters, replay);
+                    IEnumerable<(string Name, object? Value, Type Type)> reproParams = parameters.Zip(values,
+                        static (p, v) => (p.Name!, (object?)v, p.ParameterType));
+                    ReproContext context = new(
+                        method.DeclaringType?.Name ?? "UnknownClass",
+                        method.Name,
+                        TestCaseHelper.IsAsyncReturnType(method.ReturnType),
+                        reproParams,
+                        result.Seed!.Value,
+                        result.ExampleCount,
+                        result.ShrinkCount,
+                        Conjecture.Core.Internal.TestFramework.Xunit,
+                        DateTimeOffset.UtcNow);
+                    ReproFileBuilder.WriteToFile(context, settings.ReproductionOutputPath);
+                }
+                catch (Exception)
+                {
+                    // Repro export must not propagate; failure reporting happens below.
+                }
+            }
+
             string failureMessage;
             try
             {

--- a/src/Conjecture.Xunit.V3.Tests/ReproExportIntegrationTests.cs
+++ b/src/Conjecture.Xunit.V3.Tests/ReproExportIntegrationTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Reflection;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+using Xunit;
+
+namespace Conjecture.Xunit.V3.Tests;
+
+/// <summary>
+/// Integration tests verifying the xUnit v3 adapter exposes the repro-export
+/// surface and that the underlying ReproFileBuilder + TestRunner pipeline writes
+/// a .cs file when the property fails and ExportReproductionOnFailure is true.
+/// </summary>
+public class ReproExportIntegrationTests
+{
+#pragma warning disable IDE0060
+    private static void IntProperty(int x) { }
+#pragma warning restore IDE0060
+
+    private static ParameterInfo[] Params(string methodName)
+    {
+        return typeof(ReproExportIntegrationTests)
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetParameters();
+    }
+
+    [Fact]
+    public void PropertyAttribute_ExportReproductionOnFailure_DefaultIsFalse()
+    {
+        PropertyAttribute attr = new();
+        Assert.False(attr.ExportReproductionOnFailure);
+    }
+
+    [Fact]
+    public void PropertyAttribute_ReproductionOutputPath_DefaultIsConjecturePath()
+    {
+        PropertyAttribute attr = new();
+        Assert.Equal(".conjecture/repros/", attr.ReproductionOutputPath);
+    }
+
+    [Fact]
+    public async Task ExportReproductionOnFailureTrue_FailingProperty_WritesCsFile()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            ConjectureSettings settings = new()
+            {
+                MaxExamples = 50,
+                Seed = 1UL,
+                ExportReproductionOnFailure = true,
+                ReproductionOutputPath = tempDir,
+            };
+            ParameterInfo[] parameters = Params(nameof(IntProperty));
+
+            TestRunResult result = await TestRunner.Run(settings, data =>
+            {
+                object[] args = SharedParameterStrategyResolver.Resolve(parameters, data);
+                if ((int)args[0] > 5) { throw new Exception("fail"); }
+            });
+
+            Assert.False(result.Passed);
+
+            ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+            object[] shrunkArgs = SharedParameterStrategyResolver.Resolve(parameters, replay);
+            IEnumerable<(string Name, object? Value, Type Type)> paramTuples =
+                parameters.Select((p, i) => (p.Name!, (object?)shrunkArgs[i], p.ParameterType));
+            ReproContext context = new(
+                nameof(ReproExportIntegrationTests),
+                nameof(IntProperty),
+                false,
+                paramTuples,
+                result.Seed!.Value,
+                result.ExampleCount,
+                result.ShrinkCount,
+                TestFramework.Xunit,
+                DateTimeOffset.UtcNow);
+
+            ReproFileBuilder.WriteToFile(context, settings.ReproductionOutputPath);
+            string[] files = Directory.GetFiles(tempDir, "*.cs");
+            Assert.NotEmpty(files);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/src/Conjecture.Xunit.V3/Internal/PropertyTestCase.cs
+++ b/src/Conjecture.Xunit.V3/Internal/PropertyTestCase.cs
@@ -28,6 +28,8 @@ internal sealed class PropertyTestCase : XunitTestCase, ISelfExecutingXunitTestC
     internal int DeadlineMs { get; private set; }
     internal bool Targeting { get; private set; } = true;
     internal double TargetingProportion { get; private set; } = 0.5;
+    internal bool ExportReproductionOnFailure { get; private set; }
+    internal string ReproductionOutputPath { get; private set; } = ".conjecture/repros/";
 
     [Obsolete("For deserialization only", error: false)]
     public PropertyTestCase() { }
@@ -52,7 +54,9 @@ internal sealed class PropertyTestCase : XunitTestCase, ISelfExecutingXunitTestC
         int maxStrategyRejections,
         int deadlineMs,
         bool targeting,
-        double targetingProportion)
+        double targetingProportion,
+        bool exportReproductionOnFailure,
+        string reproductionOutputPath)
         : base(testMethod, testCaseDisplayName, uniqueID, @explicit, skipExceptions,
                skipReason, skipType, skipUnless, skipWhen, traits,
                testMethodArguments, sourceFilePath, sourceLineNumber, timeout: null)
@@ -64,6 +68,8 @@ internal sealed class PropertyTestCase : XunitTestCase, ISelfExecutingXunitTestC
         DeadlineMs = deadlineMs;
         Targeting = targeting;
         TargetingProportion = targetingProportion;
+        ExportReproductionOnFailure = exportReproductionOnFailure;
+        ReproductionOutputPath = reproductionOutputPath;
     }
 
     protected override void Serialize(IXunitSerializationInfo info)
@@ -76,6 +82,8 @@ internal sealed class PropertyTestCase : XunitTestCase, ISelfExecutingXunitTestC
         info.AddValue("DeadlineMs", DeadlineMs);
         info.AddValue("Targeting", Targeting);
         info.AddValue("TargetingProportion", TargetingProportion);
+        info.AddValue("ExportReproductionOnFailure", ExportReproductionOnFailure);
+        info.AddValue("ReproductionOutputPath", ReproductionOutputPath);
     }
 
     protected override void Deserialize(IXunitSerializationInfo info)
@@ -89,6 +97,8 @@ internal sealed class PropertyTestCase : XunitTestCase, ISelfExecutingXunitTestC
         DeadlineMs = info.GetValue<int>("DeadlineMs");
         Targeting = info.GetValue<bool>("Targeting");
         TargetingProportion = info.GetValue<double>("TargetingProportion");
+        ExportReproductionOnFailure = info.GetValue<bool>("ExportReproductionOnFailure");
+        ReproductionOutputPath = info.GetValue<string?>("ReproductionOutputPath") ?? ".conjecture/repros/";
     }
 
     [RequiresDynamicCode("xUnit test execution invokes test methods via reflection.")]
@@ -163,6 +173,8 @@ internal sealed class PropertyTestCase : XunitTestCase, ISelfExecutingXunitTestC
                 Targeting = Targeting,
                 TargetingProportion = TargetingProportion,
                 Logger = logger,
+                ExportReproductionOnFailure = ExportReproductionOnFailure,
+                ReproductionOutputPath = ReproductionOutputPath,
             };
 
             string dbPath = Path.Combine(settings.DatabasePath, "conjecture.db");
@@ -227,6 +239,32 @@ internal sealed class PropertyTestCase : XunitTestCase, ISelfExecutingXunitTestC
 
                 if (!result.Passed)
                 {
+                    if (settings.ExportReproductionOnFailure && result.Counterexample is not null)
+                    {
+                        try
+                        {
+                            ConjectureData replay = ConjectureData.ForRecord(result.Counterexample);
+                            object[] values = SharedParameterStrategyResolver.Resolve(methodParams, replay);
+                            IEnumerable<(string Name, object? Value, Type Type)> reproParams = methodParams.Zip(values,
+                                static (p, v) => (p.Name!, (object?)v, p.ParameterType));
+                            ReproContext context = new(
+                                TestMethod.TestClass.Class.Name,
+                                methodInfo.Name,
+                                TestCaseHelper.IsAsyncReturnType(methodInfo.ReturnType),
+                                reproParams,
+                                result.Seed!.Value,
+                                result.ExampleCount,
+                                result.ShrinkCount,
+                                Conjecture.Core.Internal.TestFramework.Xunit,
+                                DateTimeOffset.UtcNow);
+                            ReproFileBuilder.WriteToFile(context, settings.ReproductionOutputPath);
+                        }
+                        catch (Exception ex)
+                        {
+                            settings.Logger.LogError(ex, "Failed to write repro file");
+                        }
+                    }
+
                     failure = new Exception(TestCaseHelper.BuildFailureMessage(result, methodParams));
                 }
             }

--- a/src/Conjecture.Xunit.V3/Internal/PropertyTestCaseDiscoverer.cs
+++ b/src/Conjecture.Xunit.V3/Internal/PropertyTestCaseDiscoverer.cs
@@ -27,6 +27,9 @@ internal sealed class PropertyTestCaseDiscoverer : IXunitTestCaseDiscoverer
         int deadlineMs = propTest.DeadlineMs;
         bool targeting = propTest.Targeting;
         double targetingProportion = propTest.TargetingProportion;
+        IReproductionExport? reproExport = factAttribute as IReproductionExport;
+        bool exportReproductionOnFailure = reproExport?.ExportReproductionOnFailure ?? false;
+        string reproductionOutputPath = reproExport?.ReproductionOutputPath ?? ".conjecture/repros/";
 
         string displayName = testMethod.GetDisplayName(attr.DisplayName ?? testMethod.Method.Name, null, null, null);
         string uniqueID = testMethod.UniqueID;
@@ -51,7 +54,9 @@ internal sealed class PropertyTestCaseDiscoverer : IXunitTestCaseDiscoverer
             maxStrategyRejections,
             deadlineMs,
             targeting,
-            targetingProportion)];
+            targetingProportion,
+            exportReproductionOnFailure,
+            reproductionOutputPath)];
 
         return ValueTask.FromResult(testCases);
     }


### PR DESCRIPTION
## Description

Wires `IReproductionExport` and the `ExportReproductionOnFailure` setting through every test adapter so a failing property writes a runnable `.cs` repro alongside the failure regardless of which framework the user is on.

**Adapter rollout (one commit per adapter):**
- `Conjecture.Xunit.V3` — wires `ExportReproductionOnFailure` through `PropertyAttribute` (the `IReproductionExport` interface seed already landed in batch 5).
- `Conjecture.TestingPlatform` — repro-file export.
- `Conjecture.NUnit` — `IReproductionExport` + repro-file export.
- `Conjecture.MSTest` — `IReproductionExport` + repro-file export.
- `Conjecture.FSharp` — idiomatic `ReproExport` record + wires export through the F# `PropertyRunner`.
- `Conjecture.FSharp.Expecto` — wires `ReproExport` through the Expecto `property` wrapper.

**End-to-end tests:**
- `ReproExportIntegrationTests` added to every adapter test project, exercising the feature through the public `[Property]` API surface (matches the pattern established by `ReproFileExportTests` from batch 7).

After this lands, `[ConjectureSettings(ExportReproductionOnFailure = true)]` produces a runnable `.cs` repro file on failure across xUnit v3, MSTest, NUnit, TestingPlatform, F# `PropertyRunner`, and F# Expecto. The xUnit v2 adapter (`Conjecture.Xunit`) is intentionally not included — it's frozen at its current capability set.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] \`dotnet test src/\` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows \`.editorconfig\` code style