### PR TITLE
[619] Strategy.Cultures: CultureInfo primitive

### DIFF
--- a/docs/site/articles/reference/strategies.md
+++ b/docs/site/articles/reference/strategies.md
@@ -134,6 +134,26 @@ Generates `TimeOnly` values in `[min, max]`.
 
 For boundary-focused extensions (`.NearMidnight()`, `.NearDstTransition()`, etc.) and `Strategy.TimeZones`/`Strategy.ClockSet` factory methods, see [Time strategies reference](time-strategies.md).
 
+## Globalization strategies
+
+### `Strategy.Cultures()`
+
+```csharp
+Strategy<CultureInfo> Strategy.Cultures()
+```
+
+Picks uniformly from `CultureInfo.GetCultures(CultureTypes.AllCultures)`. Shrinks toward `CultureInfo.InvariantCulture` (placed at index 0).
+
+### `Strategy.Cultures(CultureTypes types)`
+
+```csharp
+Strategy<CultureInfo> Strategy.Cultures(CultureTypes types)
+```
+
+Picks uniformly from `CultureInfo.GetCultures(types)`. Shrinks toward `CultureInfo.InvariantCulture` (placed at index 0).
+
+`Conjecture.Money` and `Conjecture.Time` build opinionated subsets (cultures with currency, cultures by calendar) on top of these primitives.
+
 ## Byte buffer strategies
 
 ### `Strategy.FromBytes<T>(ReadOnlySpan<byte> buffer)`

--- a/src/Conjecture.Core.Tests/Strategies/CultureStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/CultureStrategyTests.cs
@@ -31,12 +31,19 @@ public class CultureStrategyTests
     {
         Strategy<CultureInfo> strategy = Strategy.Cultures(CultureTypes.NeutralCultures);
         ConjectureData data = MakeData();
+        CultureInfo[] expected = CultureInfo.GetCultures(CultureTypes.NeutralCultures);
+        HashSet<string> expectedNames = [.. expected.Select(c => c.Name)];
 
         for (int i = 0; i < 200; i++)
         {
             CultureInfo value = strategy.Generate(data);
-            Assert.False(value.CultureTypes == CultureTypes.SpecificCultures,
-                $"Expected no specific-only cultures but got: {value.Name}");
+            if (value.Name == CultureInfo.InvariantCulture.Name)
+            {
+                continue;
+            }
+
+            Assert.True(expectedNames.Contains(value.Name),
+                $"Expected only neutral cultures but got: {value.Name}");
         }
     }
 

--- a/src/Conjecture.Core.Tests/Strategies/CultureStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/CultureStrategyTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Globalization;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class CultureStrategyTests
+{
+    private static ConjectureData MakeData(ulong seed = 42UL) =>
+        ConjectureData.ForGeneration(new SplittableRandom(seed));
+
+    [Fact]
+    public void Cultures_GeneratesNonNullValues()
+    {
+        Strategy<CultureInfo> strategy = Strategy.Cultures();
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 100; i++)
+        {
+            CultureInfo value = strategy.Generate(data);
+            Assert.True(value is not null);
+        }
+    }
+
+    [Fact]
+    public void Cultures_WithNeutralCulturesFilter_ExcludesSpecificCultures()
+    {
+        Strategy<CultureInfo> strategy = Strategy.Cultures(CultureTypes.NeutralCultures);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 200; i++)
+        {
+            CultureInfo value = strategy.Generate(data);
+            Assert.False(value.CultureTypes == CultureTypes.SpecificCultures,
+                $"Expected no specific-only cultures but got: {value.Name}");
+        }
+    }
+
+    [Fact]
+    public async Task Cultures_ShrinksTowardInvariantCulture()
+    {
+        Strategy<CultureInfo> strategy = Strategy.Cultures();
+        ConjectureSettings settings = new() { MaxExamples = 200, Seed = 1UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            CultureInfo culture = strategy.Generate(data);
+            throw new Exception($"always fails: {culture.Name}");
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        CultureInfo shrunk = strategy.Generate(replay);
+        Assert.Equal(CultureInfo.InvariantCulture, shrunk);
+    }
+
+    [Fact]
+    public void Cultures_DefaultIncludesInvariantCulture()
+    {
+        Strategy<CultureInfo> strategy = Strategy.Cultures();
+        ConjectureData data = MakeData();
+        bool found = false;
+
+        for (int i = 0; i < 20000; i++)
+        {
+            CultureInfo value = strategy.Generate(data);
+            if (value.Equals(CultureInfo.InvariantCulture))
+            {
+                found = true;
+                break;
+            }
+        }
+
+        Assert.True(found, "InvariantCulture was not produced in 20000 draws from Cultures()");
+    }
+
+    [Fact]
+    public void Cultures_DeterministicWithSeed()
+    {
+        Strategy<CultureInfo> strategy = Strategy.Cultures();
+
+        List<string> results1 = Enumerable.Range(0, 20)
+            .Select(_ => strategy.Generate(MakeData(99UL)).Name)
+            .ToList();
+        List<string> results2 = Enumerable.Range(0, 20)
+            .Select(_ => strategy.Generate(MakeData(99UL)).Name)
+            .ToList();
+
+        Assert.Equal(results1, results2);
+    }
+}

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -55,6 +55,8 @@ static Conjecture.Core.Strategy.Decimals(decimal min, decimal max) -> Conjecture
 static Conjecture.Core.Strategy.DateTimes() -> Conjecture.Core.Strategy<System.DateTime>!
 static Conjecture.Core.Strategy.DateTimes(System.DateTime min, System.DateTime max) -> Conjecture.Core.Strategy<System.DateTime>!
 static Conjecture.Core.Strategy.Chars() -> Conjecture.Core.Strategy<char>!
