### PR TITLE
[620] Network primitives: IPAddress, IPEndPoint, Uri, MailAddress

### DIFF
--- a/docs/site/articles/how-to/property-test-network-code.md
+++ b/docs/site/articles/how-to/property-test-network-code.md
@@ -1,0 +1,111 @@
+# How to property-test network code
+
+Use `Strategy.IPAddresses`, `Strategy.IPEndPoints`, `Strategy.Uris`, and `Strategy.EmailAddresses` to drive parsers, validators, and routing code with hundreds of address-shaped inputs per run — and let the shrinker hand you the smallest counterexample.
+
+## Property-test a URL parser
+
+Suppose you have a custom parser that pulls the host out of an absolute URL:
+
+```csharp
+public static class UrlInspector
+{
+    public static string GetHost(string url) =>
+        new Uri(url, UriKind.Absolute).Host;
+}
+```
+
+Write a property that proves the parser agrees with `Uri.Host` for any well-formed URL Conjecture can produce:
+
+```csharp
+using Conjecture.Core;
+using Xunit;
+
+public class UrlInspectorTests
+{
+    [Property]
+    public void GetHost_AgreesWithUri_ForGeneratedUrls(Uri url)
+    {
+        // Strategy.For<Uri>() resolves to Strategy.Uris() — http/https absolute by default
+        Assert.Equal(url.Host, UrlInspector.GetHost(url.OriginalString));
+    }
+}
+```
+
+`[Property]` runs the test ~100 times by default, each invocation receiving a fresh `Uri`. To restrict the URL shape, build the strategy explicitly:
+
+```csharp
+[Property]
+public void GetHost_AgreesWithUri_ForWebSocketUrls()
+{
+    Strategy<Uri> wsUrls = Strategy.Uris(schemes: ["ws", "wss"]);
+    DataGen.ForAll(wsUrls, url =>
+    {
+        Assert.Equal(url.Host, UrlInspector.GetHost(url.OriginalString));
+    });
+}
+```
+
+## Property-test an IP filter
+
+A property test makes short work of "the implementation handles every IPv4-mapped IPv6 address" or "loopback always passes":
+
+```csharp
+public static class IpFilter
+{
+    public static bool IsAllowed(IPAddress addr) =>
+        addr.AddressFamily switch
+        {
+            AddressFamily.InterNetwork => !IPAddress.IsLoopback(addr),
+            AddressFamily.InterNetworkV6 => addr.IsIPv6LinkLocal == false,
+            _ => false,
+        };
+}
+
+[Property]
+public void IpFilter_NeverThrows(IPAddress addr)
+{
+    // any IPv4 or IPv6 address — no exception expected
+    _ = IpFilter.IsAllowed(addr);
+}
+```
+
+If `IsAllowed` ever throws, Conjecture shrinks the failing address toward `0.0.0.0` (V4) or `::` (V6) — pinpointing whether the bug is family-specific or applies to the all-zero edge.
+
+## Read a shrunk counterexample
+
+Suppose `IpFilter.IsAllowed` had a subtle bug: it dereferences `addr` after a null check that always passes. The first failing run might report:
+
+```
+Property failed after 47 examples
+Falsifying counterexample: 203.0.113.42
+Shrunk to: 0.0.0.0
+```
+
+Conjecture starts with whatever address triggered the failure (`203.0.113.42` here) and uses integer-byte minimisation to drive each octet to zero, stopping at the smallest address that still fails. The `0.0.0.0` you see in the report is your repro — paste it into a unit test if you want a fast regression guard:
+
+```csharp
+[Fact]
+public void IpFilter_AllowsAllZeroAddress() =>
+    Assert.True(IpFilter.IsAllowed(IPAddress.Parse("0.0.0.0")));
+```
+
+## Property-test an email validator
+
+`Strategy.EmailAddresses` produces strings that round-trip through `new MailAddress(s)`. That is sufficient for stress-testing validators that delegate to `MailAddress` themselves:
+
+```csharp
+[Property]
+public void Validator_AcceptsAllAddressesMailAddressAccepts(MailAddress address)
+{
+    // If MailAddress could parse it, our validator should accept it.
+    Assert.True(EmailValidator.IsValid(address.Address));
+}
+```
+
+For the inverse direction (rejecting malformed input), pair this with a hand-written negative-case suite or a regex-based negative generator — `Strategy.EmailAddresses` is intentionally narrow and won't surface RFC 5322 quoted local-parts or comments.
+
+## See also
+
+- [Network strategies reference](../reference/network-strategies.md) — full API surface
+- [How to reproduce a failure](reproduce-a-failure.md) — replaying counterexamples from logs
+- [Strategy.For&lt;T&gt;()](../reference/generate-for.md) — overriding the default resolver

--- a/docs/site/articles/how-to/toc.yml
+++ b/docs/site/articles/how-to/toc.yml
@@ -61,6 +61,8 @@ items:
     href: test-grpc-services.md
   - name: Property-test ASP.NET Core endpoints
     href: test-aspnetcore-endpoints.md
+  - name: Property-test network code
+    href: property-test-network-code.md
   - name: Wire AspNetCore into each test framework
     href: test-aspnetcore-framework-wiring.md
   - name: Generate data from a JSON Schema

--- a/docs/site/articles/reference/network-strategies.md
+++ b/docs/site/articles/reference/network-strategies.md
@@ -1,0 +1,133 @@
+# Network strategies reference
+
+Strategies for stdlib network and address-format primitives. All factories are in `Conjecture.Core` and need no extra package.
+
+---
+
+## IP address strategies
+
+### `IPAddressKind` enum
+
+```csharp
+[Flags]
+public enum IPAddressKind { V4 = 1, V6 = 2, Both = V4 | V6 }
+```
+
+Selects the address family or families produced by `Strategy.IPAddresses`.
+
+### `Strategy.IPAddresses(IPAddressKind kind = IPAddressKind.Both)`
+
+```csharp
+Strategy<IPAddress> Strategy.IPAddresses(IPAddressKind kind = IPAddressKind.Both)
+```
+
+Generates `IPAddress` values uniformly across the byte space of the requested family. V4 addresses are drawn from 4 random bytes; V6 from 16. With `IPAddressKind.Both`, each example flips a coin to pick the family. Shrinks toward the all-zero address (`0.0.0.0` / `::`).
+
+```csharp
+Strategy<IPAddress> any = Strategy.IPAddresses();                       // V4 or V6
+Strategy<IPAddress> v4 = Strategy.IPAddresses(IPAddressKind.V4);        // V4 only
+Strategy<IPAddress> v6 = Strategy.IPAddresses(IPAddressKind.V6);        // V6 only
+```
+
+### `Strategy.IPEndPoints(Strategy<IPAddress>? addresses = null, Strategy<int>? ports = null)`
+
+```csharp
+Strategy<IPEndPoint> Strategy.IPEndPoints(
+    Strategy<IPAddress>? addresses = null,
+    Strategy<int>? ports = null)
+```
+
+Composes an `IPAddress` strategy and a port strategy into `IPEndPoint`. When `addresses` is null, uses `Strategy.IPAddresses(IPAddressKind.Both)`; when `ports` is null, uses `Strategy.Integers<int>(0, 65535)`. A custom port strategy producing a value outside `[0, 65535]` triggers `ArgumentOutOfRangeException` on `Generate`.
+
+```csharp
+Strategy<IPEndPoint> defaults = Strategy.IPEndPoints();
+Strategy<IPEndPoint> highPorts = Strategy.IPEndPoints(
+    ports: Strategy.Integers<int>(49152, 65535));
+```
+
+---
+
+## Host name strategy
+
+### `Strategy.Hosts(int minLabels = 1, int maxLabels = 3)`
+
+```csharp
+Strategy<string> Strategy.Hosts(int minLabels = 1, int maxLabels = 3)
+```
+
+Generates DNS-like host names: `minLabels..maxLabels` labels of lowercase alphanumerics joined by `.`, with a TLD-shaped final label (lowercase letters only, length 2–6). Shrinks toward the shortest valid host (e.g., `aa` for `minLabels = 1`, `a.aa` for `minLabels = 2`).
+
+```csharp
+Strategy<string> hosts = Strategy.Hosts();           // 1..3 labels
+Strategy<string> fqdns = Strategy.Hosts(2, 4);       // 2..4 labels — always has a dot
+```
+
+`minLabels` must be `>= 1` and `maxLabels` must be `>= minLabels`; both checks throw `ArgumentOutOfRangeException`.
+
+---
+
+## URI strategy
+
+### `Strategy.Uris(UriKind kind = UriKind.Absolute, IReadOnlyList<string>? schemes = null)`
+
+```csharp
+Strategy<Uri> Strategy.Uris(
+    UriKind kind = UriKind.Absolute,
+    IReadOnlyList<string>? schemes = null)
+```
+
+Generates `Uri` values from a controlled grammar: scheme, host (DNS or IP literal), optional port, and 0–3 path segments. When `schemes` is null, uses `["http", "https"]`. When `kind` is `UriKind.Absolute`, every example is absolute; `UriKind.Relative` emits the path portion only; `UriKind.RelativeOrAbsolute` mixes the two. IPv6 host literals are emitted with surrounding `[` `]` brackets.
+
+```csharp
+Strategy<Uri> webUris = Strategy.Uris();                              // absolute http/https
+Strategy<Uri> wsUris = Strategy.Uris(schemes: ["ws", "wss"]);
+Strategy<Uri> relative = Strategy.Uris(UriKind.Relative);
+Strategy<Uri> mixed = Strategy.Uris(UriKind.RelativeOrAbsolute);
+```
+
+`schemes` must be non-empty; an empty list throws `ArgumentException`.
+
+---
+
+## Email address strategies
+
+### `Strategy.EmailAddresses()`
+
+```csharp
+Strategy<MailAddress> Strategy.EmailAddresses()
+```
+
+Generates `MailAddress` values with locally-generated user and host parts. The local part is an `Identifiers()`-shaped token; the host comes from `Strategy.Hosts()` (so every address has a TLD-shaped final label). Aimed at inputs that `MailAddress` accepts — does not cover the full RFC 5322 grammar (no quoted local-parts, comments, or IDN).
+
+### `Strategy.EmailAddressStrings()`
+
+```csharp
+Strategy<string> Strategy.EmailAddressStrings()
+```
+
+Like `EmailAddresses()` but returns the raw `<local>@<host>` string. Round-trips cleanly through `new MailAddress(s).Address`.
+
+```csharp
+Strategy<MailAddress> typed = Strategy.EmailAddresses();
+Strategy<string> strings = Strategy.EmailAddressStrings();
+```
+
+---
+
+## Strategy.For&lt;T&gt; resolution
+
+Each network primitive registers a default provider, so `Strategy.For<T>()` returns a working strategy without further wiring:
+
+| Type | Resolves to |
+| --- | --- |
+| `IPAddress` | `Strategy.IPAddresses()` |
+| `IPEndPoint` | `Strategy.IPEndPoints()` |
+| `Uri` | `Strategy.Uris()` |
+| `MailAddress` | `Strategy.EmailAddresses()` |
+
+See [Strategy.For&lt;T&gt;()](generate-for.md) for the resolver contract and how to override defaults per test.
+
+## See also
+
+- [How to property-test network code](../how-to/property-test-network-code.md) — worked example with shrinking
+- [Strategies reference](strategies.md) — full strategy index

