### PR TITLE
[623] Strategy.Indices and Strategy.Ranges: slicing primitives

### DIFF
--- a/docs/site/articles/reference/strategies.md
+++ b/docs/site/articles/reference/strategies.md
@@ -178,6 +178,28 @@ Picks uniformly from `CultureInfo.GetCultures(types)`. Shrinks toward `CultureIn
 
 `Conjecture.Money` and `Conjecture.Time` build opinionated subsets (cultures with currency, cultures by calendar) on top of these primitives.
 
+## Index and Range strategies
+
+### `Strategy.Indices(int maxValue = 100)`
+
+```csharp
+Strategy<Index> Strategy.Indices(int maxValue = 100)
+```
+
+Generates `System.Index` values whose `Value` falls in `[0, maxValue]`. Both from-start and from-end forms are produced. All generated indices are valid for slice/range expressions on an array of length `maxValue`, but a from-start index with value `maxValue` is out of bounds for element access — use `maxValue - 1` as the upper bound if you need safe element indexing. The shrink target is `(Index)0` (from-start, value 0).
+
+A negative `maxValue` throws `ArgumentOutOfRangeException`.
+
+### `Strategy.Ranges(int maxValue = 100)`
+
+```csharp
+Strategy<Range> Strategy.Ranges(int maxValue = 100)
+```
+
+Generates `System.Range` values whose `Start` and `End` indices fall in `[0, maxValue]`. Mixed from-start/from-end combinations are valid (e.g. `1..^2`), and the generated range is always well-formed against an array of length `maxValue`. The shrink target is `0..0`.
+
+A negative `maxValue` throws `ArgumentOutOfRangeException`.
+
 ## Version strategies
 
 ### `Strategy.Versions(int maxMajor = 9, int maxMinor = 9, int maxBuild = 9, int maxRevision = 9)`

--- a/src/Conjecture.Core.Tests/Strategies/IndexStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/IndexStrategyTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class IndexStrategyTests
+{
+    private static ConjectureData MakeData(ulong seed = 42UL) =>
+        ConjectureData.ForGeneration(new SplittableRandom(seed));
+
+    [Fact]
+    public void Indices_ReturnsValuesWithinMaxValue()
+    {
+        Strategy<Index> strategy = Strategy.Indices();
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 200; i++)
+        {
+            Index index = strategy.Generate(data);
+            Assert.True(index.Value >= 0, $"Expected Value >= 0 but got {index.Value}");
+            Assert.True(index.Value <= 100, $"Expected Value <= 100 but got {index.Value}");
+        }
+    }
+
+    [Fact]
+    public void Indices_FromEndBranchReachable()
+    {
+        Strategy<Index> strategy = Strategy.Indices();
+        ConjectureData data = MakeData();
+        bool seenFromEnd = false;
+        bool seenFromStart = false;
+
+        for (int i = 0; i < 500; i++)
+        {
+            Index index = strategy.Generate(data);
+            if (index.IsFromEnd)
+            {
+                seenFromEnd = true;
+            }
+            else
+            {
+                seenFromStart = true;
+            }
+
+            if (seenFromEnd && seenFromStart)
+            {
+                break;
+            }
+        }
+
+        Assert.True(seenFromEnd, "No from-end Index was generated in 500 draws");
+        Assert.True(seenFromStart, "No from-start Index was generated in 500 draws");
+    }
+
+    [Fact]
+    public async Task Indices_ShrinksTowardZero()
+    {
+        Strategy<Index> strategy = Strategy.Indices();
+        ConjectureSettings settings = new() { MaxExamples = 200, Seed = 1UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            Index index = strategy.Generate(data);
+            throw new Exception($"always fails: {index}");
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        Index shrunk = strategy.Generate(replay);
+        Assert.Equal(0, shrunk.Value);
+        Assert.False(shrunk.IsFromEnd);
+    }
+
+    [Fact]
+    public void Indices_RespectsCustomMaxValue()
+    {
+        Strategy<Index> strategy = Strategy.Indices(10);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 200; i++)
+        {
+            Index index = strategy.Generate(data);
+            Assert.True(index.Value <= 10, $"Expected Value <= 10 but got {index.Value}");
+        }
+    }
+
+    [Fact]
+    public void Indices_ThrowsOnNegativeMaxValue()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Strategy.Indices(-1));
+    }
+}

--- a/src/Conjecture.Core.Tests/Strategies/RangeStrategyTests.cs
+++ b/src/Conjecture.Core.Tests/Strategies/RangeStrategyTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using Conjecture.Core;
+using Conjecture.Core.Internal;
+
+namespace Conjecture.Core.Tests.Strategies;
+
+public class RangeStrategyTests
+{
+    private static ConjectureData MakeData(ulong seed = 42UL) =>
+        ConjectureData.ForGeneration(new SplittableRandom(seed));
+
+    [Fact]
+    public void Ranges_GeneratesWellFormedRangesAgainstMaxValueArray()
+    {
+        Strategy<Range> strategy = Strategy.Ranges();
+        ConjectureData data = MakeData();
+        int maxValue = 100;
+
+        for (int i = 0; i < 500; i++)
+        {
+            Range range = strategy.Generate(data);
+            (int offset, int length) = range.GetOffsetAndLength(maxValue);
+            Assert.True(length >= 0, $"Expected Length >= 0 but got {length} for range {range}");
+        }
+    }
+
+    [Fact]
+    public void Ranges_StartAndEndStayWithinMaxValue()
+    {
+        Strategy<Range> strategy = Strategy.Ranges();
+        ConjectureData data = MakeData();
+        int maxValue = 100;
+
+        for (int i = 0; i < 500; i++)
+        {
+            Range range = strategy.Generate(data);
+            Assert.True(range.Start.Value >= 0 && range.Start.Value <= maxValue,
+                $"Start.Value {range.Start.Value} out of [0, {maxValue}]");
+            Assert.True(range.End.Value >= 0 && range.End.Value <= maxValue,
+                $"End.Value {range.End.Value} out of [0, {maxValue}]");
+        }
+    }
+
+    [Fact]
+    public void Ranges_MixedFromStartFromEndReachable()
+    {
+        Strategy<Range> strategy = Strategy.Ranges();
+        ConjectureData data = MakeData();
+        bool seenMixed = false;
+        bool seenBothFromStart = false;
+        bool seenBothFromEnd = false;
+
+        for (int i = 0; i < 1000; i++)
+        {
+            Range range = strategy.Generate(data);
+            bool startFromEnd = range.Start.IsFromEnd;
+            bool endFromEnd = range.End.IsFromEnd;
+
+            if (startFromEnd != endFromEnd)
+            {
+                seenMixed = true;
+            }
+            else if (!startFromEnd && !endFromEnd)
+            {
+                seenBothFromStart = true;
+            }
+            else if (startFromEnd && endFromEnd)
+            {
+                seenBothFromEnd = true;
+            }
+
+            if (seenMixed && seenBothFromStart && seenBothFromEnd)
+            {
+                break;
+            }
+        }
+
+        Assert.True(seenMixed, "No mixed from-start/from-end range generated in 1000 draws");
+        Assert.True(seenBothFromStart, "No both-from-start range generated in 1000 draws");
+        Assert.True(seenBothFromEnd, "No both-from-end range generated in 1000 draws");
+    }
+
+    [Fact]
+    public async Task Ranges_ShrinksTowardZeroToZero()
+    {
+        Strategy<Range> strategy = Strategy.Ranges();
+        ConjectureSettings settings = new() { MaxExamples = 200, Seed = 1UL };
+
+        TestRunResult result = await TestRunner.Run(settings, data =>
+        {
+            Range range = strategy.Generate(data);
+            throw new Exception($"always fails: {range}");
+        });
+
+        Assert.False(result.Passed);
+        ConjectureData replay = ConjectureData.ForRecord(result.Counterexample!);
+        Range shrunk = strategy.Generate(replay);
+        Assert.Equal(0, shrunk.Start.Value);
+        Assert.False(shrunk.Start.IsFromEnd);
+        Assert.Equal(0, shrunk.End.Value);
+        Assert.False(shrunk.End.IsFromEnd);
+    }
+
+    [Fact]
+    public void Ranges_RespectsCustomMaxValue()
+    {
+        Strategy<Range> strategy = Strategy.Ranges(10);
+        ConjectureData data = MakeData();
+
+        for (int i = 0; i < 200; i++)
+        {
+            Range range = strategy.Generate(data);
+            Assert.True(range.Start.Value <= 10, $"Start.Value {range.Start.Value} exceeds maxValue 10");
+            Assert.True(range.End.Value <= 10, $"End.Value {range.End.Value} exceeds maxValue 10");
+        }
+    }
+
+    [Fact]
+    public void Ranges_ThrowsOnNegativeMaxValue()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Strategy.Ranges(-1));
+    }
+}

--- a/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
+++ b/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
@@ -199,6 +199,7 @@ internal static class SharedParameterStrategyResolver
             _ when type == typeof(DateOnly) => Strategy.DateOnlyValues().Generate(data),
             _ when type == typeof(TimeOnly) => Strategy.TimeOnlyValues().Generate(data),
             _ when type == typeof(Rune) => Strategy.Runes().Generate(data),
+            _ when type == typeof(Index) => Strategy.Indices().Generate(data),
             { IsEnum: true } => GenerateEnum(type, data),
             _ when Nullable.GetUnderlyingType(type) is { } u
                                              => data.NextInteger(0, 9) == 0 ? null! : GenerateValue(u, data),

--- a/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
+++ b/src/Conjecture.Core/Internal/SharedParameterStrategyResolver.cs
@@ -200,6 +200,7 @@ internal static class SharedParameterStrategyResolver
             _ when type == typeof(TimeOnly) => Strategy.TimeOnlyValues().Generate(data),
             _ when type == typeof(Rune) => Strategy.Runes().Generate(data),
             _ when type == typeof(Index) => Strategy.Indices().Generate(data),
+            _ when type == typeof(Range) => Strategy.Ranges().Generate(data),
             { IsEnum: true } => GenerateEnum(type, data),
             _ when Nullable.GetUnderlyingType(type) is { } u
                                              => data.NextInteger(0, 9) == 0 ? null! : GenerateValue(u, data),

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -70,6 +70,7 @@ static Conjecture.Core.Strategy.IPEndPoints(Conjecture.Core.Strategy<System.Net.
 static Conjecture.Core.Strategy.Uris(System.UriKind kind = System.UriKind.Absolute, System.Collections.Generic.IReadOnlyList<string!>? schemes = null) -> Conjecture.Core.Strategy<System.Uri!>!
 static Conjecture.Core.Strategy.EmailAddresses() -> Conjecture.Core.Strategy<System.Net.Mail.MailAddress!>!
 static Conjecture.Core.Strategy.Indices(int maxValue = 100) -> Conjecture.Core.Strategy<System.Index>!
+static Conjecture.Core.Strategy.Ranges(int maxValue = 100) -> Conjecture.Core.Strategy<System.Range>!
 static Conjecture.Core.Strategy.EmailAddressStrings() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.Strategy.Halves() -> Conjecture.Core.Strategy<System.Half>!
 static Conjecture.Core.Strategy.Halves(System.Half min, System.Half max) -> Conjecture.Core.Strategy<System.Half>!

--- a/src/Conjecture.Core/PublicAPI.Unshipped.txt
+++ b/src/Conjecture.Core/PublicAPI.Unshipped.txt
@@ -69,6 +69,7 @@ static Conjecture.Core.Strategy.IPAddresses(Conjecture.Core.IPAddressKind kind =
 static Conjecture.Core.Strategy.IPEndPoints(Conjecture.Core.Strategy<System.Net.IPAddress!>? addresses = null, Conjecture.Core.Strategy<int>? ports = null) -> Conjecture.Core.Strategy<System.Net.IPEndPoint!>!
 static Conjecture.Core.Strategy.Uris(System.UriKind kind = System.UriKind.Absolute, System.Collections.Generic.IReadOnlyList<string!>? schemes = null) -> Conjecture.Core.Strategy<System.Uri!>!
 static Conjecture.Core.Strategy.EmailAddresses() -> Conjecture.Core.Strategy<System.Net.Mail.MailAddress!>!
+static Conjecture.Core.Strategy.Indices(int maxValue = 100) -> Conjecture.Core.Strategy<System.Index>!
 static Conjecture.Core.Strategy.EmailAddressStrings() -> Conjecture.Core.Strategy<string!>!
 static Conjecture.Core.Strategy.Halves() -> Conjecture.Core.Strategy<System.Half>!
 static Conjecture.Core.Strategy.Halves(System.Half min, System.Half max) -> Conjecture.Core.Strategy<System.Half>!

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -366,6 +366,22 @@ public static class Strategy
             ? throw new ArgumentOutOfRangeException(nameof(maxValue), maxValue, "maxValue must be non-negative.")
             : Tuples(Integers<int>(0, maxValue), Booleans()).Select(static t => new Index(t.Item1, t.Item2));
 
+    /// <summary>Returns a strategy that generates <see cref="Range"/> values whose <c>Start</c> and <c>End</c> indices fall in <c>[0, maxValue]</c>. Mixed from-start/from-end forms are produced. The generated range is well-formed against an array of length <paramref name="maxValue"/>; shrinks toward <c>0..0</c>.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxValue"/> is negative.</exception>
+    public static Strategy<Range> Ranges(int maxValue = 100)
+        => maxValue < 0
+            ? throw new ArgumentOutOfRangeException(nameof(maxValue), maxValue, "maxValue must be non-negative.")
+            : Tuples(Integers<int>(0, maxValue), Integers<int>(0, maxValue), Integers<int>(0, 1), Integers<int>(0, 1)).Select(t =>
+            {
+                int startPos = t.Item1 <= t.Item2 ? t.Item1 : t.Item2;
+                int endPos = t.Item1 <= t.Item2 ? t.Item2 : t.Item1;
+                bool startFromEnd = t.Item3 == 1;
+                bool endFromEnd = t.Item4 == 1;
+                Index start = startFromEnd ? new Index(maxValue - startPos, true) : new Index(startPos, false);
+                Index end = endFromEnd ? new Index(maxValue - endPos, true) : new Index(endPos, false);
+                return new Range(start, end);
+            });
+
     private static readonly ConcurrentDictionary<CultureTypes, CultureInfo[]> CulturesCache = new();
 
     /// <summary>Returns a strategy that generates random <see cref="CultureInfo"/> values from all cultures, with <see cref="CultureInfo.InvariantCulture"/> at index 0 to guide shrinking.</summary>

--- a/src/Conjecture.Core/Strategy.Factory.cs
+++ b/src/Conjecture.Core/Strategy.Factory.cs
@@ -359,6 +359,13 @@ public static class Strategy
         return Compose<T>(ctx => ctx.Generate(GenerateForRegistry.ResolveWithOverrides(cfg)));
     }
 
+    /// <summary>Returns a strategy that generates <see cref="Index"/> values whose <c>Value</c> falls in <c>[0, maxValue]</c>. Both from-start and from-end forms are produced; shrinks toward <c>(Index)0</c>.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxValue"/> is negative.</exception>
+    public static Strategy<Index> Indices(int maxValue = 100)
+        => maxValue < 0
+            ? throw new ArgumentOutOfRangeException(nameof(maxValue), maxValue, "maxValue must be non-negative.")
+            : Tuples(Integers<int>(0, maxValue), Booleans()).Select(static t => new Index(t.Item1, t.Item2));
+
     private static readonly ConcurrentDictionary<CultureTypes, CultureInfo[]> CulturesCache = new();
 
     /// <summary>Returns a strategy that generates random <see cref="CultureInfo"/> values from all cultures, with <see cref="CultureInfo.InvariantCulture"/> at index 0 to guide shrinking.</summary>

--- a/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
+++ b/src/Conjecture.Mcp.Tests/Tools/StrategyToolsTests.cs
@@ -358,4 +358,18 @@ public class StrategyToolsTests
         string result = StrategyTools.SuggestForType("Rune");
         Assert.Contains("Strategy.Runes(min, max)", result);
     }
+
+    [Fact]
+    public void SuggestStrategy_Index_ReturnsIndicesGuidance()
+    {
+        string result = StrategyTools.SuggestStrategy(typeName: "Index");
+        Assert.Contains("Strategy.Indices(", result);
+    }
+
+    [Fact]
+    public void SuggestStrategy_Range_ReturnsRangesGuidance()
+    {
+        string result = StrategyTools.SuggestStrategy(typeName: "Range");
+        Assert.Contains("Strategy.Ranges(", result);
+    }
 }

--- a/src/Conjecture.Mcp/Docs/strategies.md
+++ b/src/Conjecture.Mcp/Docs/strategies.md
@@ -33,6 +33,8 @@
 | `Strategy.DateOnlyValues(min, max)` | `Strategy<DateOnly>` | Bounded range |
 | `Strategy.TimeOnlyValues()` | `Strategy<TimeOnly>` | Full range |
 | `Strategy.TimeOnlyValues(min, max)` | `Strategy<TimeOnly>` | Bounded range |
+| `Strategy.Indices(int maxValue)` | `Strategy<Index>` | Forward and from-end indices valid for a collection of `maxValue` length |
+| `Strategy.Ranges(int maxValue)` | `Strategy<Range>` | Ranges valid for a collection of `maxValue` length |
 | `Strategy.Identifiers(minPrefixLength, maxPrefixLength, minDigits, maxDigits)` | `Strategy<string>` | Identifier strings (`[a-z]+\d+`); all params optional |
 | `Strategy.NumericStrings(minDigits, maxDigits, prefix, suffix)` | `Strategy<string>` | Numeric strings with optional prefix/suffix |
 | `Strategy.VersionStrings(maxMajor, maxMinor, maxPatch)` | `Strategy<string>` | Version strings (`MAJOR.MINOR.PATCH`) |

--- a/src/Conjecture.Mcp/Tools/StrategyTools.cs
+++ b/src/Conjecture.Mcp/Tools/StrategyTools.cs
@@ -13,7 +13,8 @@ internal static class StrategyTools
     [McpServerTool(Name = "suggest-strategy")]
     [Description(
         "Suggests the Conjecture Strategy.* strategy to use for a given C# type or description. " +
-        "Handles primitives (int, bool, string, float, double, byte[]), date/time types " +
+        "Handles primitives (int, bool, string, float, double, byte[]), index/range types " +
+        "(Index, Range), date/time types " +
         "(DateTimeOffset, TimeSpan, DateOnly, TimeOnly), collections " +
         "(List<T>, IReadOnlySet<T>, IReadOnlyDictionary<K,V>), nullable types, value " +
         "tuples, enums, and custom types. Also handles regex-constrained strings via the " +
@@ -133,6 +134,24 @@ internal static class StrategyTools
             ```
 
             Add the NuGet package: `Conjecture.Time`