+static Conjecture.Core.Strategy.Cultures() -> Conjecture.Core.Strategy<System.Globalization.CultureInfo!>!
+static Conjecture.Core.Strategy.Cultures(System.Globalization.CultureTypes types) -> Conjecture.Core.Strategy<System.Globalization.CultureInfo!>!
 static Conjecture.Core.Strategy.OneOf<T>(params System.ReadOnlySpan<Conjecture.Core.Strategy<T>!> strategies) -> Conjecture.Core.Strategy<T>!
 Conjecture.Core.SeededStrategy<T>
 Conjecture.Core.SeededStrategy<T>.SeededStrategy() -> void

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -4,6 +4,8 @@
 // Derived from the Python Hypothesis library.
 // Original copyright: Copyright (c) 2013-present, David R. MacIver and contributors.
 
+using System.Collections.Concurrent;
+using System.Globalization;
 using System.Numerics;
 
 namespace Conjecture.Core;
@@ -288,5 +290,29 @@ public static class Strategy
         ForConfiguration<T> cfg = new();
         configure(cfg);
         return Compose<T>(ctx => ctx.Generate(GenerateForRegistry.ResolveWithOverrides(cfg)));
+    }
+
+    private static readonly ConcurrentDictionary<CultureTypes, CultureInfo[]> CulturesCache = new();
+
+    /// <summary>Returns a strategy that generates random <see cref="CultureInfo"/> values from all cultures, with <see cref="CultureInfo.InvariantCulture"/> at index 0 to guide shrinking.</summary>
+    public static Strategy<CultureInfo> Cultures()
+        => SampledFrom(CulturesCache.GetOrAdd(CultureTypes.AllCultures, static t => BuildCultures(t)));
+
+    /// <summary>Returns a strategy that generates random <see cref="CultureInfo"/> values matching <paramref name="types"/>, with <see cref="CultureInfo.InvariantCulture"/> at index 0 to guide shrinking.</summary>
+    public static Strategy<CultureInfo> Cultures(CultureTypes types)
+        => SampledFrom(CulturesCache.GetOrAdd(types, static t => BuildCultures(t)));
+
+    private static CultureInfo[] BuildCultures(CultureTypes types)
+    {
+        List<CultureInfo> result = [CultureInfo.InvariantCulture];
+        foreach (CultureInfo culture in CultureInfo.GetCultures(types))
+        {
+            if (culture.Name != CultureInfo.InvariantCulture.Name)
+            {
+                result.Add(culture);
+            }
+        }
+
+        return [.. result];
     }
 }


### PR DESCRIPTION
## Description

Adds `Strategy.Cultures()` and `Strategy.Cultures(CultureTypes types)` factory methods to `Conjecture.Core`. Both delegate to `SampledFrom` over a `ConcurrentDictionary`-cached array of cultures returned by `CultureInfo.GetCultures(types)`, with `CultureInfo.InvariantCulture` pinned at index 0 so the shrinker collapses toward it (mirrors the UTC-at-index-0 pattern used by `Strategy.TimeZones()`).

Adds reference documentation under `docs/site/articles/reference/strategies.md` (new "Globalization strategies" section).

Unblocks `Conjecture.Money` and `Conjecture.Time` follow-ups that build opinionated subsets (cultures with currency, cultures by calendar) on top of this primitive.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes (CI build-and-test green)
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #619

## Cycles included

- 4a9c698 Fixes Cultures_WithNeutralCulturesFilter test on Linux
- 3883451 Documents Strategy.Cultures() in the strategies reference
- dd5bd88 Adds Strategy.Cultures() and Strategy.Cultures(CultureTypes) factories