### PR TITLE
[683] Microsoft.Testing.Platform 2.x upgrade and integration improvements

### DIFF
--- a/docs/site/articles/how-to/export-repros.md
+++ b/docs/site/articles/how-to/export-repros.md
@@ -61,7 +61,28 @@ In a GitHub Actions workflow:
     path: artifacts/repros/
 ```
 
+## MTP adapter: TRX artifact and post-run summary
+
+When using the `Conjecture.TestingPlatform` (MTP) adapter, you do not need to remember `ReproductionOutputPath` to locate exported repros on CI. The adapter automatically attaches the repro file to the failed test node as a TRX artifact and prints its path in the post-run summary.
+
+Run with `--report-trx` to see the attachment in the TRX output:
+
+```bash
+dotnet test --report-trx
+```
+
+After the run completes, the post-run summary lists each exported file:
+
+```text
+Failed  MyTests.My_property
+  Counterexample: value = 1000
+  Repro exported: artifacts/repros/MyTests.My_property__seed_0xDEADBEEF.repro
+```
+
+The file path is also embedded in the TRX under `<ResultFiles>` for the failed test node, so CI systems that parse TRX reports (Azure DevOps, GitHub Actions with a TRX reporter) pick it up automatically — no separate upload step required.
+
 ## See also
 
 - [Reference: Settings](../reference/settings.md) — `ExportReproductionOnFailure`, `ReproductionOutputPath`
 - [How to reproduce a failure](reproduce-a-failure.md) — pin a seed to replay a failure
+- [How to use the MTP adapter](use-mtp-adapter.md) — full MTP setup and CLI options

--- a/docs/site/articles/how-to/use-mtp-adapter.md
+++ b/docs/site/articles/how-to/use-mtp-adapter.md
@@ -125,6 +125,14 @@ dotnet test --report-trx
 
 Failed test nodes include the Conjecture counterexample, so the TRX captures the minimal failing input alongside the failure message.
 
+Conjecture log output is routed through stdout and stderr, so it integrates with the `--show-stdout` and `--show-stderr` flags added in MTP 2.2.1:
+
+```bash
+dotnet test --show-stdout --show-stderr
+```
+
+Routing follows log level: **Error** and **Critical** messages go to stderr; **Information** and **Warning** messages go to stdout. Pass both flags together to see the full Conjecture output inline with the test results.
+
 ## Next
 
 - [Tutorial 5: Framework Adapters](../tutorials/05-framework-adapters.md) — side-by-side comparison of all adapters

--- a/src/Conjecture.Aspire.Tests/Samples/TestingPlatformWiringSampleTests.cs
+++ b/src/Conjecture.Aspire.Tests/Samples/TestingPlatformWiringSampleTests.cs
@@ -23,12 +23,11 @@ using System.Threading.Tasks;
 
 using Aspire.Hosting;
 
-using Conjecture.Aspire;
-using Conjecture.Core;
-
 using Conjecture.Abstractions.Aspire;
 using Conjecture.Abstractions.Interactions;
+using Conjecture.Aspire;
 using Conjecture.Aspire.Http;
+using Conjecture.Core;
 using Conjecture.Http;
 
 namespace Conjecture.Aspire.Tests.Samples;
@@ -95,6 +94,31 @@ public sealed class TestingPlatformWiringSampleTests
                 .IsAssignableFrom(typeof(AspireSessionLifetimeHandler)));
     }
 
+    [Fact]
+    public async Task OnTestSessionStartingAsync_WithStubContext_CallsFixtureStartAsyncWithContextCancellationToken()
+    {
+        TrackingFixture fixture = new();
+        AspireSessionLifetimeHandler handler = new(fixture);
+        CancellationToken expected = new CancellationTokenSource().Token;
+        StubTestSessionContext context = new(expected);
+
+        await handler.OnTestSessionStartingAsync(context);
+
+        Assert.Equal(expected, fixture.StartCalledWithToken);
+    }
+
+    [Fact]
+    public async Task OnTestSessionFinishingAsync_WithStubContext_DisposesFixture()
+    {
+        TrackingFixture fixture = new();
+        AspireSessionLifetimeHandler handler = new(fixture);
+        StubTestSessionContext context = new(CancellationToken.None);
+
+        await handler.OnTestSessionFinishingAsync(context);
+
+        Assert.True(fixture.Disposed);
+    }
+
     // ── Public runner API wires session-scoped fixture into the state machine ──
 
     [Fact]
@@ -119,5 +143,34 @@ public sealed class TestingPlatformWiringSampleTests
         public override ValueTask<string> RunCommand(string state, IInteraction interaction, IInteractionTarget target, CancellationToken ct) => ValueTask.FromResult<string>(state);
 
         public override void Invariant(string state) { }
+    }
+
+    private sealed class TrackingFixture : IAspireAppFixture
+    {
+        public CancellationToken StartCalledWithToken { get; private set; }
+        public bool Disposed { get; private set; }
+
+        public override Task<DistributedApplication> StartAsync(CancellationToken cancellationToken = default)
+        {
+            StartCalledWithToken = cancellationToken;
+            IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder([]);
+            return Task.FromResult(builder.Build());
+        }
+
+        public override Task ResetAsync(DistributedApplication app, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public override ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class StubTestSessionContext(CancellationToken cancellationToken)
+        : Microsoft.Testing.Platform.Services.ITestSessionContext
+    {
+        public Microsoft.Testing.Platform.TestHost.SessionUid SessionUid { get; } = new("stub-session");
+        public CancellationToken CancellationToken { get; } = cancellationToken;
     }
 }

--- a/src/Conjecture.Aspire/AspireSessionLifetimeHandler.cs
+++ b/src/Conjecture.Aspire/AspireSessionLifetimeHandler.cs
@@ -2,21 +2,20 @@
 // See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
 
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
+
+using Conjecture.Abstractions.Aspire;
 
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.TestHost;
-using Microsoft.Testing.Platform.TestHost;
-
-using Conjecture.Abstractions.Aspire;
+using Microsoft.Testing.Platform.Services;
 
 namespace Conjecture.Aspire;
 
 /// <summary>
 /// Manages the lifetime of an <see cref="IAspireAppFixture"/> within a
 /// Microsoft.Testing.Platform test session. Register via
-/// <c>builder.TestHost.AddTestSessionLifetimeHandle(_ =&gt; new AspireSessionLifetimeHandler(fixture))</c>.
+/// <c>builder.TestHost.AddTestSessionLifetimeHandler(_ =&gt; new AspireSessionLifetimeHandler(fixture))</c>.
 /// </summary>
 public sealed class AspireSessionLifetimeHandler(IAspireAppFixture fixture)
     : ITestSessionLifetimeHandler
@@ -42,10 +41,10 @@ public sealed class AspireSessionLifetimeHandler(IAspireAppFixture fixture)
     public Task<bool> IsEnabledAsync() => Task.FromResult(true);
 
     /// <inheritdoc />
-    public Task OnTestSessionStartingAsync(SessionUid sessionUid, CancellationToken cancellationToken) =>
-        Fixture.StartAsync(cancellationToken);
+    public Task OnTestSessionStartingAsync(ITestSessionContext context) =>
+        Fixture.StartAsync(context.CancellationToken);
 
     /// <inheritdoc />
-    public Task OnTestSessionFinishingAsync(SessionUid sessionUid, CancellationToken cancellationToken) =>
+    public Task OnTestSessionFinishingAsync(ITestSessionContext context) =>
         Fixture.DisposeAsync().AsTask();
 }

--- a/src/Conjecture.Aspire/PublicAPI.Shipped.txt
+++ b/src/Conjecture.Aspire/PublicAPI.Shipped.txt
@@ -4,8 +4,8 @@ Conjecture.Aspire.AspireSessionLifetimeHandler
 Conjecture.Aspire.AspireSessionLifetimeHandler.Description.get -> string!
 Conjecture.Aspire.AspireSessionLifetimeHandler.DisplayName.get -> string!
 Conjecture.Aspire.AspireSessionLifetimeHandler.IsEnabledAsync() -> System.Threading.Tasks.Task<bool>!
-Conjecture.Aspire.AspireSessionLifetimeHandler.OnTestSessionFinishingAsync(Microsoft.Testing.Platform.TestHost.SessionUid sessionUid, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
-Conjecture.Aspire.AspireSessionLifetimeHandler.OnTestSessionStartingAsync(Microsoft.Testing.Platform.TestHost.SessionUid sessionUid, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Conjecture.Aspire.AspireSessionLifetimeHandler.OnTestSessionFinishingAsync(Microsoft.Testing.Platform.Services.ITestSessionContext! context) -> System.Threading.Tasks.Task!
+Conjecture.Aspire.AspireSessionLifetimeHandler.OnTestSessionStartingAsync(Microsoft.Testing.Platform.Services.ITestSessionContext! context) -> System.Threading.Tasks.Task!
 Conjecture.Aspire.AspireSessionLifetimeHandler.Uid.get -> string!
 Conjecture.Aspire.AspireSessionLifetimeHandler.Version.get -> string!
 Conjecture.Aspire.AspireSessionLifetimeHandler.AspireSessionLifetimeHandler(Conjecture.Abstractions.Aspire.IAspireAppFixture! fixture) -> void

--- a/src/Conjecture.Core/Internal/ReproFileBuilder.cs
+++ b/src/Conjecture.Core/Internal/ReproFileBuilder.cs
@@ -104,7 +104,7 @@ internal static class ReproFileBuilder
         sb.AppendLine(GetTestAttribute(framework));
     }
 
-    internal static void WriteToFile(ReproContext context, string outputPath)
+    internal static string? WriteToFile(ReproContext context, string outputPath)
     {
         try
         {
@@ -114,12 +114,15 @@ internal static class ReproFileBuilder
             string fullPath = Path.Combine(outputPath, fileName);
             string content = Build(context);
             File.WriteAllText(fullPath, content);
+            return fullPath;
         }
         catch (IOException)
         {
+            return null;
         }
         catch (UnauthorizedAccessException)
         {
+            return null;
         }
     }
 

--- a/src/Conjecture.FSharp/PropertyRunner.fs
+++ b/src/Conjecture.FSharp/PropertyRunner.fs
@@ -53,7 +53,7 @@ module PropertyRunner =
                         shrinkCount,
                         TestFramework.Xunit,
                         DateTimeOffset.UtcNow)
-                ReproFileBuilder.WriteToFile(context, repro.OutputPath)
+                ReproFileBuilder.WriteToFile(context, repro.OutputPath) |> ignore
             with _ -> ()
 
     /// Runs a bool-returning property with optional repro export. <c>false</c> is treated as a test failure.

--- a/src/Conjecture.TestingPlatform.Tests/Conjecture.TestingPlatform.Tests.csproj
+++ b/src/Conjecture.TestingPlatform.Tests/Conjecture.TestingPlatform.Tests.csproj
@@ -4,6 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!-- MTP 2.x blocks VSTest on .NET 10+ when IsTestingPlatformApplication=true.
+         This project uses xUnit and must not be treated as an MTP application,
+         even though it references Conjecture.TestingPlatform (which carries the
+         Conjecture.TestingPlatform.props that sets IsTestingPlatformApplication=true). -->
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Conjecture.TestingPlatform.Tests/Internal/MtpLoggerTests.cs
+++ b/src/Conjecture.TestingPlatform.Tests/Internal/MtpLoggerTests.cs
@@ -17,10 +17,10 @@ namespace Conjecture.TestingPlatform.Tests.Internal;
 
 public class MtpLoggerTests
 {
-    // ── Log produces TestMetadataProperty ────────────────────────────────────
+    // ── Log_Information_Publishes_StandardOutputProperty_With_Level_Prefix ───
 
     [Fact]
-    public void Log_InformationLevel_PublishesTestMetadataPropertyWithExpectedKey()
+    public void Log_Information_Publishes_StandardOutputProperty_With_Level_Prefix()
     {
         CapturingMessageBus bus = new();
         TestNodeUid nodeUid = new("test-node");
@@ -30,39 +30,67 @@ public class MtpLoggerTests
         logger.Log(LogLevel.Information, default, "hello", null, static (s, _) => s);
 
         TestNodeUpdateMessage message = Assert.Single(bus.Updates);
-        TestMetadataProperty? property = message.TestNode.Properties
-            .SingleOrDefault<TestMetadataProperty>();
+        StandardOutputProperty? property = message.TestNode.Properties
+            .SingleOrDefault<StandardOutputProperty>();
         Assert.NotNull(property);
-        Assert.Equal($"conjecture.log.{LogLevel.Information}", property.Key);
-        Assert.Equal("hello", property.Value);
+        Assert.StartsWith("[Information] ", property.StandardOutput);
+        Assert.EndsWith(Environment.NewLine, property.StandardOutput);
+        Assert.Contains("hello", property.StandardOutput);
     }
 
+    // ── Log_Error_Publishes_StandardErrorProperty ─────────────────────────────
+
     [Fact]
-    public void Log_WarningLevel_PublishesTestMetadataPropertyWithWarningKey()
+    public void Log_Error_Publishes_StandardErrorProperty()
     {
         CapturingMessageBus bus = new();
         TestNodeUid nodeUid = new("test-node");
         SessionUid session = new("test-session");
         MtpLogger logger = new(bus, nodeUid, session);
 
-        logger.Log(LogLevel.Warning, default, "watch out", null, static (s, _) => s);
+        logger.Log(LogLevel.Error, default, "bad thing", null, static (s, _) => s);
 
         TestNodeUpdateMessage message = Assert.Single(bus.Updates);
-        TestMetadataProperty? property = message.TestNode.Properties
-            .SingleOrDefault<TestMetadataProperty>();
+        StandardErrorProperty? property = message.TestNode.Properties
+            .SingleOrDefault<StandardErrorProperty>();
         Assert.NotNull(property);
-        Assert.Equal($"conjecture.log.{LogLevel.Warning}", property.Key);
+        Assert.Contains("bad thing", property.StandardError);
+        Assert.Null(message.TestNode.Properties.SingleOrDefault<StandardOutputProperty>());
     }
 
+    // ── Log_Critical_Routed_To_StandardError ─────────────────────────────────
+
     [Fact]
-    public void Log_BelowInformationLevel_DoesNotPublish()
+    public void Log_Critical_Routed_To_StandardError()
     {
         CapturingMessageBus bus = new();
         TestNodeUid nodeUid = new("test-node");
         SessionUid session = new("test-session");
         MtpLogger logger = new(bus, nodeUid, session);
 
-        logger.Log(LogLevel.Debug, default, "verbose", null, static (s, _) => s);
+        logger.Log(LogLevel.Critical, default, "fatal", null, static (s, _) => s);
+
+        TestNodeUpdateMessage message = Assert.Single(bus.Updates);
+        StandardErrorProperty? property = message.TestNode.Properties
+            .SingleOrDefault<StandardErrorProperty>();
+        Assert.NotNull(property);
+        Assert.Contains("fatal", property.StandardError);
+        Assert.Null(message.TestNode.Properties.SingleOrDefault<StandardOutputProperty>());
+    }
+
+    // ── Log_Below_Information_Threshold_Publishes_Nothing ────────────────────
+
+    [Theory]
+    [InlineData(LogLevel.Trace)]
+    [InlineData(LogLevel.Debug)]
+    public void Log_Below_Information_Threshold_Publishes_Nothing(LogLevel level)
+    {
+        CapturingMessageBus bus = new();
+        TestNodeUid nodeUid = new("test-node");
+        SessionUid session = new("test-session");
+        MtpLogger logger = new(bus, nodeUid, session);
+
+        logger.Log(level, default, "verbose", null, static (s, _) => s);
 
         Assert.Empty(bus.Updates);
     }

--- a/src/Conjecture.TestingPlatform.Tests/Internal/MtpLoggerTests.cs
+++ b/src/Conjecture.TestingPlatform.Tests/Internal/MtpLoggerTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Kim Ommundsen. Licensed under the MPL-2.0.
+// See LICENSE.txt in the project root or https://mozilla.org/MPL/2.0/
+
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+using Conjecture.TestingPlatform.Internal;
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Messages;
+using Microsoft.Testing.Platform.TestHost;
+
+using Xunit;
+
+namespace Conjecture.TestingPlatform.Tests.Internal;
+
+public class MtpLoggerTests
+{
+    // ── Log produces TestMetadataProperty ────────────────────────────────────
+
+    [Fact]
+    public void Log_InformationLevel_PublishesTestMetadataPropertyWithExpectedKey()
+    {
+        CapturingMessageBus bus = new();
+        TestNodeUid nodeUid = new("test-node");
+        SessionUid session = new("test-session");
+        MtpLogger logger = new(bus, nodeUid, session);
+
+        logger.Log(LogLevel.Information, default, "hello", null, static (s, _) => s);
+
+        TestNodeUpdateMessage message = Assert.Single(bus.Updates);
+        TestMetadataProperty? property = message.TestNode.Properties
+            .SingleOrDefault<TestMetadataProperty>();
+        Assert.NotNull(property);
+        Assert.Equal($"conjecture.log.{LogLevel.Information}", property.Key);
+        Assert.Equal("hello", property.Value);
+    }
+
+    [Fact]
+    public void Log_WarningLevel_PublishesTestMetadataPropertyWithWarningKey()
+    {
+        CapturingMessageBus bus = new();
+        TestNodeUid nodeUid = new("test-node");
+        SessionUid session = new("test-session");
+        MtpLogger logger = new(bus, nodeUid, session);
+
+        logger.Log(LogLevel.Warning, default, "watch out", null, static (s, _) => s);
+
+        TestNodeUpdateMessage message = Assert.Single(bus.Updates);
+        TestMetadataProperty? property = message.TestNode.Properties
+            .SingleOrDefault<TestMetadataProperty>();
+        Assert.NotNull(property);
+        Assert.Equal($"conjecture.log.{LogLevel.Warning}", property.Key);
+    }
+
+    [Fact]
+    public void Log_BelowInformationLevel_DoesNotPublish()
+    {
+        CapturingMessageBus bus = new();
+        TestNodeUid nodeUid = new("test-node");
+        SessionUid session = new("test-session");
+        MtpLogger logger = new(bus, nodeUid, session);
+
+        logger.Log(LogLevel.Debug, default, "verbose", null, static (s, _) => s);
+
+        Assert.Empty(bus.Updates);
+    }
+
+    // ── Fake infrastructure ───────────────────────────────────────────────────
+
+    private sealed class CapturingMessageBus : IMessageBus
+    {
+        private readonly ConcurrentBag<TestNodeUpdateMessage> updates = [];
+
+        public List<TestNodeUpdateMessage> Updates => updates.ToList();
+
+        public Task PublishAsync(IDataProducer dataProducer, IData data)
+        {
+            if (data is TestNodeUpdateMessage msg)
+            {
+                updates.Add(msg);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Conjecture.TestingPlatform.Tests/Internal/PropertyTestFrameworkTests.cs
+++ b/src/Conjecture.TestingPlatform.Tests/Internal/PropertyTestFrameworkTests.cs
@@ -139,6 +139,116 @@ public class PropertyTestFrameworkTests
         Assert.Contains(updates, static u => u.TestNode.Properties.Any<PassedTestNodeStateProperty>());
     }
 
+    // ---- Behaviour 8: failure with ExportReproductionOnFailure → FileArtifactProperty on failure node ----
+
+    [Fact]
+    public async Task RunAsync_FailingPropertyWithExportReproductionOnFailure_AddsFileArtifactProperty()
+    {
+        string outputDir = ReproExportEnabledFixtureMethods.ReproOutputPath;
+        if (Directory.Exists(outputDir))
+        {
+            Directory.Delete(outputDir, true);
+        }
+
+        Directory.CreateDirectory(outputDir);
+        try
+        {
+            PropertyTestFramework framework = CreateFramework(typeof(ReproExportEnabledFixtureMethods));
+            CapturingMessageBus bus = new();
+            SessionUid session = new("test-session-repro");
+
+            await framework.RunAsync(bus, session);
+
+            List<TestNodeUpdateMessage> updates = bus.Updates
+                .Where(static u => NodeUidFor(u) == ReproExportEnabledFixtureMethods.AlwaysFailsUid)
+                .ToList();
+
+            TestNode failureNode = updates
+                .First(static u => u.TestNode.Properties.Any<FailedTestNodeStateProperty>())
+                .TestNode;
+
+            FileArtifactProperty? artifact = failureNode.Properties.SingleOrDefault<FileArtifactProperty>();
+            Assert.NotNull(artifact);
+            Assert.True(File.Exists(artifact.FileInfo.FullName));
+        }
+        finally
+        {
+            if (Directory.Exists(outputDir))
+            {
+                Directory.Delete(outputDir, true);
+            }
+        }
+    }
+
+    // ---- Behaviour 9: failure without ExportReproductionOnFailure → no FileArtifactProperty ----
+
+    [Fact]
+    public async Task RunAsync_FailingPropertyWithoutExportReproductionOnFailure_AddsNoFileArtifactProperty()
+    {
+        PropertyTestFramework framework = CreateFramework(typeof(ReproExportDisabledFixtureMethods));
+        CapturingMessageBus bus = new();
+        SessionUid session = new("test-session-no-repro");
+
+        await framework.RunAsync(bus, session);
+
+        List<TestNodeUpdateMessage> updates = bus.Updates
+            .Where(static u => NodeUidFor(u) == ReproExportDisabledFixtureMethods.AlwaysFailsUid)
+            .ToList();
+
+        TestNode failureNode = updates
+            .First(static u => u.TestNode.Properties.Any<FailedTestNodeStateProperty>())
+            .TestNode;
+
+        FileArtifactProperty? artifact = failureNode.Properties.SingleOrDefault<FileArtifactProperty>();
+        Assert.Null(artifact);
+    }
+
+    // ---- Behaviour 10: repro write failure → failure node published, no FileArtifactProperty, no throw ----
+
+    [Fact]
+    public async Task RunAsync_ReproWriteFailure_PublishesFailureNodeWithoutFileArtifactPropertyAndDoesNotThrow()
+    {
+        // The fixture's ReproductionOutputPath is a file that already exists,
+        // causing Directory.CreateDirectory to fail inside ReproFileBuilder.WriteToFile.
+        string blockerFile = ReproExportBlockedFixtureMethods.ReproOutputPath;
+        string? parentDir = Path.GetDirectoryName(blockerFile);
+        if (parentDir is not null)
+        {
+            Directory.CreateDirectory(parentDir);
+        }
+
+        File.WriteAllText(blockerFile, "blocker");
+        try
+        {
+            PropertyTestFramework framework = CreateFramework(typeof(ReproExportBlockedFixtureMethods));
+            CapturingMessageBus bus = new();
+            SessionUid session = new("test-session-repro-fail");
+
+            Exception? thrown = await Record.ExceptionAsync(async () =>
+                await framework.RunAsync(bus, session));
+
+            Assert.Null(thrown);
+
+            List<TestNodeUpdateMessage> updates = bus.Updates
+                .Where(static u => NodeUidFor(u) == ReproExportBlockedFixtureMethods.AlwaysFailsUid)
+                .ToList();
+
+            TestNode failureNode = updates
+                .First(static u => u.TestNode.Properties.Any<FailedTestNodeStateProperty>())
+                .TestNode;
+
+            FileArtifactProperty? artifact = failureNode.Properties.SingleOrDefault<FileArtifactProperty>();
+            Assert.Null(artifact);
+        }
+        finally
+        {
+            if (File.Exists(blockerFile))
+            {
+                File.Delete(blockerFile);
+            }
+        }
+    }
+
     private static string NodeUidFor(TestNodeUpdateMessage message)
     {
         return message.TestNode.Uid.Value;
@@ -231,5 +341,70 @@ internal static class ParameterisedTestMethods
 #pragma warning disable IDE0060
     [Conjecture.TestingPlatform.PropertyAttribute(MaxExamples = 10)]
     public static void IntProperty(int x) { }
+#pragma warning restore IDE0060
+}
+
+// Fixture: failing property with ExportReproductionOnFailure enabled.
+// ReproOutputPath is a const so it can be used in the attribute and from tests.
+internal static class ReproExportEnabledFixtureMethods
+{
+    internal const string ReproOutputPath = "obj/test-repro-export-enabled/";
+
+    internal static readonly string AlwaysFailsUid =
+        Conjecture.Core.Internal.TestCaseHelper.ComputeTestId(
+            typeof(ReproExportEnabledFixtureMethods).GetMethod(nameof(AlwaysFails))!);
+
+#pragma warning disable IDE0060
+    [Conjecture.TestingPlatform.PropertyAttribute(
+        MaxExamples = 10,
+        Seed = 1UL,
+        ExportReproductionOnFailure = true,
+        ReproductionOutputPath = ReproOutputPath)]
+    public static void AlwaysFails(int x)
+    {
+        throw new InvalidOperationException("always fails for repro export test");
+    }
+#pragma warning restore IDE0060
+}
+
+// Fixture: failing property with ExportReproductionOnFailure disabled (default).
+internal static class ReproExportDisabledFixtureMethods
+{
+    internal static readonly string AlwaysFailsUid =
+        Conjecture.Core.Internal.TestCaseHelper.ComputeTestId(
+            typeof(ReproExportDisabledFixtureMethods).GetMethod(nameof(AlwaysFails))!);
+
+#pragma warning disable IDE0060
+    [Conjecture.TestingPlatform.PropertyAttribute(
+        MaxExamples = 10,
+        Seed = 1UL,
+        ExportReproductionOnFailure = false)]
+    public static void AlwaysFails(int x)
+    {
+        throw new InvalidOperationException("always fails for no-repro test");
+    }
+#pragma warning restore IDE0060
+}
+
+// Fixture: failing property whose ReproductionOutputPath is intentionally set to a file path
+// (not a directory) so that the write will fail, exercising the swallow-on-failure branch.
+internal static class ReproExportBlockedFixtureMethods
+{
+    internal const string ReproOutputPath = "obj/test-repro-blocked-sentinel.txt";
+
+    internal static readonly string AlwaysFailsUid =
+        Conjecture.Core.Internal.TestCaseHelper.ComputeTestId(
+            typeof(ReproExportBlockedFixtureMethods).GetMethod(nameof(AlwaysFails))!);
+
+#pragma warning disable IDE0060
+    [Conjecture.TestingPlatform.PropertyAttribute(
+        MaxExamples = 10,
+        Seed = 1UL,
+        ExportReproductionOnFailure = true,
+        ReproductionOutputPath = ReproOutputPath)]
+    public static void AlwaysFails(int x)
+    {
+        throw new InvalidOperationException("always fails for blocked-write test");
+    }
 #pragma warning restore IDE0060
 }

--- a/src/Conjecture.TestingPlatform/Internal/MtpLogger.cs
+++ b/src/Conjecture.TestingPlatform/Internal/MtpLogger.cs
@@ -51,14 +51,16 @@ internal sealed class MtpLogger : ILogger
         }
 
         string message = formatter(state, exception);
+        IProperty property = level is LogLevel.Error or LogLevel.Critical
+            ? new StandardErrorProperty(message + Environment.NewLine)
+            : new StandardOutputProperty($"[{level}] {message}{Environment.NewLine}");
         _ = bus.PublishAsync(producer!, new TestNodeUpdateMessage(
             session,
             new TestNode
             {
                 Uid = nodeUid,
                 DisplayName = string.Empty,
-                Properties = new PropertyBag(
-                    new TestMetadataProperty($"conjecture.log.{level}", message))
+                Properties = new PropertyBag(property)
             }));
     }
 }

--- a/src/Conjecture.TestingPlatform/Internal/MtpLogger.cs
+++ b/src/Conjecture.TestingPlatform/Internal/MtpLogger.cs
@@ -58,9 +58,7 @@ internal sealed class MtpLogger : ILogger
                 Uid = nodeUid,
                 DisplayName = string.Empty,
                 Properties = new PropertyBag(
-#pragma warning disable CS0618 // KeyValuePairStringProperty is obsolete
-                    new KeyValuePairStringProperty($"conjecture.log.{level}", message))
-#pragma warning restore CS0618
+                    new TestMetadataProperty($"conjecture.log.{level}", message))
             }));
     }
 }

--- a/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
+++ b/src/Conjecture.TestingPlatform/Internal/PropertyTestFramework.cs
@@ -273,7 +273,7 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
                     object[] values = SharedParameterStrategyResolver.Resolve(parameters, replay);
                     IEnumerable<(string Name, object? Value, Type Type)> reproParams = parameters.Zip(values,
                         static (p, v) => (p.Name!, (object?)v, p.ParameterType));
-                    ReproContext context = new(
+                    ReproContext reproContext = new(
                         method.DeclaringType?.Name ?? "UnknownClass",
                         method.Name,
                         TestCaseHelper.IsAsyncReturnType(method.ReturnType),
@@ -283,7 +283,14 @@ internal sealed class PropertyTestFramework : ITestFramework, IDataProducer
                         result.ShrinkCount,
                         Conjecture.Core.Internal.TestFramework.Xunit,
                         DateTimeOffset.UtcNow);
-                    ReproFileBuilder.WriteToFile(context, settings.ReproductionOutputPath);
+                    string? reproFilePath = ReproFileBuilder.WriteToFile(reproContext, settings.ReproductionOutputPath);
+                    if (reproFilePath is not null)
+                    {
+                        resultNode.Properties.Add(new FileArtifactProperty(
+                            new FileInfo(reproFilePath),
+                            "Conjecture repro",
+                            $"C# snippet to reproduce the minimal failing example (seed {result.Seed})."));
+                    }
                 }
                 catch (Exception)
                 {

--- a/src/Conjecture.TestingPlatform/build/Conjecture.TestingPlatform.targets
+++ b/src/Conjecture.TestingPlatform/build/Conjecture.TestingPlatform.targets
@@ -13,6 +13,9 @@
           Condition="'$(IsTestProject)' == 'true'">
     <PropertyGroup>
       <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+      <!-- MTP 2.x blocks VSTest on .NET 10+; opt-in test projects that use this package
+           via project reference into the new dotnet test integration instead. -->
+      <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
   </Target>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -68,9 +68,9 @@
     <PackageVersion Include="LINQPad.Reference" Version="1.3.1" />
 
     <!-- Microsoft Testing Platform -->
-    <PackageVersion Include="Microsoft.Testing.Platform" Version="1.9.1" />
-    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="1.9.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="1.9.1" />
+    <PackageVersion Include="Microsoft.Testing.Platform" Version="2.2.2" />
+    <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.2.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="2.2.2" />
 
     <!-- xunit assertions (standalone, no runner) -->
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />


### PR DESCRIPTION
## Description

Upgrades `Microsoft.Testing.Platform` (and the matching `TrxReport.Abstractions` and `Platform.MSBuild` packages) from 1.9.1 to 2.2.2, adapting to v2 breaking changes (`KeyValuePairStringProperty` removal, `ITestSessionLifetimeHandler` signature change to `ITestSessionContext`). Folds in two opportunistic 2.x-only improvements: routes `MtpLogger` output via `StandardOutputProperty`/`StandardErrorProperty` (Error/Critical → stderr; Information/Warning → stdout) so it integrates with `--show-stdout`/`--show-stderr` from MTP 2.2.1, and publishes the failure repro file as a `FileArtifactProperty` so it surfaces in TRX `<ResultFiles>` and the post-run summary. Replaces Dependabot PR #678. Refreshes the related how-to docs.

## Type of change

- [x] New feature / strategy
- [x] Refactor (no behavior change)
- [x] Documentation / chore

## Checklist

- [x] `dotnet test src/` passes
- [x] New behavior is covered by tests (TDD: Red → Green → Refactor)
- [x] Follows `.editorconfig` code style

Closes #683

## Cycles included

- 4b4f9b2 Document MTP stdout/stderr routing and TRX repro artifact (#687)
- f879a33 Attach failure repro file as FileArtifactProperty (#686)
- 9fa4d88 Route MtpLogger output via StandardOutputProperty and StandardErrorProperty (#685)
- eeafa50 Bump Microsoft.Testing.Platform to 2.2.2 and adapt to v2 breaking changes (#684)