+            """,
+
+            "Index" =>
+                """
+            Use `Strategy.Indices(maxValue)` to generate `System.Index` values (both forward and from-end) within a given length:
+            ```csharp
+            Strategy.Indices(maxValue: 10)
+            // → Strategy<Index> of indices valid for a collection of length 10
+            ```
+            """,
+
+            "Range" =>
+                """
+            Use `Strategy.Ranges(maxValue)` to generate `System.Range` values within a given length:
+            ```csharp
+            Strategy.Ranges(maxValue: 10)
+            // → Strategy<Range> of ranges valid for a collection of length 10
+            ```
             """,
 
             "DateTime" =>


### PR DESCRIPTION
## Description

Adds two new strategy factory methods for slicing/indexing primitives:

- `Strategy.Indices(int maxValue = 100)` — generates `System.Index` values whose `Value` falls in `[0, maxValue]`, with optional from-end bias. Wired into `Strategy.For<Index>`. Shrinks toward `(Index)0`.
- `Strategy.Ranges(int maxValue = 100)` — generates `System.Range` values that are well-formed against an array of length `maxValue` (i.e. `range.GetOffsetAndLength(maxValue)` does not throw). Mixed from-start/from-end variants are reachable. Wired into `Strategy.For<Range>`. Shrinks toward `0..0`.

Also exposes both via the `suggest-strategy` MCP tool and adds reference-page entries.

## Type of change

- [x] New feature / strategy
- [x] AI tools adjustments
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #623

## Cycles included
- 38ea00b IndexStrategy: generate System.Index values with optional from-end flag (#649)
- aa90576 RangeStrategy: generate System.Range values bounded by maxValue (#650)
- 2c99ada StrategyTools: suggest Indices and Ranges via suggest-strategy (#651)
- 0abb3da Docs: reference page entries for Strategy.Indices and Strategy.Ranges (#652)