### PR TITLE
[624] Conjecture.Money: culture-aware currency strategies

### DIFF
--- a/docs/site/articles/explanation/money-decimal-arithmetic.md
+++ b/docs/site/articles/explanation/money-decimal-arithmetic.md
@@ -45,6 +45,14 @@ The shrink pass sees the `long` draw and reduces it toward `0` by the standard i
 
 The practical result: a counterexample generated at `9843.27m` will shrink toward `0.00m`, passing through values like `4921.63m`, `2460.81m`, `1230.40m`, … until the smallest failing value is found. The shrunk counterexample is always a valid representable USD amount with exactly 2 decimal places.
 
+## Why surfacing the cultural axis matters
+
+`decimal` arithmetic is exact, but presentation is not. The string `"$1,234.56"` (en-US) and `"1.234,56 $"` (some European locales) represent the same decimal value but require different parse logic. A test that only checks arithmetic without exercising the cultural formatting layer will miss bugs in any code path that calls `ToString("C", ...)` or `decimal.Parse(...)`.
+
+`Strategy.CulturesWithCurrency()` generates `CultureInfo` instances that have a currency symbol, spanning the diversity of negative-value patterns (parentheses vs. minus sign), decimal separators (`.` vs. `,`), and symbol placement (prefix vs. suffix). `Strategy.CulturesByCurrencyCode("USD")` narrows that set to cultures that format USD specifically.
+
+Combining an amount strategy with a culture strategy lets a single property exercise both the arithmetic and the formatting/parsing contract in one run. See [How to test monetary and decimal arithmetic](../how-to/use-money-strategies.md#round-tripping-currency-formatting) for the end-to-end snippet.
+
 ## See also
 
 - [Reference: Money strategies](../reference/money-strategies.md)

--- a/docs/site/articles/how-to/use-money-strategies.md
+++ b/docs/site/articles/how-to/use-money-strategies.md
@@ -76,6 +76,33 @@ public bool Allocator_SumsToOriginalAmount()
 }
 ```
 
+## Round-tripping currency formatting
+
+Use `Strategy.Amounts` together with `Strategy.CulturesByCurrencyCode` to property-test that `decimal.ToString("C", culture)` round-trips through `decimal.Parse`:
+
+```csharp
+using System.Globalization;
+using Conjecture.Core;
+using Conjecture.Money;
+
+[Property]
+public bool CurrencyFormatting_RoundTrips()
+{
+    // Arrange
+    decimal amount = DataGen.SampleOne(Strategy.Amounts("USD"));
+    CultureInfo culture = DataGen.SampleOne(Strategy.CulturesByCurrencyCode("USD"));
+
+    // Act
+    string formatted = amount.ToString("C", culture);
+    decimal parsed = decimal.Parse(formatted, NumberStyles.Currency, culture);
+
+    // Assert — parsing the formatted string must recover the original amount
+    return parsed == amount;
+}
+```
+
+`Strategy.CulturesByCurrencyCode("USD")` samples from the set of `CultureInfo` instances on the current host whose currency symbol matches USD. This exercises locale-specific formatting differences — separator characters, negative-value patterns, symbol placement — that a single hard-coded culture would miss.
+
 ## See also
 
 - [Reference: Money strategies](../reference/money-strategies.md) — full API surface

--- a/docs/site/articles/reference/money-strategies.md
+++ b/docs/site/articles/reference/money-strategies.md
@@ -57,6 +57,32 @@ Samples uniformly from all `System.MidpointRounding` enum values:
 - `ToZero`
 - `TowardZero`
 
+## `Strategy.CulturesWithCurrency()`
+
+```csharp
+Strategy<CultureInfo> Strategy.CulturesWithCurrency()
+```
+
+Generates `CultureInfo` instances that have a non-null, non-empty `NumberFormat.CurrencySymbol`. Samples from the cultures installed on the current .NET runtime; the set is host-dependent — different runtimes and operating systems ship different culture sets.
+
+> [!NOTE]
+> **Host-dependent.** The cultures available at runtime vary between .NET versions, operating systems, and ICU data versions. A property that passes on one machine may generate a different sample space on another. Pin the ICU data version in CI if you need full reproducibility.
+
+Shrinks toward the first culture in the sorted enumeration.
+
+## `Strategy.CulturesByCurrencyCode(string currencyCode)`
+
+```csharp
+Strategy<CultureInfo> Strategy.CulturesByCurrencyCode(string currencyCode)
+```
+
+Generates `CultureInfo` instances whose `NumberFormat.CurrencySymbol` matches the symbol for the given ISO 4217 `currencyCode`. Useful for round-tripping `decimal.ToString("C", culture)` ↔ `decimal.Parse`.
+
+> [!NOTE]
+> **Host-dependent.** The cultures available at runtime vary between .NET versions, operating systems, and ICU data versions. A property that passes on one machine may generate a different sample space on another.
+
+Throws `ArgumentException` if `currencyCode` is not an active ISO 4217 code or if no cultures on the current host match the currency.
+
 ## ISO 4217 snapshot
 
 The embedded snapshot covers 141 active codes as of 2026:

--- a/src/Conjecture.Core/Conjecture.Core.csproj
+++ b/src/Conjecture.Core/Conjecture.Core.csproj
@@ -103,6 +103,9 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>Conjecture.Aspire</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Conjecture.Money.Tests</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 
 </Project>

--- a/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
+++ b/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
@@ -201,6 +201,20 @@ public class StrategyToolsTests
     }
 
     [Fact]
+    public void SuggestStrategy_Currency_MentionsCulturesWithCurrency()
+    {
+        string result = StrategyTools.SuggestForType("currency");
+        Assert.Contains("CulturesWithCurrency", result);
+    }
+
+    [Fact]
+    public void SuggestStrategy_Currency_MentionsCulturesByCurrencyCode()
+    {
+        string result = StrategyTools.SuggestForType("currency");
+        Assert.Contains("CulturesByCurrencyCode", result);
+    }
+
+    [Fact]
     public void SuggestForType_MidpointRounding_ContainsRoundingModes()
     {
         string result = StrategyTools.SuggestForType("MidpointRounding");

--- a/src/Conjecture.Mcp/Tools/StrategyTools.cs
+++ b/src/Conjecture.Mcp/Tools/StrategyTools.cs
@@ -296,6 +296,17 @@ internal static class StrategyTools
             // → Strategy<decimal> of valid currency amounts for the given currency code
             ```
 
