### PR TITLE
Fixes docs workflow publishing before NuGet packages are available

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,7 @@ name: Deploy documentation
 
 on:
   push:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'docs/site/**'
+    tags: ['v*']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description

The docs workflow was triggering on every push to `main` that touched `src/` or `docs/site/`. This meant feature documentation went live before the corresponding NuGet packages were published — users could read docs for APIs they couldn't yet install.

Now the workflow only triggers on `v*` tags, in sync with the release workflow. Manual deploys remain available via `workflow_dispatch`.

## Type of change

- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [ ] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style