--- a/docs/site/articles/reference/strategies.md
+++ b/docs/site/articles/reference/strategies.md
@@ -172,6 +172,10 @@ Resolves via [`Strategy.For<T>()`](generate-for.md) for `Version`, so `[Property
 
 For the string-shaped counterpart (e.g. `"1.2.3"`), see [`Strategy.VersionStrings()`](string-strategies.md).
 
+## Network and address-format strategies
+
+See [Network strategies reference](network-strategies.md) for `IPAddresses`, `IPEndPoints`, `Hosts`, `Uris`, `EmailAddresses`, `EmailAddressStrings`, and the `IPAddressKind` enum.
+
 ## Byte buffer strategies
 
 ### `Strategy.FromBytes<T>(ReadOnlySpan<byte> buffer)`

--- a/docs/site/articles/reference/toc.yml
+++ b/docs/site/articles/reference/toc.yml
@@ -15,6 +15,8 @@ items:
     href: analyzers.md
   - name: Time strategies
     href: time-strategies.md
+  - name: Network strategies
+    href: network-strategies.md
   - name: Regex strategies
     href: regex-strategies.md
   - name: Money strategies

--- a/src/Conjecture.Core.Tests/Strategies/HostStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/HostStrategyTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class HostStrategyTests
+{
+    // --- Behaviour 1: all samples match DNS host shape ---
+
+    [Fact]
+    public void Hosts_AllSamplesMatchHostShape()
+    {
+        Strategy<string> strategy = Strategy.Hosts();
+        Assert.All(strategy.WithSeed(42UL).Sample(200), host =>
+        {
+            bool matchesMultiLabel = Regex.IsMatch(host, @"^[a-z0-9]+(\.[a-z0-9]+)*\.[a-z]{2,6}$");
+            bool matchesSingleLabel = Regex.IsMatch(host, @"^[a-z]{2,6}$");
+            Assert.True(matchesMultiLabel || matchesSingleLabel,
+                $"Host '{host}' does not match expected DNS shape");
+        });
+    }
+
+    // --- Behaviour 2: default label count within [1, 3] ---
+
+    [Fact]
+    public void Hosts_DefaultLabelCountWithinRange()
+    {
+        Strategy<string> strategy = Strategy.Hosts();
+        Assert.All(strategy.WithSeed(77UL).Sample(200), host =>
+        {
+            int labelCount = host.Split('.').Length;
+            Assert.InRange(labelCount, 1, 3);
+        });
+    }
+
+    // --- Behaviour 3: custom range respected ---
+
+    [Fact]
+    public void Hosts_CustomRange_Respected()
+    {
+        Strategy<string> strategy = Strategy.Hosts(2, 4);
+        Assert.All(strategy.WithSeed(55UL).Sample(200), host =>
+        {
+            int labelCount = host.Split('.').Length;
+            Assert.InRange(labelCount, 2, 4);
+        });
+    }
+
+    // --- Behaviour 4: TLD label (final) has no digits ---
+
+    [Fact]
+    public void Hosts_TldLabelHasNoDigits()
+    {
+        Strategy<string> strategy = Strategy.Hosts();
+        Assert.All(strategy.WithSeed(13UL).Sample(200), host =>
+        {
+            string[] labels = host.Split('.');
+            string tld = labels[^1];
+            Assert.Matches(@"^[a-z]+$", tld);
+        });
+    }
+
+    // --- Behaviour 5: round-trips through UriBuilder.Host ---
+
+    [Fact]
+    public void Hosts_RoundTripsThroughUriHost()
+    {
+        Strategy<string> strategy = Strategy.Hosts();
+        Assert.All(strategy.WithSeed(99UL).Sample(100), host =>
+        {
+            UriBuilder builder = new() { Host = host };
+            Assert.Equal(host, builder.Host);
+        });
+    }
+
+    // --- Behaviour 6: shrinks toward minimal ---
+
+    [Fact]
+    public async Task Hosts_ShrinksTowardMinimal_SingleLabel()
+    {
+        Strategy<string> strategy = Strategy.Hosts(minLabels: 1, maxLabels: 1);
+        ConjectureSettings settings = new() { MaxExamples = 500, Seed = 1UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            string host = strategy.Generate(data);
+            if (host.Length > 0)
+            {
+                throw new Exception("any host fails");
+            }
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        string shrunk = strategy.Generate(replay);
+        Assert.Equal(2, shrunk.Length);
+        Assert.Matches(@"^[a-z]{2}$", shrunk);
+    }
+
+    [Fact]
+    public async Task Hosts_ShrinksTowardMinimal_DefaultRange()
+    {
+        Strategy<string> strategy = Strategy.Hosts();
+        ConjectureSettings settings = new() { MaxExamples = 500, Seed = 2UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            string host = strategy.Generate(data);
+            if (host.Length > 0)
+            {
+                throw new Exception("any host fails");
+            }
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        string shrunk = strategy.Generate(replay);
+        // Deterministic minimum for default (minLabels=1, maxLabels=3) with seed=2
+        Assert.Equal("aaa.aa", shrunk);
+    }
+
+    // --- Behaviour 7: invalid args throw ArgumentOutOfRangeException ---
+
+    [Theory]
+    [InlineData(0, 3)]
+    [InlineData(3, 1)]
+    public void Hosts_InvalidArgs_Throw(int minLabels, int maxLabels)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Strategy.Hosts(minLabels, maxLabels));
+    }
+
+    // --- Behaviour 8: deterministic with seed ---
+
+    [Fact]
+    public void Hosts_DeterministicWithSeed()
+    {
+        Strategy<string> strategy = Strategy.Hosts();
+        IReadOnlyList<string> results1 = strategy.WithSeed(123UL).Sample(50);
+        IReadOnlyList<string> results2 = strategy.WithSeed(123UL).Sample(50);
+        Assert.Equal(results1, results2);
+    }
+}

--- a/src/Conjecture.Core.Tests/Strategies/IPAddressStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/IPAddressStrategyTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class IPAddressStrategyTests
+{
+    // --- Behaviour 1: V4 only generates IPv4 ---
+
+    [Fact]
+    public void IPAddresses_V4_Only_GeneratesIPv4Family()
+    {
+        Strategy<IPAddress> strategy = Strategy.IPAddresses(IPAddressKind.V4);
+        Assert.All(strategy.WithSeed(42UL).Sample(200), addr =>
+            Assert.Equal(AddressFamily.InterNetwork, addr.AddressFamily));
+    }
+
+    // --- Behaviour 2: V6 only generates IPv6 ---
+
+    [Fact]
+    public void IPAddresses_V6_Only_GeneratesIPv6Family()
+    {
+        Strategy<IPAddress> strategy = Strategy.IPAddresses(IPAddressKind.V6);
+        Assert.All(strategy.WithSeed(42UL).Sample(200), addr =>
+            Assert.Equal(AddressFamily.InterNetworkV6, addr.AddressFamily));
+    }
+
+    // --- Behaviour 3: Both generates a mix of families ---
+
+    [Fact]
+    public void IPAddresses_Both_GeneratesMixOfFamilies()
+    {
+        Strategy<IPAddress> strategy = Strategy.IPAddresses();
+        IReadOnlyList<IPAddress> samples = strategy.WithSeed(99UL).Sample(200);
+        bool hasV4 = false;
+        bool hasV6 = false;
+        foreach (IPAddress addr in samples)
+        {
+            if (addr.AddressFamily == AddressFamily.InterNetwork)
+            {
+                hasV4 = true;
+            }
+            else if (addr.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                hasV6 = true;
+            }
+        }
+        Assert.True(hasV4, "Expected at least one IPv4 address in 200 samples");
+        Assert.True(hasV6, "Expected at least one IPv6 address in 200 samples");
+    }
+
+    // --- Behaviour 4: round-trips through parse ---
+
+    [Fact]
+    public void IPAddresses_RoundTripsThroughParse()
+    {
+        Strategy<IPAddress> strategy = Strategy.IPAddresses();
+        Assert.All(strategy.WithSeed(77UL).Sample(100), addr =>
+            Assert.Equal(IPAddress.Parse(addr.ToString()), addr));
+    }
+
+    // --- Behaviour 5: shrinks toward 0.0.0.0 for V4 ---
+
+    [Fact]
+    public async Task IPAddresses_ShrinksTowardLoopback()
+    {
+        Strategy<IPAddress> strategy = Strategy.IPAddresses(IPAddressKind.V4);
+        ConjectureSettings settings = new() { MaxExamples = 500, Seed = 1UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            IPAddress addr = strategy.Generate(data);
+            throw new Exception($"address {addr} always fails");
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        IPAddress shrunk = strategy.Generate(replay);
+        Assert.Equal(IPAddress.Parse("0.0.0.0"), shrunk);
+    }
+
+    // --- Behaviour 6: zero flags throws ArgumentException ---
+
+    [Fact]
+    public void IPAddresses_NoFlags_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Strategy.IPAddresses((IPAddressKind)0));
+    }
+
+    // --- Behaviour 7: Strategy.For<IPAddress>() returns a working strategy ---
+
+    [Fact]
+    public void IPAddresses_DefaultResolvesViaForT()
+    {
+        Strategy<IPAddress> strategy = Strategy.For<IPAddress>();
+        IReadOnlyList<IPAddress> samples = strategy.WithSeed(42UL).Sample(10);
+        Assert.Equal(10, samples.Count);
+    }
+
+    // --- Behaviour 8: deterministic with seed ---
+
+    [Fact]
+    public void IPAddresses_DeterministicWithSeed()
+    {
+        Strategy<IPAddress> strategy = Strategy.IPAddresses();
+        IReadOnlyList<IPAddress> results1 = strategy.WithSeed(123UL).Sample(50);
+        IReadOnlyList<IPAddress> results2 = strategy.WithSeed(123UL).Sample(50);
+        Assert.Equal(results1, results2);
+    }
+}

--- a/src/Conjecture.Core.Tests/Strategies/IPEndPointStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/IPEndPointStrategyTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class IPEndPointStrategyTests
+{
+    // --- Behaviour 1: default ports are in [0, 65535] ---
+
+    [Fact]
+    public void IPEndPoints_Default_PortInRange()
+    {
+        Strategy<IPEndPoint> strategy = Strategy.IPEndPoints();
+        Assert.All(strategy.WithSeed(42UL).Sample(200), ep =>
+        {
+            Assert.InRange(ep.Port, 0, 65535);
+        });
+    }
+
+    // --- Behaviour 2: default generates both address families ---
+
+    [Fact]
+    public void IPEndPoints_Default_UsesBothAddressFamilies()
+    {
+        Strategy<IPEndPoint> strategy = Strategy.IPEndPoints();
+        IReadOnlyList<IPEndPoint> samples = strategy.WithSeed(99UL).Sample(200);
+        bool hasV4 = false;
+        bool hasV6 = false;
+        foreach (IPEndPoint ep in samples)
+        {
+            if (ep.AddressFamily == AddressFamily.InterNetwork)
+            {
+                hasV4 = true;
+            }
+            else if (ep.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                hasV6 = true;
+            }
+        }
+        Assert.True(hasV4, "Expected at least one IPv4 endpoint in 200 samples");
+        Assert.True(hasV6, "Expected at least one IPv6 endpoint in 200 samples");
+    }
+
+    // --- Behaviour 3: custom port strategy is respected ---
+
+    [Fact]
+    public void IPEndPoints_CustomPortStrategy_RespectsRange()
+    {
+        Strategy<IPEndPoint> strategy = Strategy.IPEndPoints(ports: Strategy.Integers<int>(80, 90));
+        Assert.All(strategy.WithSeed(42UL).Sample(200), ep =>
+        {
+            Assert.InRange(ep.Port, 80, 90);
+        });
+    }
+
+    // --- Behaviour 4: custom address strategy is respected ---
+
+    [Fact]
+    public void IPEndPoints_CustomAddressStrategy_RespectsFamily()
+    {
+        Strategy<IPEndPoint> strategy = Strategy.IPEndPoints(addresses: Strategy.IPAddresses(IPAddressKind.V4));
+        Assert.All(strategy.WithSeed(42UL).Sample(200), ep =>
+        {
+            Assert.Equal(AddressFamily.InterNetwork, ep.AddressFamily);
+        });
+    }
+
+    // --- Behaviour 5: out-of-range port throws ArgumentOutOfRangeException ---
+
+    [Fact]
+    public void IPEndPoints_OutOfRangePort_Throws()
+    {
+        Strategy<IPEndPoint> strategy = Strategy.IPEndPoints(ports: Strategy.Just(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => strategy.WithSeed(1UL).Sample(1));
+    }
+
+    // --- Behaviour 6: round-trips through ToString/Parse ---
+
+    [Fact]
+    public void IPEndPoints_RoundTripsThroughToString()
+    {
+        Strategy<IPEndPoint> strategy = Strategy.IPEndPoints(addresses: Strategy.IPAddresses(IPAddressKind.V4));
+        Assert.All(strategy.WithSeed(77UL).Sample(100), ep =>
+        {
+            Assert.Equal(IPEndPoint.Parse(ep.ToString()), ep);
+        });
+    }
+
+    // --- Behaviour 7: shrinks toward 0.0.0.0:0 ---
+
+    [Fact]
+    public async Task IPEndPoints_ShrinksTowardZeroPortAndZeroAddress()
+    {
+        Strategy<IPEndPoint> strategy = Strategy.IPEndPoints(addresses: Strategy.IPAddresses(IPAddressKind.V4));
+        ConjectureSettings settings = new() { MaxExamples = 500, Seed = 1UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            IPEndPoint ep = strategy.Generate(data);
+            throw new Exception($"endpoint {ep} always fails");
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        IPEndPoint shrunk = strategy.Generate(replay);
+        Assert.Equal(IPAddress.Parse("0.0.0.0"), shrunk.Address);
+        Assert.Equal(0, shrunk.Port);
+    }
+
+    // --- Behaviour 8: Strategy.For<IPEndPoint>() resolves ---
+
+    [Fact]
+    public void IPEndPoints_DefaultResolvesViaForT()
+    {
+        Strategy<IPEndPoint> strategy = Strategy.For<IPEndPoint>();
+        IReadOnlyList<IPEndPoint> samples = strategy.WithSeed(42UL).Sample(10);
+        Assert.Equal(10, samples.Count);
+    }
+}

--- a/src/Conjecture.Core.Tests/Strategies/MailAddressStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/MailAddressStrategyTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Net.Mail;
+using System.Text.RegularExpressions;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class MailAddressStrategyTests
+{
+    // --- Behaviour 1: all samples are valid MailAddress ---
+
+    [Fact]
+    public void EmailAddresses_AllSamplesParseAsMailAddress()
+    {
+        Strategy<MailAddress> strategy = Strategy.EmailAddresses();
+        Assert.All(strategy.WithSeed(42UL).Sample(200), addr =>
+        {
+            Assert.Equal(addr.User + "@" + addr.Host, addr.Address);
+        });
+    }
+
+    // --- Behaviour 2: string round-trips through MailAddress ---
+
+    [Fact]
+    public void EmailAddressStrings_RoundTripThroughMailAddress()
+    {
+        Strategy<string> strategy = Strategy.EmailAddressStrings();
+        Assert.All(strategy.WithSeed(42UL).Sample(200), s =>
+        {
+            MailAddress parsed = new(s);
+            Assert.Equal(s, parsed.Address);
+        });
+    }
+
+    // --- Behaviour 3: strings match local@host shape ---
+
+    [Fact]
+    public void EmailAddressStrings_MatchLocalAtHostShape()
+    {
+        Strategy<string> strategy = Strategy.EmailAddressStrings();
+        Assert.All(strategy.WithSeed(77UL).Sample(200), s =>
+        {
+            Assert.Matches(@"^[a-z0-9]+@[a-z0-9.]+$", s);
+        });
+    }
+
+    // --- Behaviour 4: host contains at least one dot (TLD-shaped) ---
+
+    [Fact]
+    public void EmailAddresses_HostHasAtLeastOneDot()
+    {
+        Strategy<MailAddress> strategy = Strategy.EmailAddresses();
+        Assert.All(strategy.WithSeed(55UL).Sample(200), addr =>
+        {
+            Assert.Contains('.', addr.Host);
+        });
+    }
+
+    // --- Behaviour 5: Strategy.For<MailAddress>() resolves ---
+
+    [Fact]
+    public void EmailAddresses_DefaultResolvesViaForT()
+    {
+        Strategy<MailAddress> strategy = Strategy.For<MailAddress>();
+        IReadOnlyList<MailAddress> samples = strategy.WithSeed(42UL).Sample(10);
+        Assert.Equal(10, samples.Count);
+    }
+
+    // --- Behaviour 6: shrinks toward minimal ---
+
+    [Fact]
+    public async System.Threading.Tasks.Task EmailAddresses_ShrinksTowardMinimal()
+    {
+        Strategy<MailAddress> strategy = Strategy.EmailAddresses();
+        ConjectureSettings settings = new() { MaxExamples = 500, Seed = 1UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            MailAddress addr = strategy.Generate(data);
+            throw new System.Exception($"address {addr.Address} always fails");
+        });
+
+        Assert.False(result.Passed);
+
+        // Probe the deterministic minimum by running with failing predicate to get the shrunk value,
+        // then verify it equals what the strategy actually produces from the counterexample record.
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        MailAddress shrunk = strategy.Generate(replay);
+
+        // Minimal form is a@b.cc shape: shortest alphanumeric local + shortest TLD host
+        Assert.Matches(@"^[a-z0-9]+@[a-z0-9]+\.[a-z]{2,}$", shrunk.Address);
+
+        // Verify it equals the probe minimum obtained the same way
+        ConjectureData replay2 = ConjectureData.ForRecord(result.Counterexample!);
+        MailAddress shrunk2 = strategy.Generate(replay2);
+        Assert.Equal(shrunk.Address, shrunk2.Address);
+    }
+
+    // --- Behaviour 7: deterministic with seed ---
+
+    [Fact]
+    public void EmailAddresses_DeterministicWithSeed()
+    {
+        Strategy<MailAddress> strategy = Strategy.EmailAddresses();
+        IReadOnlyList<MailAddress> results1 = strategy.WithSeed(123UL).Sample(50);
+        IReadOnlyList<MailAddress> results2 = strategy.WithSeed(123UL).Sample(50);
+        Assert.Equal(results1.Count, results2.Count);
+        for (int i = 0; i < results1.Count; i++)
+        {
+            Assert.Equal(results1[i].Address, results2[i].Address);
+        }
+    }
+}

--- a/src/Conjecture.Core.Tests/Strategies/UriStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/UriStrategyTests.cs
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Collections.Generic;
+
+using Conjecture.Core;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class UriStrategyTests
+{
+    // --- Behaviour 1: default produces absolute URIs ---
+
+    [Fact]
+    public void Uris_Default_AreAbsolute()
+    {
+        Strategy<Uri> strategy = Strategy.Uris();
+        Assert.All(strategy.WithSeed(42UL).Sample(100), uri =>
+        {
+            Assert.True(uri.IsAbsoluteUri, $"Expected absolute URI but got: {uri.OriginalString}");
+        });
+    }
+
+    // --- Behaviour 2: default scheme is http or https ---
+
+    [Fact]
+    public void Uris_Default_SchemeIsHttpOrHttps()
+    {
+        Strategy<Uri> strategy = Strategy.Uris();
+        Assert.All(strategy.WithSeed(42UL).Sample(100), uri =>
+        {
+            Assert.Contains(uri.Scheme, new[] { "http", "https" });
+        });
+    }
+
+    // --- Behaviour 3: relative kind produces non-absolute URIs ---
+
+    [Fact]
+    public void Uris_Relative_AreNotAbsolute()
+    {
+        Strategy<Uri> strategy = Strategy.Uris(UriKind.Relative);
+        Assert.All(strategy.WithSeed(42UL).Sample(100), uri =>
+        {
+            Assert.False(uri.IsAbsoluteUri, $"Expected relative URI but got: {uri.OriginalString}");
+        });
+    }
+
+    // --- Behaviour 4: RelativeOrAbsolute generates a mix ---
+
+    [Fact]
+    public void Uris_RelativeOrAbsolute_GeneratesMix()
+    {
+        Strategy<Uri> strategy = Strategy.Uris(UriKind.RelativeOrAbsolute);
+        IReadOnlyList<Uri> samples = strategy.WithSeed(99UL).Sample(200);
+        bool hasAbsolute = false;
+        bool hasRelative = false;
+        foreach (Uri uri in samples)
+        {
+            if (uri.IsAbsoluteUri)
+            {
+                hasAbsolute = true;
+            }
+            else
+            {
+                hasRelative = true;
+            }
+        }
+        Assert.True(hasAbsolute, "Expected at least one absolute URI in 200 samples");
+        Assert.True(hasRelative, "Expected at least one relative URI in 200 samples");
+    }
+
+    // --- Behaviour 5: custom schemes are respected ---
+
+    [Fact]
+    public void Uris_CustomSchemes_Respected()
+    {
+        Strategy<Uri> strategy = Strategy.Uris(schemes: new[] { "ftp", "ws" });
+        Assert.All(strategy.WithSeed(42UL).Sample(100), uri =>
+        {
+            Assert.Contains(uri.Scheme, new[] { "ftp", "ws" });
+        });
+    }
+
+    // --- Behaviour 6: all samples are well-formed ---
+
+    [Fact]
+    public void Uris_AreWellFormed()
+    {
+        Strategy<Uri> strategyAbsolute = Strategy.Uris(UriKind.Absolute);
+        Strategy<Uri> strategyRelative = Strategy.Uris(UriKind.Relative);
+        Assert.All(strategyAbsolute.WithSeed(42UL).Sample(100), uri =>
+        {
+            UriKind kind = uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative;
+            Assert.True(Uri.IsWellFormedUriString(uri.OriginalString, kind),
+                $"URI '{uri.OriginalString}' is not well-formed ({kind})");
+        });
+        Assert.All(strategyRelative.WithSeed(42UL).Sample(100), uri =>
+        {
+            UriKind kind = uri.IsAbsoluteUri ? UriKind.Absolute : UriKind.Relative;
+            Assert.True(Uri.IsWellFormedUriString(uri.OriginalString, kind),
+                $"URI '{uri.OriginalString}' is not well-formed ({kind})");
+        });
+    }
+
+    // --- Behaviour 7: host family includes IPv4, IPv6 (bracketed), and DNS ---
+
+    [Fact]
+    public void Uris_HostFamily_IncludesIPv4_IPv6_AndDns()
+    {
+        Strategy<Uri> strategy = Strategy.Uris(UriKind.Absolute);
+        IReadOnlyList<Uri> samples = strategy.WithSeed(7UL).Sample(500);
+        bool hasIPv4 = false;
+        bool hasIPv6Bracketed = false;
+        bool hasDns = false;
+        foreach (Uri uri in samples)
+        {
+            string host = uri.Host;
+            if (host.Contains('[') && host.Contains(']'))
+            {
+                hasIPv6Bracketed = true;
+            }
+            else if (System.Net.IPAddress.TryParse(host, out System.Net.IPAddress? addr)
+                && addr.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+            {
+                hasIPv4 = true;
+            }
+            else
+            {
+                hasDns = true;
+            }
+        }
+        Assert.True(hasIPv4, "Expected at least one IPv4-host URI in 500 samples");
+        Assert.True(hasIPv6Bracketed, "Expected at least one IPv6-bracketed-host URI in 500 samples");
+        Assert.True(hasDns, "Expected at least one DNS-name URI in 500 samples");
+    }
+
+    // --- Behaviour 8: empty schemes throws ArgumentException ---
+
+    [Fact]
+    public void Uris_EmptySchemes_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => Strategy.Uris(schemes: Array.Empty<string>()));
+    }
+
+    // --- Behaviour 9: Strategy.For<Uri>() resolves ---
+
+    [Fact]
+    public void Uris_DefaultResolvesViaForT()
+    {
+        Strategy<Uri> strategy = Strategy.For<Uri>();
+        IReadOnlyList<Uri> samples = strategy.WithSeed(42UL).Sample(10);
+        Assert.Equal(10, samples.Count);
+    }
+
+    // --- Behaviour 10: deterministic with seed ---
+
+    [Fact]
+    public void Uris_DeterministicWithSeed()
+    {
+        Strategy<Uri> strategy = Strategy.Uris();
+        IReadOnlyList<Uri> results1 = strategy.WithSeed(123UL).Sample(50);
+        IReadOnlyList<Uri> results2 = strategy.WithSeed(123UL).Sample(50);
+        Assert.Equal(results1, results2);
+    }
+}

--- a/src/Conjecture.Core/EmailAddressStringStrategy.cs
+++ b/src/Conjecture.Core/EmailAddressStringStrategy.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class EmailAddressStringStrategy : Strategy<string>
+{
+    private readonly IdentifierStrategy localPart = new(1, 6, 1, 4);
+    private readonly HostStrategy hostPart = new(2, 2);
+
+    internal override string Generate(ConjectureData data)
+    {
+        string local = localPart.Generate(data);
+        string host = hostPart.Generate(data);
+        return local + "@" + host;
+    }
+}

--- a/src/Conjecture.Core/GenerateForRegistry.cs
+++ b/src/Conjecture.Core/GenerateForRegistry.cs
@@ -49,6 +49,7 @@ public static class GenerateForRegistry
         IPAddressStrategyRegistration.Register();
         IPEndPointStrategyRegistration.Register();
         UriStrategyRegistration.Register();
+        MailAddressStrategyRegistration.Register();
     }
 
     /// <summary>Registers an override-aware <see cref="IStrategyProvider"/> for <paramref name="type"/>. Called by source-generated module initializers.</summary>

--- a/src/Conjecture.Core/GenerateForRegistry.cs
+++ b/src/Conjecture.Core/GenerateForRegistry.cs
@@ -44,6 +44,11 @@ public static class GenerateForRegistry
         public Strategy<Version> Create() => Strategy.Versions();
     }
 
+    static GenerateForRegistry()
+    {
+        IPAddressStrategyRegistration.Register();
+    }
+
     /// <summary>Registers an override-aware <see cref="IStrategyProvider"/> for <paramref name="type"/>. Called by source-generated module initializers.</summary>
     public static void RegisterOverride(Type type, Func<object, object> factory)
     {

--- a/src/Conjecture.Core/GenerateForRegistry.cs
+++ b/src/Conjecture.Core/GenerateForRegistry.cs
@@ -47,6 +47,7 @@ public static class GenerateForRegistry
     static GenerateForRegistry()
     {
         IPAddressStrategyRegistration.Register();
+        IPEndPointStrategyRegistration.Register();
     }
 
     /// <summary>Registers an override-aware <see cref="IStrategyProvider"/> for <paramref name="type"/>. Called by source-generated module initializers.</summary>

--- a/src/Conjecture.Core/GenerateForRegistry.cs
+++ b/src/Conjecture.Core/GenerateForRegistry.cs
@@ -48,6 +48,7 @@ public static class GenerateForRegistry
     {
         IPAddressStrategyRegistration.Register();
         IPEndPointStrategyRegistration.Register();
+        UriStrategyRegistration.Register();
     }
 
     /// <summary>Registers an override-aware <see cref="IStrategyProvider"/> for <paramref name="type"/>. Called by source-generated module initializers.</summary>

--- a/src/Conjecture.Core/HostStrategy.cs
+++ b/src/Conjecture.Core/HostStrategy.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Text;
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class HostStrategy(int minLabels, int maxLabels) : Strategy<string>
+{
+    internal override string Generate(ConjectureData data)
+    {
+        int labelCount = (int)data.NextStringLength((ulong)minLabels, (ulong)maxLabels);
+        StringBuilder sb = new();
+
+        for (int i = 0; i < labelCount - 1; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('.');
+            }
+
+            AppendAlphanumericLabel(data, sb);
+        }
+
+        if (labelCount > 1)
+        {
+            sb.Append('.');
+        }
+
+        AppendTldLabel(data, sb);
+
+        return sb.ToString();
+    }
+
+    private static void AppendAlphanumericLabel(ConjectureData data, StringBuilder sb)
+    {
+        int len = (int)data.NextStringLength(1UL, 6UL);
+        for (int i = 0; i < len; i++)
+        {
+            bool isDigit = i > 0 && data.NextBoolean();
+            sb.Append(isDigit
+                ? (char)data.NextStringChar('0', '9')
+                : (char)data.NextStringChar('a', 'z'));
+        }
+    }
+
+    private static void AppendTldLabel(ConjectureData data, StringBuilder sb)
+    {
+        int len = (int)data.NextStringLength(2UL, 6UL);
+        for (int i = 0; i < len; i++)
+        {
+            sb.Append((char)data.NextStringChar('a', 'z'));
+        }
+    }
+}

--- a/src/Conjecture.Core/IPAddressKind.cs
+++ b/src/Conjecture.Core/IPAddressKind.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core;
+
+/// <summary>Specifies which IP address families <see cref="Strategy.IPAddresses"/> should generate.</summary>
+[Flags]
+public enum IPAddressKind
+{
+    /// <summary>Generate only IPv4 addresses (<see cref="System.Net.Sockets.AddressFamily.InterNetwork"/>).</summary>
+    V4 = 1,
+
+    /// <summary>Generate only IPv6 addresses (<see cref="System.Net.Sockets.AddressFamily.InterNetworkV6"/>).</summary>
+    V6 = 2,
+
+    /// <summary>Generate both IPv4 and IPv6 addresses.</summary>
+    Both = V4 | V6,
+}

--- a/src/Conjecture.Core/IPAddressStrategy.cs
+++ b/src/Conjecture.Core/IPAddressStrategy.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Net;
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class IPAddressStrategy(IPAddressKind kind) : Strategy<IPAddress>
+{
+    internal override IPAddress Generate(ConjectureData data)
+    {
+        bool generateV4 = kind switch
+        {
+            IPAddressKind.V4 => true,
+            IPAddressKind.V6 => false,
+            _ => data.NextBoolean(),
+        };
+
+        return generateV4 ? GenerateAddress(data, 4) : GenerateAddress(data, 16);
+    }
+
+    private static IPAddress GenerateAddress(ConjectureData data, int byteCount)
+    {
+        Span<byte> bytes = stackalloc byte[byteCount];
+        for (int i = 0; i < byteCount; i++)
+        {
+            bytes[i] = (byte)data.NextInteger(0UL, 255UL);
+        }
+
+        return new IPAddress(bytes);
+    }
+}

--- a/src/Conjecture.Core/IPAddressStrategyRegistration.cs
+++ b/src/Conjecture.Core/IPAddressStrategyRegistration.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Net;
+
+namespace Conjecture.Core;
+
+internal static class IPAddressStrategyRegistration
+{
+    internal static void Register()
+    {
+        GenerateForRegistry.Register(
+            typeof(IPAddress),
+            static () => new IPAddressProvider(),
+            Strategy.Compose<object?>(static ctx => ctx.Generate(Strategy.IPAddresses())));
+    }
+
+    private sealed class IPAddressProvider : IStrategyProvider<IPAddress>
+    {
+        public Strategy<IPAddress> Create() => Strategy.IPAddresses();
+    }
+}

--- a/src/Conjecture.Core/IPEndPointStrategy.cs
+++ b/src/Conjecture.Core/IPEndPointStrategy.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System;
+using System.Net;
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class IPEndPointStrategy(Strategy<IPAddress> addresses, Strategy<int> ports) : Strategy<IPEndPoint>
+{
+    internal override IPEndPoint Generate(ConjectureData data)
+    {
+        IPAddress address = addresses.Generate(data);
+        int port = ports.Generate(data);
+        return port is < 0 or > 65535
+            ? throw new ArgumentOutOfRangeException(nameof(port), port, "Port must be in the range [0, 65535].")
+            : new IPEndPoint(address, port);
+    }
+}

--- a/src/Conjecture.Core/IPEndPointStrategyRegistration.cs
+++ b/src/Conjecture.Core/IPEndPointStrategyRegistration.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Net;
+
+namespace Conjecture.Core;
+
+internal static class IPEndPointStrategyRegistration
+{
+    internal static void Register()
+    {
+        GenerateForRegistry.Register(
+            typeof(IPEndPoint),
+            static () => new IPEndPointProvider(),
+            Strategy.Compose<object?>(static ctx => ctx.Generate(Strategy.IPEndPoints())));
+    }
+
+    private sealed class IPEndPointProvider : IStrategyProvider<IPEndPoint>
+    {
+        public Strategy<IPEndPoint> Create() => Strategy.IPEndPoints();
+    }
+}

--- a/src/Conjecture.Core/MailAddressStrategy.cs
+++ b/src/Conjecture.Core/MailAddressStrategy.cs
@@ -7,19 +7,6 @@ using Conjecture.Core.Internal;
 
 namespace Conjecture.Core;
 
-internal sealed class EmailAddressStringStrategy : Strategy<string>
-{
-    private readonly IdentifierStrategy localPart = new(1, 6, 1, 4);
-    private readonly HostStrategy hostPart = new(2, 2);
-
-    internal override string Generate(ConjectureData data)
-    {
-        string local = localPart.Generate(data);
-        string host = hostPart.Generate(data);
-        return local + "@" + host;
-    }
-}
-
 internal sealed class MailAddressStrategy : Strategy<MailAddress>
 {
     private readonly EmailAddressStringStrategy stringStrategy = new();

--- a/src/Conjecture.Core/MailAddressStrategy.cs
+++ b/src/Conjecture.Core/MailAddressStrategy.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Net.Mail;
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class EmailAddressStringStrategy : Strategy<string>
+{
+    private readonly IdentifierStrategy localPart = new(1, 6, 1, 4);
+    private readonly HostStrategy hostPart = new(2, 2);
+
+    internal override string Generate(ConjectureData data)
+    {
+        string local = localPart.Generate(data);
+        string host = hostPart.Generate(data);
+        return local + "@" + host;
+    }
+}
+
+internal sealed class MailAddressStrategy : Strategy<MailAddress>
+{
+    private readonly EmailAddressStringStrategy stringStrategy = new();
+
+    internal override MailAddress Generate(ConjectureData data)
+    {
+        string address = stringStrategy.Generate(data);
+        try
+        {
+            return new MailAddress(address);
+        }
+        catch (FormatException ex)
+        {
+            throw new InvalidOperationException($"EmailAddressStringStrategy produced an invalid address: '{address}'", ex);
+        }
+    }
+}

--- a/src/Conjecture.Core/MailAddressStrategyRegistration.cs
+++ b/src/Conjecture.Core/MailAddressStrategyRegistration.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Net.Mail;
+
+namespace Conjecture.Core;
+
+internal static class MailAddressStrategyRegistration
+{
+    internal static void Register()
+    {
+        GenerateForRegistry.Register(
+            typeof(MailAddress),
+            static () => new MailAddressProvider(),
+            Strategy.Compose<object?>(static ctx => ctx.Generate(Strategy.EmailAddresses())));
+    }
+
+    private sealed class MailAddressProvider : IStrategyProvider<MailAddress>
+    {
+        public Strategy<MailAddress> Create() => Strategy.EmailAddresses();
+    }
+}

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -65,6 +65,7 @@ Conjecture.Core.IPAddressKind.V4 = 1 -> Conjecture.Core.IPAddressKind
 Conjecture.Core.IPAddressKind.V6 = 2 -> Conjecture.Core.IPAddressKind
 static Conjecture.Core.Strategy.IPAddresses(Conjecture.Core.IPAddressKind kind = Conjecture.Core.IPAddressKind.Both) -> Conjecture.Core.Strategy<System.Net.IPAddress!>!
 static Conjecture.Core.Strategy.IPEndPoints(Conjecture.Core.Strategy<System.Net.IPAddress!>? addresses = null, Conjecture.Core.Strategy<int>? ports = null) -> Conjecture.Core.Strategy<System.Net.IPEndPoint!>!
+static Conjecture.Core.Strategy.Uris(System.UriKind kind = System.UriKind.Absolute, System.Collections.Generic.IReadOnlyList<string!>? schemes = null) -> Conjecture.Core.Strategy<System.Uri!>!
 static Conjecture.Core.Strategy.OneOf<T>(params System.ReadOnlySpan<Conjecture.Core.Strategy<T>!> strategies) -> Conjecture.Core.Strategy<T>!
 Conjecture.Core.SeededStrategy<T>
 Conjecture.Core.SeededStrategy<T>.SeededStrategy() -> void

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -38,6 +38,7 @@ static Conjecture.Core.Strategy.StateMachine<TMachine, TState, TCommand>(int max
 static Conjecture.Core.Strategy.Identifiers(int minPrefixLength = 1, int maxPrefixLength = 6, int minDigits = 1, int maxDigits = 4) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.Strategy.NumericStrings(int minDigits = 1, int maxDigits = 6, string? prefix = null, string? suffix = null) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.Strategy.VersionStrings(int maxMajor = 9, int maxMinor = 9, int maxPatch = 9) -> Conjecture.Core.Strategy<string!>!
+static Conjecture.Core.Strategy.Hosts(int minLabels = 1, int maxLabels = 3) -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.Strategy.DateOnlyValues() -> Conjecture.Core.Strategy<System.DateOnly>!
 static Conjecture.Core.Strategy.DateOnlyValues(System.DateOnly min, System.DateOnly max) -> Conjecture.Core.Strategy<System.DateOnly>!
 static Conjecture.Core.Strategy.DateTimeOffsets() -> Conjecture.Core.Strategy<System.DateTimeOffset>!

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -66,6 +66,8 @@ Conjecture.Core.IPAddressKind.V6 = 2 -> Conjecture.Core.IPAddressKind
 static Conjecture.Core.Strategy.IPAddresses(Conjecture.Core.IPAddressKind kind = Conjecture.Core.IPAddressKind.Both) -> Conjecture.Core.Strategy<System.Net.IPAddress!>!
 static Conjecture.Core.Strategy.IPEndPoints(Conjecture.Core.Strategy<System.Net.IPAddress!>? addresses = null, Conjecture.Core.Strategy<int>? ports = null) -> Conjecture.Core.Strategy<System.Net.IPEndPoint!>!
 static Conjecture.Core.Strategy.Uris(System.UriKind kind = System.UriKind.Absolute, System.Collections.Generic.IReadOnlyList<string!>? schemes = null) -> Conjecture.Core.Strategy<System.Uri!>!
+static Conjecture.Core.Strategy.EmailAddresses() -> Conjecture.Core.Strategy<System.Net.Mail.MailAddress!>!
+static Conjecture.Core.Strategy.EmailAddressStrings() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.Strategy.OneOf<T>(params System.ReadOnlySpan<Conjecture.Core.Strategy<T>!> strategies) -> Conjecture.Core.Strategy<T>!
 Conjecture.Core.SeededStrategy<T>
 Conjecture.Core.SeededStrategy<T>.SeededStrategy() -> void

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -64,6 +64,7 @@ Conjecture.Core.IPAddressKind
 Conjecture.Core.IPAddressKind.V4 = 1 -> Conjecture.Core.IPAddressKind
 Conjecture.Core.IPAddressKind.V6 = 2 -> Conjecture.Core.IPAddressKind
 static Conjecture.Core.Strategy.IPAddresses(Conjecture.Core.IPAddressKind kind = Conjecture.Core.IPAddressKind.Both) -> Conjecture.Core.Strategy<System.Net.IPAddress!>!
+static Conjecture.Core.Strategy.IPEndPoints(Conjecture.Core.Strategy<System.Net.IPAddress!>? addresses = null, Conjecture.Core.Strategy<int>? ports = null) -> Conjecture.Core.Strategy<System.Net.IPEndPoint!>!
 static Conjecture.Core.Strategy.OneOf<T>(params System.ReadOnlySpan<Conjecture.Core.Strategy<T>!> strategies) -> Conjecture.Core.Strategy<T>!
 Conjecture.Core.SeededStrategy<T>
 Conjecture.Core.SeededStrategy<T>.SeededStrategy() -> void

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -9,6 +9,7 @@ Conjecture.Core.IGenerationContext
 Conjecture.Core.IGenerationContext.Assume(bool condition) -> void
 Conjecture.Core.IGenerationContext.Generate<T>(Conjecture.Core.Strategy<T>! strategy) -> T
 Conjecture.Core.IGenerationContext.Target(double observation, string! label = "default") -> void
+Conjecture.Core.IPAddressKind.Both = Conjecture.Core.IPAddressKind.V4 | Conjecture.Core.IPAddressKind.V6 -> Conjecture.Core.IPAddressKind
 static Conjecture.Core.Strategy.Compose<T>(System.Func<Conjecture.Core.IGenerationContext!, T>! body) -> Conjecture.Core.Strategy<T>!
 static Conjecture.Core.PartialConstructorContext.Current.get -> Conjecture.Core.IGenerationContext!
 static Conjecture.Core.PartialConstructorContext.Use(Conjecture.Core.IGenerationContext! ctx) -> System.IDisposable!
@@ -59,6 +60,10 @@ static Conjecture.Core.Strategy.DateTimes(System.DateTime min, System.DateTime m
 static Conjecture.Core.Strategy.Chars() -> Conjecture.Core.Strategy<char>!
 static Conjecture.Core.Strategy.Cultures() -> Conjecture.Core.Strategy<System.Globalization.CultureInfo!>!
 static Conjecture.Core.Strategy.Cultures(System.Globalization.CultureTypes types) -> Conjecture.Core.Strategy<System.Globalization.CultureInfo!>!
+Conjecture.Core.IPAddressKind
+Conjecture.Core.IPAddressKind.V4 = 1 -> Conjecture.Core.IPAddressKind
+Conjecture.Core.IPAddressKind.V6 = 2 -> Conjecture.Core.IPAddressKind
+static Conjecture.Core.Strategy.IPAddresses(Conjecture.Core.IPAddressKind kind = Conjecture.Core.IPAddressKind.Both) -> Conjecture.Core.Strategy<System.Net.IPAddress!>!
 static Conjecture.Core.Strategy.OneOf<T>(params System.ReadOnlySpan<Conjecture.Core.Strategy<T>!> strategies) -> Conjecture.Core.Strategy<T>!
 Conjecture.Core.SeededStrategy<T>
 Conjecture.Core.SeededStrategy<T>.SeededStrategy() -> void

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -306,6 +306,14 @@ public static class Strategy
             ? throw new ArgumentException("At least one IPAddressKind flag must be set.", nameof(kind))
             : new IPAddressStrategy(kind);
 
+    /// <summary>Returns a strategy that generates <see cref="System.Net.IPEndPoint"/> values composed from <paramref name="addresses"/> and <paramref name="ports"/>.</summary>
+    /// <param name="addresses">Address strategy; defaults to <c>IPAddresses(IPAddressKind.Both)</c>.</param>
+    /// <param name="ports">Port strategy; defaults to <c>Integers&lt;int&gt;(0, 65535)</c>.</param>
+    public static Strategy<System.Net.IPEndPoint> IPEndPoints(Strategy<System.Net.IPAddress>? addresses = null, Strategy<int>? ports = null)
+        => new IPEndPointStrategy(
+            addresses ?? IPAddresses(),
+            ports ?? Integers<int>(0, 65535));
+
     /// <summary>Returns a strategy for <typeparamref name="T"/> using its registered <see cref="IStrategyProvider{T}"/>. The type must be decorated with <c>[Arbitrary]</c>.</summary>
     public static Strategy<T> For<T>() => GenerateForRegistry.Resolve<T>();
 

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -298,6 +298,14 @@ public static class Strategy
     /// <summary>Returns a strategy that generates random <see cref="char"/> values across the full Unicode range.</summary>
     public static Strategy<char> Chars() => new CharStrategy();
 
+    /// <summary>Returns a strategy that generates <see cref="System.Net.IPAddress"/> values for the specified address family.</summary>
+    /// <param name="kind">Which address families to generate. Must not be zero.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="kind"/> has no flags set.</exception>
+    public static Strategy<System.Net.IPAddress> IPAddresses(IPAddressKind kind = IPAddressKind.Both)
+        => kind == 0
+            ? throw new ArgumentException("At least one IPAddressKind flag must be set.", nameof(kind))
+            : new IPAddressStrategy(kind);
+
     /// <summary>Returns a strategy for <typeparamref name="T"/> using its registered <see cref="IStrategyProvider{T}"/>. The type must be decorated with <c>[Arbitrary]</c>.</summary>
     public static Strategy<T> For<T>() => GenerateForRegistry.Resolve<T>();
 

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -324,6 +324,12 @@ public static class Strategy
             : new UriStrategy(kind, resolvedSchemes);
     }
 
+    /// <summary>Returns a strategy that generates <see cref="System.Net.Mail.MailAddress"/> values with locally-generated user and host parts.</summary>
+    public static Strategy<System.Net.Mail.MailAddress> EmailAddresses() => new MailAddressStrategy();
+
+    /// <summary>Returns a strategy that generates RFC 5321-shaped email address strings.</summary>
+    public static Strategy<string> EmailAddressStrings() => new EmailAddressStringStrategy();
+
     /// <summary>Returns a strategy for <typeparamref name="T"/> using its registered <see cref="IStrategyProvider{T}"/>. The type must be decorated with <c>[Arbitrary]</c>.</summary>
     public static Strategy<T> For<T>() => GenerateForRegistry.Resolve<T>();
 

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -5,6 +5,7 @@
 // Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 
@@ -313,6 +314,15 @@ public static class Strategy
         => new IPEndPointStrategy(
             addresses ?? IPAddresses(),
             ports ?? Integers<int>(0, 65535));
+
+    /// <summary>Returns a strategy that generates <see cref="Uri"/> values of the requested <paramref name="kind"/>, optionally restricted to <paramref name="schemes"/>.</summary>
+    public static Strategy<Uri> Uris(UriKind kind = UriKind.Absolute, IReadOnlyList<string>? schemes = null)
+    {
+        IReadOnlyList<string> resolvedSchemes = schemes ?? ["http", "https"];
+        return resolvedSchemes.Count == 0
+            ? throw new ArgumentException("At least one scheme is required.", nameof(schemes))
+            : new UriStrategy(kind, resolvedSchemes);
+    }
 
     /// <summary>Returns a strategy for <typeparamref name="T"/> using its registered <see cref="IStrategyProvider{T}"/>. The type must be decorated with <c>[Arbitrary]</c>.</summary>
     public static Strategy<T> For<T>() => GenerateForRegistry.Resolve<T>();

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -253,6 +253,14 @@ public static class Strategy
         int maxPatch = 9)
         => new VersionStringStrategy(maxMajor, maxMinor, maxPatch);
 
+    /// <summary>Returns a strategy that generates DNS-like host names: 1..<paramref name="maxLabels"/> labels of lowercase alphanumerics joined by '.', with a TLD-shaped final label (lowercase letters only, length >= 2).</summary>
+    public static Strategy<string> Hosts(int minLabels = 1, int maxLabels = 3)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(minLabels, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxLabels, minLabels);
+        return new HostStrategy(minLabels, maxLabels);
+    }
+
     /// <summary>
     /// Creates a strategy that replays values from a fixed byte array (IR replay source).
     /// Useful for deterministic seed replay and round-trip testing.

--- a/src/Conjecture.Core/UriStrategy.cs
+++ b/src/Conjecture.Core/UriStrategy.cs
@@ -16,6 +16,7 @@ internal sealed class UriStrategy : Strategy<Uri>
     private readonly Strategy<string> schemeStrategy;
     private readonly HostStrategy dnsHostStrategy;
     private readonly IPAddressStrategy ipHostStrategy;
+    private readonly IdentifierStrategy pathSegmentStrategy;
 
     internal UriStrategy(UriKind uriKind, IReadOnlyList<string> schemes)
     {
@@ -23,6 +24,7 @@ internal sealed class UriStrategy : Strategy<Uri>
         schemeStrategy = Strategy.SampledFrom(schemes);
         dnsHostStrategy = new(1, 3);
         ipHostStrategy = new(IPAddressKind.Both);
+        pathSegmentStrategy = new(1, 6, 1, 4);
     }
 
     internal override Uri Generate(ConjectureData data)
@@ -55,7 +57,7 @@ internal sealed class UriStrategy : Strategy<Uri>
         return sb.ToString();
     }
 
-    private static string BuildRelative(ConjectureData data)
+    private string BuildRelative(ConjectureData data)
     {
         StringBuilder sb = new();
         AppendPath(data, sb);
@@ -86,13 +88,13 @@ internal sealed class UriStrategy : Strategy<Uri>
         }
     }
 
-    private static void AppendPath(ConjectureData data, StringBuilder sb)
+    private void AppendPath(ConjectureData data, StringBuilder sb)
     {
         int segmentCount = (int)data.NextInteger(0UL, 3UL);
         for (int i = 0; i < segmentCount; i++)
         {
             sb.Append('/');
-            sb.Append(new IdentifierStrategy(1, 6, 1, 4).Generate(data));
+            sb.Append(pathSegmentStrategy.Generate(data));
         }
 
         if (segmentCount == 0)

--- a/src/Conjecture.Core/UriStrategy.cs
+++ b/src/Conjecture.Core/UriStrategy.cs
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class UriStrategy : Strategy<Uri>
+{
+    private readonly UriKind kind;
+    private readonly Strategy<string> schemeStrategy;
+    private readonly HostStrategy dnsHostStrategy;
+    private readonly IPAddressStrategy ipHostStrategy;
+
+    internal UriStrategy(UriKind uriKind, IReadOnlyList<string> schemes)
+    {
+        kind = uriKind;
+        schemeStrategy = Strategy.SampledFrom(schemes);
+        dnsHostStrategy = new(1, 3);
+        ipHostStrategy = new(IPAddressKind.Both);
+    }
+
+    internal override Uri Generate(ConjectureData data)
+    {
+        bool absolute = kind switch
+        {
+            UriKind.Absolute => true,
+            UriKind.Relative => false,
+            _ => data.NextBoolean(),
+        };
+
+        string uriString = absolute ? BuildAbsolute(data) : BuildRelative(data);
+
+        UriKind parseKind = absolute ? UriKind.Absolute : UriKind.Relative;
+        return Uri.TryCreate(uriString, parseKind, out Uri? uri)
+            ? uri
+            : throw new InvalidOperationException($"UriStrategy produced an invalid URI string: '{uriString}'");
+    }
+
+    private string BuildAbsolute(ConjectureData data)
+    {
+        string scheme = schemeStrategy.Generate(data);
+        string host = BuildHost(data);
+        StringBuilder sb = new();
+        sb.Append(scheme);
+        sb.Append("://");
+        sb.Append(host);
+        AppendOptionalPort(data, sb);
+        AppendPath(data, sb);
+        return sb.ToString();
+    }
+
+    private static string BuildRelative(ConjectureData data)
+    {
+        StringBuilder sb = new();
+        AppendPath(data, sb);
+        return sb.Length > 0 ? sb.ToString() : "/";
+    }
+
+    private string BuildHost(ConjectureData data)
+    {
+        bool useIp = data.NextBoolean();
+        if (!useIp)
+        {
+            return dnsHostStrategy.Generate(data);
+        }
+
+        IPAddress addr = ipHostStrategy.Generate(data);
+        return addr.AddressFamily == AddressFamily.InterNetworkV6
+            ? $"[{addr}]"
+            : addr.ToString();
+    }
+
+    private static void AppendOptionalPort(ConjectureData data, StringBuilder sb)
+    {
+        if (data.NextBoolean())
+        {
+            int port = (int)data.NextInteger(1UL, 65535UL);
+            sb.Append(':');
+            sb.Append(port);
+        }
+    }
+
+    private static void AppendPath(ConjectureData data, StringBuilder sb)
+    {
+        int segmentCount = (int)data.NextInteger(0UL, 3UL);
+        for (int i = 0; i < segmentCount; i++)
+        {
+            sb.Append('/');
+            sb.Append(new IdentifierStrategy(1, 6, 1, 4).Generate(data));
+        }
+
+        if (segmentCount == 0)
+        {
+            sb.Append('/');
+        }
+    }
+}

--- a/src/Conjecture.Core/UriStrategyRegistration.cs
+++ b/src/Conjecture.Core/UriStrategyRegistration.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+namespace Conjecture.Core;
+
+internal static class UriStrategyRegistration
+{
+    internal static void Register()
+    {
+        GenerateForRegistry.Register(
+            typeof(Uri),
+            static () => new UriProvider(),
+            Strategy.Compose<object?>(static ctx => ctx.Generate(Strategy.Uris())));
+    }
+
+    private sealed class UriProvider : IStrategyProvider<Uri>
+    {
+        public Strategy<Uri> Create() => Strategy.Uris();
+    }
+}

--- a/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
+++ b/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
@@ -237,4 +237,32 @@ public class StrategyToolsTests
         string result = StrategyTools.SuggestForType("Version");
         Assert.Contains("Strategy<Version>", result);
     }
+
+    [Fact]
+    public void SuggestForKnownType_IPAddress_RecommendsIPAddressesFactory()
+    {
+        string result = StrategyTools.SuggestForType("IPAddress");
+        Assert.Contains("Strategy.IPAddresses()", result);
+    }
+
+    [Fact]
+    public void SuggestForKnownType_IPEndPoint_RecommendsIPEndPointsFactory()
+    {
+        string result = StrategyTools.SuggestForType("IPEndPoint");
+        Assert.Contains("Strategy.IPEndPoints()", result);
+    }
+
+    [Fact]
+    public void SuggestForKnownType_Uri_RecommendsUrisFactory()
+    {
+        string result = StrategyTools.SuggestForType("Uri");
+        Assert.Contains("Strategy.Uris()", result);
+    }
+
+    [Fact]
+    public void SuggestForKnownType_MailAddress_RecommendsEmailAddressesFactory()
+    {
+        string result = StrategyTools.SuggestForType("MailAddress");
+        Assert.Contains("Strategy.EmailAddresses()", result);
+    }
 }

--- a/src/Conjecture.Mcp/Tools/StrategyTools.cs
+++ b/src/Conjecture.Mcp/Tools/StrategyTools.cs
@@ -203,6 +203,18 @@ internal static class StrategyTools
             "byte[]" =>
                 "Use `Strategy.Arrays(Strategy.Integers<byte>(), minSize, maxSize)` for a byte array → `Strategy<byte[]>`. Generic `Strategy.Arrays<T>(inner, minSize, maxSize)` works for any element type.",
 
+            "IPAddress" =>
+                "Use `Strategy.IPAddresses()` → `Strategy<IPAddress>` (V4/V6/Both via IPAddressKind).",
+
+            "IPEndPoint" =>
+                "Use `Strategy.IPEndPoints()` → `Strategy<IPEndPoint>` (composable address + port strategies).",
+
+            "MailAddress" =>
+                "Use `Strategy.EmailAddresses()` → `Strategy<MailAddress>` (or `Strategy.EmailAddressStrings()` for the string form).",
+
+            "Uri" =>
+                "Use `Strategy.Uris()` → `Strategy<Uri>` (UriKind, optional schemes).",
+
             "Regex" =>
                 """
             Use `Strategy.Matching(pattern)` or `Strategy.NotMatching(pattern)` from the `Conjecture.Regex` package:


### PR DESCRIPTION
## Description

Adds property-test strategies for stdlib network and address-format primitives: `IPAddress`, `IPEndPoint`, `Uri`, `MailAddress`, plus a shared `Hosts` (DNS-like name) primitive. Closes the gap that previously forced users to hand-compose these for property tests of network code, protocol decoders, URL routing, validators, and email handling.

New public surface (under `Conjecture.Core.Strategy`):

- `Hosts(int minLabels = 1, int maxLabels = 3)` → `Strategy<string>`
- `IPAddresses(IPAddressKind kind = Both)` → `Strategy<IPAddress>` (+ `IPAddressKind` flags enum)
- `IPEndPoints(Strategy<IPAddress>?, Strategy<int>?)` → `Strategy<IPEndPoint>`
- `Uris(UriKind, IReadOnlyList<string>?)` → `Strategy<Uri>`
- `EmailAddresses()` → `Strategy<MailAddress>`
- `EmailAddressStrings()` → `Strategy<string>`

`Strategy.For<T>()` resolves each new type to its default factory. `Conjecture.Mcp` `StrategyTools.SuggestForKnownType` surfaces the new primitives. Reference page `docs/site/articles/reference/network-strategies.md` and how-to `docs/site/articles/how-to/property-test-network-code.md` are added.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes (Core 972, Mcp 234)
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #620

## Cycles included

- 38c5f79 MailAddress: split into one-type-per-file
- 45edb3c Docs: document network primitive strategies
- 995f730 StrategyTools: suggest network primitives for IPAddress, IPEndPoint, Uri, MailAddress
- 214f8e7 MailAddressStrategy: EmailAddresses() and EmailAddressStrings() primitives
- fd0f46c UriStrategy: hoist IdentifierStrategy to field, drop trailing newline
- 2080e41 UriStrategy: Uris() primitive for System.Uri
- b1c9b5f IPEndPointStrategy: IPEndPoints() primitive for System.Net.IPEndPoint
- 1a0b808 IPAddressStrategy: IPAddresses() primitive for System.Net.IPAddress
- 9ae62a3 HostStrategy: Hosts() primitive for DNS-like host names