### PR TITLE
[621] Strategy.Versions: System.Version primitive

### DIFF
--- a/docs/site/articles/reference/strategies.md
+++ b/docs/site/articles/reference/strategies.md
@@ -154,6 +154,24 @@ Picks uniformly from `CultureInfo.GetCultures(types)`. Shrinks toward `CultureIn
 
 `Conjecture.Money` and `Conjecture.Time` build opinionated subsets (cultures with currency, cultures by calendar) on top of these primitives.
 
+## Version strategies
+
+### `Strategy.Versions(int maxMajor = 9, int maxMinor = 9, int maxBuild = 9, int maxRevision = 9)`
+
+```csharp
+Strategy<Version> Strategy.Versions(int maxMajor = 9, int maxMinor = 9, int maxBuild = 9, int maxRevision = 9)
+```
+
+Generates `System.Version` values whose `Major`, `Minor`, `Build`, and `Revision` components fall within `[0, maxMajor]`, `[0, maxMinor]`, `[0, maxBuild]`, and `[0, maxRevision]` respectively. Each component is drawn from `Strategy.Integers<int>(0, max*)` and the four values are projected into `new Version(major, minor, build, revision)`.
+
+The shrink target is `new Version(0, 0, 0, 0)` — when a property fails, the shrinker drives every component down to zero. The defaults keep components small so shrinking converges quickly; raise them when your property depends on larger version numbers.
+
+A negative value for any `max*` argument throws `ArgumentOutOfRangeException`.
+
+Resolves via [`Strategy.For<T>()`](generate-for.md) for `Version`, so `[Property]` parameters typed as `System.Version` work without an explicit factory call.
+
+For the string-shaped counterpart (e.g. `"1.2.3"`), see [`Strategy.VersionStrings()`](string-strategies.md).
+
 ## Byte buffer strategies
 
 ### `Strategy.FromBytes<T>(ReadOnlySpan<byte> buffer)`

--- a/src/Conjecture.Core.Tests/Strategies/VersionStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/VersionStrategyTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Generic;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class VersionStrategyTests
+{
+    private static ConjectureData MakeData(ulong seed = 42UL) =>
+        ConjectureData.ForGeneration(new SplittableRandom(seed));
+
+    // ── Bounds ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Versions_Generates_Components_Within_Bounds()
+    {
+        Strategy<Version> strategy = Strategy.Versions(maxMajor: 5, maxMinor: 3, maxBuild: 7, maxRevision: 2);
+
+        for (int i = 0; i < 200; i++)
+        {
+            Version v = strategy.Generate(MakeData((ulong)i));
+            Assert.InRange(v.Major, 0, 5);
+            Assert.InRange(v.Minor, 0, 3);
+            Assert.InRange(v.Build, 0, 7);
+            Assert.InRange(v.Revision, 0, 2);
+        }
+    }
+
+    // ── Shrink ───────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Versions_Shrinks_Toward_Zero_Components()
+    {
+        Strategy<Version> strategy = Strategy.Versions();
+        ConjectureSettings settings = new() { MaxExamples = 200, Seed = 1UL, Database = false };
+        Version zero = new(0, 0, 0, 0);
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            _ = strategy.Generate(data);
+            throw new Exception("always fails");
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        Version shrunk = strategy.Generate(replay);
+        Assert.Equal(zero, shrunk);
+    }
+
+    // ── Validation ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Versions_NegativeMaxMajor_ThrowsWithCorrectParamName()
+    {
+        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => Strategy.Versions(maxMajor: -1));
+        Assert.Equal("maxMajor", ex.ParamName);
+    }
+
+    [Fact]
+    public void Versions_NegativeMaxMinor_ThrowsWithCorrectParamName()
+    {
+        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => Strategy.Versions(maxMinor: -1));
+        Assert.Equal("maxMinor", ex.ParamName);
+    }
+
+    [Fact]
+    public void Versions_NegativeMaxBuild_ThrowsWithCorrectParamName()
+    {
+        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => Strategy.Versions(maxBuild: -1));
+        Assert.Equal("maxBuild", ex.ParamName);
+    }
+
+    [Fact]
+    public void Versions_NegativeMaxRevision_ThrowsWithCorrectParamName()
+    {
+        ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(
+            () => Strategy.Versions(maxRevision: -1));
+        Assert.Equal("maxRevision", ex.ParamName);
+    }
+
+    // ── Strategy.For<Version> ────────────────────────────────────────────────
+
+    [Fact]
+    public void Versions_Default_Resolves_Via_For_Version()
+    {
+        Strategy<Version> strategy = Strategy.For<Version>();
+
+        for (int i = 0; i < 50; i++)
+        {
+            Version v = strategy.Generate(MakeData((ulong)i));
+            Assert.NotNull(v);
+            Assert.True(v.Major >= 0);
+            Assert.True(v.Minor >= 0);
+            Assert.True(v.Build >= 0);
+            Assert.True(v.Revision >= 0);
+        }
+    }
+}

--- a/src/Conjecture.Core/GenerateForRegistry.cs
+++ b/src/Conjecture.Core/GenerateForRegistry.cs
@@ -18,12 +18,31 @@ namespace Conjecture.Core;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class GenerateForRegistry
 {
-    private static readonly ConcurrentDictionary<Type, Func<IStrategyProvider>> Providers = new();
+    private static readonly ConcurrentDictionary<Type, Func<IStrategyProvider>> Providers = InitProviders();
 
     private static readonly ConcurrentDictionary<Type, Func<object, object>> OverrideProviders = new();
 
     // Parallel dictionary holding AOT-safe boxed strategies for use via ResolveBoxed.
     private static readonly ConcurrentDictionary<Type, Strategy<object?>> BoxedStrategies = new();
+
+    /// <summary>
+    /// Registers built-in primitive types whose factory has no required arguments so
+    /// <see cref="Strategy.For{T}()"/> works out of the box for those types without requiring
+    /// <c>[Arbitrary]</c> decoration or source-generator output.
+    /// Only types with fully-defaulted factory signatures (e.g. <see cref="Version"/>) belong here;
+    /// types like <see cref="Guid"/> that have no strategy overload are intentionally excluded.
+    /// </summary>
+    private static ConcurrentDictionary<Type, Func<IStrategyProvider>> InitProviders()
+    {
+        ConcurrentDictionary<Type, Func<IStrategyProvider>> dict = new();
+        dict[typeof(Version)] = static () => new VersionStrategyProvider();
+        return dict;
+    }
+
+    private sealed class VersionStrategyProvider : IStrategyProvider<Version>
+    {
+        public Strategy<Version> Create() => Strategy.Versions();
+    }
 
     /// <summary>Registers an override-aware <see cref="IStrategyProvider"/> for <paramref name="type"/>. Called by source-generated module initializers.</summary>
     public static void RegisterOverride(Type type, Func<object, object> factory)

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -50,6 +50,7 @@ static Conjecture.Core.Strategy.TimeSpans(System.TimeSpan min, System.TimeSpan m
 static Conjecture.Core.Strategy.For<T>(System.Action<Conjecture.Core.ForConfiguration<T>!>! configure) -> Conjecture.Core.Strategy<T>!
 static Conjecture.Core.Strategy.For<T>() -> Conjecture.Core.Strategy<T>!
 static Conjecture.Core.Strategy.Guids() -> Conjecture.Core.Strategy<System.Guid>!
+static Conjecture.Core.Strategy.Versions(int maxMajor = 9, int maxMinor = 9, int maxBuild = 9, int maxRevision = 9) -> Conjecture.Core.Strategy<System.Version!>!
 static Conjecture.Core.Strategy.Decimals() -> Conjecture.Core.Strategy<decimal>!
 static Conjecture.Core.Strategy.Decimals(decimal min, decimal max) -> Conjecture.Core.Strategy<decimal>!
 static Conjecture.Core.Strategy.DateTimes() -> Conjecture.Core.Strategy<System.DateTime>!

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -263,6 +263,16 @@ public static class Strategy
     /// <summary>Returns a strategy that generates random <see cref="Guid"/> values.</summary>
     public static Strategy<Guid> Guids() => new GuidStrategy();
 
+    /// <summary>Returns a strategy that generates <see cref="Version"/> values with components in the configured ranges. Components default to a small range so shrinking converges quickly.</summary>
+    public static Strategy<Version> Versions(int maxMajor = 9, int maxMinor = 9, int maxBuild = 9, int maxRevision = 9)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(maxMajor);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxMinor);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxBuild);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxRevision);
+        return new VersionStrategy(maxMajor, maxMinor, maxBuild, maxRevision);
+    }
+
     /// <summary>Returns a strategy that generates random <see cref="decimal"/> values.</summary>
     public static Strategy<decimal> Decimals() => new DecimalStrategy();
 

--- a/src/Conjecture.Core/VersionStrategy.cs
+++ b/src/Conjecture.Core/VersionStrategy.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core;
+
+internal sealed class VersionStrategy : Strategy<Version>
+{
+    private readonly IntegerStrategy<int> majorStrategy;
+    private readonly IntegerStrategy<int> minorStrategy;
+    private readonly IntegerStrategy<int> buildStrategy;
+    private readonly IntegerStrategy<int> revisionStrategy;
+
+    internal VersionStrategy(int maxMajor, int maxMinor, int maxBuild, int maxRevision)
+    {
+        majorStrategy = new IntegerStrategy<int>(0, maxMajor);
+        minorStrategy = new IntegerStrategy<int>(0, maxMinor);
+        buildStrategy = new IntegerStrategy<int>(0, maxBuild);
+        revisionStrategy = new IntegerStrategy<int>(0, maxRevision);
+    }
+
+    internal override Version Generate(ConjectureData data)
+    {
+        int major = majorStrategy.Generate(data);
+        int minor = minorStrategy.Generate(data);
+        int build = buildStrategy.Generate(data);
+        int revision = revisionStrategy.Generate(data);
+        return new(major, minor, build, revision);
+    }
+}

--- a/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
+++ b/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
@@ -223,4 +223,18 @@ public class StrategyToolsTests
         string result = StrategyTools.SuggestForType("rounding");
         Assert.Contains("Strategy.RoundingModes()", result);
     }
+
+    [Fact]
+    public void SuggestForType_Version_ContainsVersionsFactory()
+    {
+        string result = StrategyTools.SuggestForType("Version");
+        Assert.Contains("Strategy.Versions()", result);
+    }
+
+    [Fact]
+    public void SuggestForType_Version_MentionsStrategyOfVersion()
+    {
+        string result = StrategyTools.SuggestForType("Version");
+        Assert.Contains("Strategy<Version>", result);
+    }
 }

--- a/src/Conjecture.Mcp/Tools/StrategyTools.cs
+++ b/src/Conjecture.Mcp/Tools/StrategyTools.cs
@@ -197,6 +197,9 @@ internal static class StrategyTools
             "Guid" =>
                 "Use `Strategy.Guids()` → `Strategy<Guid>`.",
 
+            "Version" =>
+                "Use `Strategy.Versions()` → `Strategy<Version>`.",
+
             "byte[]" =>
                 "Use `Strategy.Arrays(Strategy.Integers<byte>(), minSize, maxSize)` for a byte array → `Strategy<byte[]>`. Generic `Strategy.Arrays<T>(inner, minSize, maxSize)` works for any element type.",
 


### PR DESCRIPTION
## Description

Adds `Strategy.Versions(...)` to `Conjecture.Core` — the typed counterpart to the existing `Strategy.VersionStrings()`. Generates `System.Version` instances by composing four `Strategy.Integers<int>(0, max*)` strategies and projecting into `new Version(major, minor, build, revision)`. Shrinks toward `new Version(0, 0, 0, 0)`. Wires the default-arg form into `Strategy.For<Version>()` so `[Property]` parameters of type `Version` resolve out of the box. The MCP `SuggestForKnownType` tool surfaces `Strategy.Versions()` for `System.Version`, and the strategies reference page documents the new factory.

## Type of change

- [ ] Bug fix
- [x] New feature / strategy
- [ ] Refactor (no behavior change)
- [ ] Documentation / chore
- [ ] AI tools adjustments

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #621

## Cycles included
- 807000d Adds Strategy.Versions primitive for System.Version (#626)
- dd1d592 Surfaces Strategy.Versions in MCP StrategyTools.SuggestForKnownType (#628)
- cb9a5b1 Adds Strategy.Versions reference entry (#630)