+            For culture-dependent formatting and parsing, use `Strategy.CulturesWithCurrency()` or `Strategy.CulturesByCurrencyCode(string)`:
+            ```csharp
+            using Conjecture.Money;
+
+            Strategy.CulturesByCurrencyCode("USD")
+            // → Strategy<CultureInfo> samples cultures using USD; shrinks to en-US
+
+            Strategy.Amounts("USD").Combine(Strategy.CulturesByCurrencyCode("USD"))
+            // → Strategy<(decimal, CultureInfo)> for round-trip property tests
+            ```
+
             Add the NuGet package: `Conjecture.Money`
             """,
 

--- a/src/Conjecture.Money.Tests/Conjecture.Money.Tests.csproj
+++ b/src/Conjecture.Money.Tests/Conjecture.Money.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Conjecture.Core\Conjecture.Core.csproj" />
     <ProjectReference Include="..\Conjecture.Money\Conjecture.Money.csproj" />
     <ProjectReference Include="..\Conjecture.Xunit.V3\Conjecture.Xunit.V3.csproj" />
   </ItemGroup>

--- a/src/Conjecture.Money.Tests/CultureCurrencyStrategyTests.cs
+++ b/src/Conjecture.Money.Tests/CultureCurrencyStrategyTests.cs
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Globalization;
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Money.Tests;
+
+public class CultureCurrencyStrategyTests
+{
+    [Fact]
+    public void CulturesWithCurrency_All_Have_NonEmpty_ISOCurrencySymbol()
+    {
+        Strategy<CultureInfo> strategy = Strategy.CulturesWithCurrency();
+        IReadOnlyList<CultureInfo> samples = strategy.WithSeed(1UL).Sample(200);
+
+        Assert.All(samples, culture =>
+        {
+            RegionInfo region = new(culture.Name);
+            Assert.False(string.IsNullOrEmpty(region.ISOCurrencySymbol),
+                $"Culture '{culture.Name}' has an empty ISOCurrencySymbol");
+        });
+    }
+
+    [Fact]
+    public void CulturesWithCurrency_All_Are_Specific_Cultures()
+    {
+        Strategy<CultureInfo> strategy = Strategy.CulturesWithCurrency();
+        IReadOnlyList<CultureInfo> samples = strategy.WithSeed(2UL).Sample(200);
+
+        Assert.All(samples, culture =>
+            Assert.False(culture.IsNeutralCulture,
+                $"Culture '{culture.Name}' is a neutral culture"));
+    }
+
+    [Fact]
+    public void CulturesWithCurrency_ShrinksToEnUs()
+    {
+        // en-US is placed at index 0 so SampledFrom shrinks toward it.
+        // The smallest draw from SampledFrom always resolves to index 0.
+        Strategy<CultureInfo> strategy = Strategy.CulturesWithCurrency();
+        IReadOnlyList<CultureInfo> samples = strategy.WithSeed(3UL).Sample(500);
+
+        string expectedName = CultureInfo.GetCultures(CultureTypes.SpecificCultures)
+            .Any(static c => c.Name == "en-US")
+            ? "en-US"
+            : CultureInfo.InvariantCulture.Name;
+
+        bool found = samples.Any(c => c.Name == expectedName);
+        Assert.True(found, $"Expected '{expectedName}' (shrink target at index 0) to appear in 500 samples");
+    }
+
+    [Fact]
+    public async Task CulturesWithCurrency_ShrinksToEnUsViaTestRunner()
+    {
+        Strategy<CultureInfo> strategy = Strategy.CulturesWithCurrency();
+        ConjectureSettings settings = new() { MaxExamples = 200, Seed = 5UL };
+
+        string expectedName = CultureInfo.GetCultures(CultureTypes.SpecificCultures)
+            .Any(static c => c.Name == "en-US")
+            ? "en-US"
+            : CultureInfo.InvariantCulture.Name;
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            CultureInfo culture = strategy.Generate(data);
+            throw new Exception($"always fails: {culture.Name}");
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        CultureInfo shrunk = strategy.Generate(replay);
+        Assert.Equal(expectedName, shrunk.Name);
+    }
+
+    [Fact]
+    public void CulturesWithCurrency_IsDeterministic()
+    {
+        Strategy<CultureInfo> strategy = Strategy.CulturesWithCurrency();
+        IReadOnlyList<CultureInfo> first = strategy.WithSeed(4UL).Sample(100);
+        IReadOnlyList<CultureInfo> second = strategy.WithSeed(4UL).Sample(100);
+
+        Assert.Equal(
+            first.Select(static c => c.Name).ToList(),
+            second.Select(static c => c.Name).ToList());
+    }
+}

--- a/src/Conjecture.Money.Tests/CultureCurrencyStrategyTests.cs
+++ b/src/Conjecture.Money.Tests/CultureCurrencyStrategyTests.cs
@@ -86,4 +86,85 @@ public class CultureCurrencyStrategyTests
             first.Select(static c => c.Name).ToList(),
             second.Select(static c => c.Name).ToList());
     }
+
+    [Fact]
+    public void CulturesByCurrencyCode_USD_All_Use_USD()
+    {
+        Strategy<CultureInfo> strategy = Strategy.CulturesByCurrencyCode("USD");
+        IReadOnlyList<CultureInfo> samples = strategy.WithSeed(10UL).Sample(100);
+
+        Assert.All(samples, culture =>
+        {
+            RegionInfo region = new(culture.Name);
+            Assert.Equal("USD", region.ISOCurrencySymbol);
+        });
+    }
+
+    [Fact]
+    public void CulturesByCurrencyCode_EUR_All_Use_EUR()
+    {
+        Strategy<CultureInfo> strategy = Strategy.CulturesByCurrencyCode("EUR");
+        IReadOnlyList<CultureInfo> samples = strategy.WithSeed(11UL).Sample(100);
+
+        Assert.All(samples, culture =>
+        {
+            RegionInfo region = new(culture.Name);
+            Assert.Equal("EUR", region.ISOCurrencySymbol);
+        });
+    }
+
+    [Fact]
+    public void CulturesByCurrencyCode_Unknown_Throws()
+    {
+        ArgumentException ex = Assert.Throws<ArgumentException>(() => Strategy.CulturesByCurrencyCode("ZZZ"));
+        Assert.Contains("ZZZ", ex.Message);
+    }
+
+    [Fact]
+    public void CulturesByCurrencyCode_LowerCase_ThrowsArgumentException()
+    {
+        // Case-sensitive to match Iso4217Data keys directly — "usd" is not a known code.
+        Assert.Throws<ArgumentException>(() => Strategy.CulturesByCurrencyCode("usd"));
+    }
+
+    [Fact]
+    public async Task CulturesByCurrencyCode_USD_ShrinksToEnUs()
+    {
+        Strategy<CultureInfo> strategy = Strategy.CulturesByCurrencyCode("USD");
+        ConjectureSettings settings = new() { MaxExamples = 200, Seed = 12UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            CultureInfo culture = strategy.Generate(data);
+            throw new Exception($"always fails: {culture.Name}");
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        CultureInfo shrunk = strategy.Generate(replay);
+        Assert.Equal("en-US", shrunk.Name);
+    }
+
+    [Fact]
+    public async Task CulturesByCurrencyCode_USD_AmountRoundTripsViaToString()
+    {
+        Strategy<(decimal Amount, CultureInfo Culture)> strategy =
+            Strategy.Amounts("USD").Zip(Strategy.CulturesByCurrencyCode("USD"));
+        ConjectureSettings settings = new() { MaxExamples = 100, Seed = 13UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            (decimal amount, CultureInfo culture) = strategy.Generate(data);
+            decimal parsed = decimal.Parse(
+                amount.ToString("C", culture),
+                System.Globalization.NumberStyles.Currency,
+                culture);
+            if (parsed != amount)
+            {
+                throw new Exception($"Round-trip failed: {amount} -> '{amount.ToString("C", culture)}' -> {parsed} for culture '{culture.Name}'");
+            }
+        });
+
+        Assert.True(result.Passed);
+    }
 }

--- a/src/Conjecture.Money/MoneyStrategyExtensions.cs
+++ b/src/Conjecture.Money/MoneyStrategyExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using System.Collections.Concurrent;
 using System.Globalization;
 
 using Conjecture.Money.Internal;
@@ -50,13 +51,32 @@ public static class MoneyStrategyExtensions
         {
             return Strategy.SampledFrom(CulturesWithCurrencyCache.Value);
         }
+
+        /// <summary>Returns a strategy that samples cultures whose <see cref="RegionInfo.ISOCurrencySymbol"/> equals <paramref name="currencyCode"/>. Shrinks toward the first matching culture (e.g. <c>en-US</c> for USD).</summary>
+        public static Strategy<CultureInfo> CulturesByCurrencyCode(string currencyCode)
+        {
+            if (!Iso4217Data.DecimalPlacesByCurrency.ContainsKey(currencyCode))
+            {
+                throw new ArgumentException($"Unknown ISO 4217 currency code: '{currencyCode}'.", nameof(currencyCode));
+            }
+
+            CultureInfo[] cultures = CulturesByCurrencyCodeCache.GetOrAdd(currencyCode, BuildCulturesByCurrencyCode);
+            return cultures.Length == 0
+                ? throw new ArgumentException($"No culture on this host uses currency '{currencyCode}'.", nameof(currencyCode))
+                : Strategy.SampledFrom(cultures);
+        }
     }
 
-    private static readonly Lazy<CultureInfo[]> CulturesWithCurrencyCache = new(static () => BuildCulturesWithCurrency());
+    private static readonly Lazy<(CultureInfo Culture, string CurrencyCode)[]> SpecificCulturesWithRegionsCache =
+        new(BuildSpecificCulturesWithRegions);
+
+    private static readonly Lazy<CultureInfo[]> CulturesWithCurrencyCache = new(BuildCulturesWithCurrency);
+
+    private static readonly ConcurrentDictionary<string, CultureInfo[]> CulturesByCurrencyCodeCache = new();
 
     private static CultureInfo[] BuildCulturesWithCurrency()
     {
-        CultureInfo[] specificCultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
+        (CultureInfo Culture, string CurrencyCode)[] allCultures = SpecificCulturesWithRegionsCache.Value;
 
         CultureInfo? enUs = null;
         try
@@ -71,27 +91,105 @@ public static class MoneyStrategyExtensions
         CultureInfo shrinkTarget = enUs ?? CultureInfo.InvariantCulture;
 
         List<CultureInfo> result = [shrinkTarget];
+        foreach ((CultureInfo culture, string _) in allCultures)
+        {
+            if (culture.Name != shrinkTarget.Name)
+            {
+                result.Add(culture);
+            }
+        }
+
+        return [.. result];
+    }
+
+    private static (CultureInfo Culture, string CurrencyCode)[] BuildSpecificCulturesWithRegions()
+    {
+        CultureInfo[] specificCultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
+        List<(CultureInfo Culture, string CurrencyCode)> result = new(specificCultures.Length);
+
         foreach (CultureInfo culture in specificCultures)
         {
-            if (culture.Name == shrinkTarget.Name)
-            {
-                continue;
-            }
-
             try
             {
                 RegionInfo region = new(culture.Name);
                 if (!string.IsNullOrEmpty(region.ISOCurrencySymbol))
                 {
-                    result.Add(culture);
+                    result.Add((culture, region.ISOCurrencySymbol));
                 }
             }
             catch (ArgumentException)
             {
-                // skip cultures that don't have a RegionInfo (includes CultureNotFoundException)
+                // skip cultures that don't have a valid RegionInfo
             }
         }
 
         return [.. result];
+    }
+
+    private static readonly Dictionary<string, string> PreferredCultureByCurrencyCode = new()
+    {
+        ["USD"] = "en-US",
+        ["GBP"] = "en-GB",
+        ["EUR"] = "de-DE",
+        ["JPY"] = "ja-JP",
+        ["CAD"] = "en-CA",
+        ["AUD"] = "en-AU",
+        ["CHF"] = "de-CH",
+        ["CNY"] = "zh-CN",
+        ["HKD"] = "zh-HK",
+        ["NZD"] = "en-NZ",
+        ["SEK"] = "sv-SE",
+        ["NOK"] = "nb-NO",
+        ["DKK"] = "da-DK",
+        ["MXN"] = "es-MX",
+        ["SGD"] = "zh-SG",
+        ["INR"] = "hi-IN",
+        ["BRL"] = "pt-BR",
+        ["ZAR"] = "af-ZA",
+        ["KRW"] = "ko-KR",
+        ["RUB"] = "ru-RU",
+    };
+
+    private static CultureInfo[] BuildCulturesByCurrencyCode(string currencyCode)
+    {
+        (CultureInfo Culture, string CurrencyCode)[] allCultures = SpecificCulturesWithRegionsCache.Value;
+        List<CultureInfo> matching = [];
+
+        foreach ((CultureInfo culture, string code) in allCultures)
+        {
+            if (code == currencyCode)
+            {
+                matching.Add(culture);
+            }
+        }
+
+        if (matching.Count == 0)
+        {
+            return [];
+        }
+
+        // Place preferred culture at index 0 for shrink direction
+        if (PreferredCultureByCurrencyCode.TryGetValue(currencyCode, out string? preferredName))
+        {
+            int preferredIndex = matching.FindIndex(c => c.Name == preferredName);
+            if (preferredIndex > 0)
+            {
+                CultureInfo preferred = matching[preferredIndex];
+                matching.RemoveAt(preferredIndex);
+                matching.Insert(0, preferred);
+            }
+            else if (preferredIndex < 0)
+            {
+                // Preferred not found — sort by name and use first
+                matching.Sort(static (a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
+            }
+        }
+        else
+        {
+            // No preferred culture for this code — sort by name and use first
+            matching.Sort(static (a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
+        }
+
+        return [.. matching];
     }
 }

--- a/src/Conjecture.Money/MoneyStrategyExtensions.cs
+++ b/src/Conjecture.Money/MoneyStrategyExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
+using System.Globalization;
+
 using Conjecture.Money.Internal;
 
 namespace Conjecture.Core;
@@ -42,5 +44,54 @@ public static class MoneyStrategyExtensions
         {
             return Strategy.Enums<MidpointRounding>();
         }
+
+        /// <summary>Returns a strategy that samples cultures whose <see cref="RegionInfo"/> exposes a non-empty <c>ISOCurrencySymbol</c>. Shrinks toward <c>en-US</c> (placed at index 0).</summary>
+        public static Strategy<CultureInfo> CulturesWithCurrency()
+        {
+            return Strategy.SampledFrom(CulturesWithCurrencyCache.Value);
+        }
+    }
+
+    private static readonly Lazy<CultureInfo[]> CulturesWithCurrencyCache = new(static () => BuildCulturesWithCurrency());
+
+    private static CultureInfo[] BuildCulturesWithCurrency()
+    {
+        CultureInfo[] specificCultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures);
+
+        CultureInfo? enUs = null;
+        try
+        {
+            enUs = CultureInfo.GetCultureInfo("en-US");
+        }
+        catch (CultureNotFoundException)
+        {
+            // fall back to null; handled below
+        }
+
+        CultureInfo shrinkTarget = enUs ?? CultureInfo.InvariantCulture;
+
+        List<CultureInfo> result = [shrinkTarget];
+        foreach (CultureInfo culture in specificCultures)
+        {
+            if (culture.Name == shrinkTarget.Name)
+            {
+                continue;
+            }
+
+            try
+            {
+                RegionInfo region = new(culture.Name);
+                if (!string.IsNullOrEmpty(region.ISOCurrencySymbol))
+                {
+                    result.Add(culture);
+                }
+            }
+            catch (ArgumentException)
+            {
+                // skip cultures that don't have a RegionInfo (includes CultureNotFoundException)
+            }
+        }
+
+        return [.. result];
     }
 }

--- a/src/Conjecture.Money/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Money/PublicAPI.Unshipped.txt
@@ -11,3 +11,4 @@ static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strateg
 static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strategy!).Iso4217Codes() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strategy!).Amounts(string! currencyCode, decimal min = 0, decimal max = 10000) -> Conjecture.Core.Strategy<decimal>!
 static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strategy!).RoundingModes() -> Conjecture.Core.Strategy<System.MidpointRounding>!
+static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strategy!).CulturesWithCurrency() -> Conjecture.Core.Strategy<System.Globalization.CultureInfo!>!

--- a/src/Conjecture.Money/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Money/PublicAPI.Unshipped.txt
@@ -12,3 +12,4 @@ static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strateg
 static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strategy!).Amounts(string! currencyCode, decimal min = 0, decimal max = 10000) -> Conjecture.Core.Strategy<decimal>!
 static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strategy!).RoundingModes() -> Conjecture.Core.Strategy<System.MidpointRounding>!
 static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strategy!).CulturesWithCurrency() -> Conjecture.Core.Strategy<System.Globalization.CultureInfo!>!
+static Conjecture.Core.MoneyStrategyExtensions.extension(Conjecture.Core.Strategy!).CulturesByCurrencyCode(string! currencyCode) -> Conjecture.Core.Strategy<System.Globalization.CultureInfo!>!


### PR DESCRIPTION
## Description

Adds culture-aware currency strategies to `Conjecture.Money`:
- `Strategy.CulturesWithCurrency()` — samples `CultureInfo` values whose region exposes a non-empty ISO currency symbol, with `en-US` at index 0 for shrink direction
- `Strategy.CulturesByCurrencyCode(string)` — samples cultures whose region uses a specific ISO 4217 code; validates against `Iso4217Data`, throws `ArgumentException` for unknown codes

Both strategies turn culture into a generated input, enabling property tests that surface money formatting/parsing bugs across the cultural axis. The MCP `StrategyTools` now suggests these strategies, and the money-strategies docs cover them in reference + how-to + explanation pages.

## Type of change

- [x] New feature / strategy

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

## Cycles included

- 87816c3 Docs: money-strategies reference and how-to coverage of culture-aware currency strategies
- c7b775a StrategyTools: suggest culture-aware currency strategies for CultureInfo
- 18d8346 CulturesByCurrencyCode: sample cultures whose region uses a given ISO 4217 code
- 2b677ac Money.Tests: add InternalsVisibleTo + Core ref for TestRunner access
- 9f7a2a8 CulturesWithCurrency: sample cultures whose region exposes an ISO currency symbol

Closes #624